### PR TITLE
many: add spread testing using GCE backend for ubuntu-core-initramfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ install-tmp
 ubuntu-core-initramfs.img
 factory/usr/lib/snapd/snap-bootstrap
 debian/files
+
+*.snap
+*.img
+.spread-reuse*.yaml

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,122 @@
+project: core-initrd
+
+environment:
+  SETUPDIR: /home/core-initrd
+  PROJECT_PATH: $SETUPDIR
+  PATH: $PATH:$PROJECT_PATH/tests/bin
+  TESTSLIB: $PROJECT_PATH/tests/lib
+  TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
+  # TODO: are these vars needed still?
+  LANG: "C.UTF-8"
+  LANGUAGE: "en"
+
+backends:
+  google-nested:
+    type: google
+    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+    location: computeengine/us-east1-b
+    plan: n1-standard-2
+    halt-timeout: 2h
+    systems:
+      - ubuntu-20.04-64:
+          image: ubuntu-2004-64-virt-enabled
+          storage: 20G
+
+  qemu-nested:
+    type: qemu
+    # TODO:UC20: uc20 needs 2G or grub will not loopback the kernel snap
+    #            we use nested VM's, so use 4G for the host until we can boot
+    #            uc20 with less RAM
+    memory: 4G
+    systems:
+      - ubuntu-20.04-64:
+          username: ubuntu
+          password: ubuntu
+
+path: /home/core-initrd
+
+exclude:
+  - .git
+  - "*.o"
+  - "*.a"
+  - "*.snap"
+  - "*.img"
+
+prepare: |
+  # NOTE: This part of the code needs to be in spread.yaml as it runs before
+  # the rest of the source code (including the tests/lib directory) is
+  # around. The purpose of this code is to fix some connectivity issues setup 
+  # spread functions to be more usable outside of the explicit task.yaml 
+  # sections.
+
+  # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
+  cat <<EOF > gai.conf
+  precedence  ::1/128       50
+  precedence  ::/0          40
+  precedence  2002::/16     30
+  precedence ::/96          20
+  precedence ::ffff:0:0/96 100
+  EOF
+  if ! mv gai.conf /etc/gai.conf; then
+      echo "/etc/gai.conf is not writable, ubuntu-core system? apt update won't be affected in that case"
+      rm -f gai.conf
+  fi
+
+  # Take the MATCH and REBOOT functions from spread and allow our shell
+  # scripts to use them as shell commands. The replacements are real
+  # executables in tests/lib/bin (which is on PATH) but they source
+  # spread-funcs.sh written here, base on the definitions provided by SPREAD.
+  # This ensures that 1) spread functions define the code 2) both MATCH and
+  # REBOOT are executables and not functions, and can be called from any
+  # context.
+  type MATCH | tail -n +2 > "$TESTSLIB"/spread-funcs.sh
+  unset MATCH
+  type REBOOT | tail -n +2 >> "$TESTSLIB"/spread-funcs.sh
+  unset REBOOT
+
+  # prepare common uc20 image setup by repacking snaps, etc
+  "$TESTSLIB"/prepare-uc20.sh
+
+restore-each: |
+  # delete the nested VM image after each task finishes so we don't use too much
+  # disk space
+  . "$TESTSLIB/nested.sh"
+  cleanup_nested_core_vm
+
+# it takes a while to build everything while preparing the project
+warn-timeout: 20m
+# but it shouldn't take _too_ long...
+kill-timeout: 30m
+
+suites:
+  tests/spread/:
+    summary: Main spread tests
+    environment:
+      # since we are only testing uc20 here, disable kvm unless the env
+      # specifically knows kvm works and sets this to true
+      # kvm specifically does not work on GCE with focal L1 VM and focal (UC20)
+      # L2 VM's because the L2 VM intermittently and randomly hangs and GCE's
+      # hypervisor will restart the VM, there is not currently a known
+      # workaround
+      ENABLE_KVM: '$(HOST: echo "${SPREAD_ENABLE_KVM:-false}")'
+
+      # variants of various system setup below, turning on/off secure boot and
+      # enabling/disabling tpm, this ensures that all tests we write will be run
+      # against all variants
+
+      # TODO: are there other variants/knobs the initramfs we want to support
+      # testing?
+
+      # full encryption has TPM and secure boot
+      ENABLE_TPM/fullenc: true
+      ENABLE_SECURE_BOOT/fullenc: true
+      # only secboot does not have a TPM
+      ENABLE_TPM/onlysecboot: false
+      ENABLE_SECURE_BOOT/onlysecboot: true
+      # only tpm does not have secure boot
+      ENABLE_TPM/onlytpm: true
+      ENABLE_SECURE_BOOT/onlytpm: false
+      # no enc does not have secure boot or tpm
+      ENABLE_TPM/noenc: false
+      ENABLE_SECURE_BOOT/noenc: false
+# vim:ts=4:sw=4:et

--- a/tests/bin/MATCH
+++ b/tests/bin/MATCH
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Source spread-funcs.sh which, at runtime, contains the real definition of
+# MATCH and execute it.
+
+# shellcheck source=tests/lib/spread-funcs.sh 
+. "$TESTSLIB/spread-funcs.sh"
+
+MATCH "$@"

--- a/tests/bin/REBOOT
+++ b/tests/bin/REBOOT
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Source spread-funcs.sh which, at runtime, contains the real definition of
+# REBOOT and execute it.
+
+# shellcheck source=tests/lib/spread-funcs.sh 
+. "$TESTSLIB/spread-funcs.sh"
+
+REBOOT "$@"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+WORK_DIR="${WORK_DIR:-/tmp/work-dir}"
+SSH_PORT=${SSH_PORT:-8022}
+MON_PORT=${MON_PORT:-8888}
+IMAGE_FILE="${WORK_DIR}/ubuntu-core-20.img"
+
+execute_remote(){
+    sshpass -p ubuntu ssh -p "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@localhost "$*"
+}
+
+wait_for_service() {
+    local service_name="$1"
+    local state="${2:-active}"
+    for i in $(seq 300); do
+        if systemctl show -p ActiveState "$service_name" | grep -q "ActiveState=$state"; then
+            return
+        fi
+        # show debug output every 1min
+        if [ "$i" -gt 0 ] && [ $(( i % 60 )) = 0 ]; then
+            systemctl status "$service_name" || true;
+        fi
+        sleep 1;
+    done
+
+    echo "service $service_name did not start"
+    exit 1
+}
+
+wait_for_ssh(){
+    retry=400
+    wait=1
+    while ! execute_remote true; do
+        retry=$(( retry - 1 ))
+        if [ $retry -le 0 ]; then
+            echo "Timed out waiting for ssh. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+cleanup_nested_core_vm(){
+    # stop the VM if it is running
+    systemctl stop nested-vm-*
+
+    # remove the swtpm
+    # TODO: we could just remove/reset the swtpm instead of removing the snap 
+    # wholesale
+    snap remove swtpm-mvo
+
+    # delete the image file
+    rm -rf "${IMAGE_FILE}"
+}
+
+start_nested_core_vm_unit(){
+    # copy the image file to create a new one to use
+    # TODO: maybe create a snapshot qcow image instead?
+    mkdir -p "${WORK_DIR}"
+    cp /home/core-initrd/pc.img "${IMAGE_FILE}"
+
+    # use only 2G of RAM for qemu-nested
+    if [ "${SPREAD_BACKEND}" = "google-nested" ]; then
+        PARAM_MEM="-m 4096"
+        PARAM_SMP="-smp 2"
+    elif [ "${SPREAD_BACKEND}" = "qemu-nested" ]; then
+        PARAM_MEM="-m 2048"
+        PARAM_SMP="-smp 1"
+    else
+        echo "unknown spread backend ${SPREAD_BACKEND}"
+        exit 1
+    fi
+
+    PARAM_DISPLAY="-nographic"
+    PARAM_NETWORK="-net nic,model=virtio -net user,hostfwd=tcp::${SSH_PORT}-:22"
+    # TODO: do we need monitor port still?
+    PARAM_MONITOR="-monitor tcp:127.0.0.1:${MON_PORT},server,nowait"
+    PARAM_RANDOM="-object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0"
+    PARAM_CPU=""
+    PARAM_TRACE="-d cpu_reset"
+    PARAM_LOG="-D ${WORK_DIR}/qemu.log"
+    PARAM_SERIAL="-serial file:${WORK_DIR}/serial.log"
+    PARAM_TPM=""
+
+    ATTR_KVM=""
+    if [ "$ENABLE_KVM" = "true" ]; then
+        ATTR_KVM=",accel=kvm"
+        # CPU can be defined just when kvm is enabled
+        PARAM_CPU="-cpu host"
+        # Increase the number of cpus used once the issue related to kvm and ovmf is fixed
+        # https://bugs.launchpad.net/ubuntu/+source/kvm/+bug/1872803
+        PARAM_SMP="-smp 1"
+    fi
+
+    # with qemu-nested, we can't use kvm acceleration
+    if [ "${SPREAD_BACKEND}" = "google-nested" ]; then
+        PARAM_MACHINE="-machine ubuntu${ATTR_KVM}"
+    elif [ "${SPREAD_BACKEND}" = "qemu-nested" ]; then
+        PARAM_MACHINE=""
+    else
+        echo "unknown spread backend ${SPREAD_BACKEND}"
+        exit 1
+    fi
+
+    # TODO: enable ms key booting for i.e. nightly edge jobs ?
+    OVMF_VARS="snakeoil"
+    OVMF_CODE=""
+    if [ "${ENABLE_SECURE_BOOT}" = "true" ]; then
+        OVMF_CODE=".secboot"
+    fi
+
+    mkdir -p "${WORK_DIR}/image/"
+    cp -f "/usr/share/OVMF/OVMF_VARS.${OVMF_VARS}.fd" "${WORK_DIR}/image/OVMF_VARS.${OVMF_VARS}.fd"
+    PARAM_BIOS="-drive file=/usr/share/OVMF/OVMF_CODE${OVMF_CODE}.fd,if=pflash,format=raw,unit=0,readonly -drive file=${WORK_DIR}/image/OVMF_VARS.${OVMF_VARS}.fd,if=pflash,format=raw"
+    PARAM_MACHINE="-machine q35${ATTR_KVM} -global ICH9-LPC.disable_s3=1"
+
+    if [ "${ENABLE_TPM}" = "true" ]; then
+        if ! snap list swtpm-mvo > /dev/null; then
+            snap install swtpm-mvo --beta
+        fi
+        PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
+    fi
+
+    PARAM_IMAGE="-drive file=${IMAGE_FILE},cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1"
+
+    # Create the systemd unit for running the VM, the qemu parameter order is 
+    # important. We run all of the qemu logic through a script that systemd runs
+    # for an easier time escaping everything
+    SVC_NAME="nested-vm-$(systemd-escape "${SPREAD_JOB:-unknown}")"
+    SVC_SCRIPT="/tmp/nested-vm-$RANDOM.sh"
+    cat << EOF > "${SVC_SCRIPT}"
+#!/bin/sh -e
+qemu-system-x86_64 \
+    ${PARAM_SMP} \
+    ${PARAM_CPU} \
+    ${PARAM_MEM} \
+    ${PARAM_TRACE} \
+    ${PARAM_LOG} \
+    ${PARAM_MACHINE} \
+    ${PARAM_DISPLAY} \
+    ${PARAM_NETWORK} \
+    ${PARAM_BIOS} \
+    ${PARAM_TPM} \
+    ${PARAM_RANDOM} \
+    ${PARAM_IMAGE} \
+    ${PARAM_SERIAL} \
+    ${PARAM_MONITOR}
+EOF
+    
+    chmod +x "${SVC_SCRIPT}"
+
+    printf '[Unit]\nDescription=QEMU Nested VM for UC20 spread job %s\n[Service]\nType=simple\nExecStart=%s\n' \
+        "${SPREAD_JOB:-unknown}" \
+        "${SVC_SCRIPT}" \
+            > "/run/systemd/system/${SVC_NAME}.service"
+    
+    systemctl daemon-reload
+    systemctl start "${SVC_NAME}"
+
+    # wait for the nested-vm service to appear active
+    if ! wait_for_service "${SVC_NAME}"; then
+        return 1
+    fi
+
+    # Wait until ssh is ready
+    if ! wait_for_ssh; then
+        return 1
+    fi
+}

--- a/tests/lib/prepare-uc20.sh
+++ b/tests/lib/prepare-uc20.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+
+set -e
+set -x 
+
+apt update -yqq
+
+# needed for dracut which is a build-dep of ubuntu-core-initramfs
+# and for the version of snapd here which we want to use to pull snap-bootstrap
+# from when we build the debian package
+add-apt-repository ppa:snappy-dev/image -y
+apt update
+
+# these should already be installed in GCE images with the google-nested 
+# backend, but in qemu local images from qemu-nested, we might not have them
+apt install snapd ovmf qemu-system-x86 sshpass whois -yqq
+
+# use the snapd snap explicitly
+# TODO: since ubuntu-image ships it's own version of `snap prepare-image`, 
+# should we instead install beta/edge snapd here and point ubuntu-image to this
+# version of snapd?
+snap install snapd
+
+# install some dependencies
+# TODO:UC20: when should we start using candidate / stable ubuntu-image?
+snap install ubuntu-image --edge --classic
+
+# install build-deps for ubuntu-core-initramfs
+(
+    cd "$SETUPDIR"
+    apt -y build-dep ./
+)
+
+# TODO: is this still necessary for core-initrd? (this was copied from snapd)
+# create test user for spread to use
+groupadd --gid 12345 test
+adduser --uid 12345 --gid 12345 --disabled-password --gecos '' test
+
+if getent group systemd-journal >/dev/null; then
+    usermod -G systemd-journal -a test
+    id test | MATCH systemd-journal
+fi
+
+echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# get the model
+# TODO: should this be a variant to test multiple grades i.e. signed and secured?
+curl -o ubuntu-core-20-amd64-dangerous.model https://raw.githubusercontent.com/snapcore/models/master/ubuntu-core-20-amd64-dangerous.model
+
+# build the debian package here of ubuntu-core-initramfs
+(
+    cd "$SETUPDIR"
+    DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip
+
+    # save our debs somewhere safe
+    cp ../*.deb "$SETUPDIR"
+)
+
+# install ubuntu-core-initramfs here so the repack-kernel.sh uses the version of
+# ubuntu-core-initramfs we built here
+apt install -yqq "$SETUPDIR"/ubuntu-core-initramfs*.deb
+
+# now download snap dependencies 
+# TODO:UC20: when should some of these things start tracking stable ?
+snap download pc-kernel --channel=20/edge --basename=upstream-pc-kernel
+snap download pc --channel=20/edge --basename=upstream-pc-gadget
+snap download core20 --channel=edge --basename=upstream-core20
+# note that we currently use snap-bootstrap from the snapd deb package, but we 
+# could instead copy a potentially more up-to-date version out of the snapd snap
+# but we don't currently do that as it doesn't represent what 
+# ubuntu-core-initramfs would actually used if that package was built from LP
+snap download snapd --channel=edge --basename=upstream-snapd
+
+# next repack / modify the snaps we use in the image, we do this for a few 
+# reasons:
+# 1. we need an automated way to get a user on the system to ssh into regardless
+#    of grade, so we add a systemd service to the snapd snap which will create 
+#    our user we can ssh into the VM with (if we only wanted to test dangerous,
+#    we could use cloud-init).
+# 2. we need to modify the initramfs in the kernel snap to use our initramfs, 
+#    which requires re-signing of the kernel.efi
+# 3. since we re-sign the kernel.efi of the kernel snap, for successful secure
+#    boot, we need to also re-sign the gadget shim too
+
+# first re-pack snapd snap with special systemd service which runs during run 
+# mode to create a user for us to inspect the system state
+# we also extract the snap-bootstrap binary for insertion into the kernel snap's
+# initramfs too
+
+snapddir=/tmp/snapd-workdir
+unsquashfs -d $snapddir upstream-snapd.snap
+
+# inject systemd service to setup users and other tweaks for us
+# these are copied from upstream snapd prepare.sh, slightly modified to not 
+# extract snapd spread data from ubuntu-seed as we don't need all that here
+cat > "$snapddir/lib/systemd/system/snapd.spread-tests-run-mode-tweaks.service" <<'EOF'
+[Unit]
+Description=Tweaks to run mode for spread tests
+Before=snapd.service
+Documentation=man:snap(1)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/snapd/snapd.spread-tests-run-mode-tweaks.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > "$snapddir/usr/lib/snapd/snapd.spread-tests-run-mode-tweaks.sh" <<'EOF'
+#!/bin/sh
+set -e
+# Print to kmsg and console
+# $1: string to print
+print_system()
+{
+    printf "%s spread-tests-run-mode-tweaks.sh: %s\n" "$(date -Iseconds --utc)" "$1" |
+        tee -a /dev/kmsg /dev/console /run/mnt/ubuntu-seed/spread-tests-run-mode-tweaks-log.txt || true
+}
+
+# ensure we don't enable ssh in install mode or spread will get confused
+if ! grep 'snapd_recovery_mode=run' /proc/cmdline; then
+    print_system "not in run mode - script not running"
+    exit 0
+fi
+if [ -e /root/spread-setup-done ]; then
+    print_system "already ran, not running again"
+    exit 0
+fi
+
+print_system "in run mode, not run yet, extracting overlay data"
+
+# extract data from previous stage
+(cd / && tar xf /run/mnt/ubuntu-seed/run-mode-overlay-data.tar.gz)
+cp -r /root/test-var/lib/extrausers /var/lib
+
+# user db - it's complicated
+for f in group gshadow passwd shadow; do
+    # now bind mount read-only those passwd files on boot
+    cat >/etc/systemd/system/etc-"$f".mount <<EOF2
+[Unit]
+Description=Mount root/test-etc/$f over system etc/$f
+Before=ssh.service
+
+[Mount]
+What=/root/test-etc/$f
+Where=/etc/$f
+Type=none
+Options=bind,ro
+
+[Install]
+WantedBy=multi-user.target
+EOF2
+    systemctl enable etc-"$f".mount
+    systemctl start etc-"$f".mount
+done
+
+mkdir -p /home/test
+chown 12345:12345 /home/test
+mkdir -p /home/ubuntu
+chown 1000:1000 /home/ubuntu
+mkdir -p /etc/sudoers.d/
+echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/99-test-user
+echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/99-ubuntu-user
+# TODO: do we need this for our nested VM? We don't login as root to the nested
+#       VM...
+sed -i 's/\#\?\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+echo "MaxAuthTries 120" >> /etc/ssh/sshd_config
+grep '^PermitRootLogin yes' /etc/ssh/sshd_config
+systemctl reload ssh
+
+print_system "done setting up ssh for spread test user"
+
+touch /root/spread-setup-done
+EOF
+chmod 0755 "$snapddir/usr/lib/snapd/snapd.spread-tests-run-mode-tweaks.sh"
+
+snap pack --filename=snapd.snap "$snapddir"
+rm -r $snapddir
+
+# next re-pack the kernel snap with this version of ubuntu-core-initramfs
+
+# extract the kernel snap, including extracting the initrd from the kernel.efi
+kerneldir=/tmp/kernel-workdir
+"$TESTSLIB/repack-kernel.sh" extract upstream-pc-kernel.snap $kerneldir
+
+# copy the skeleton from our installed ubuntu-core-initramfs into the initrd 
+# skeleton for the kernel snap
+cp -ar /usr/lib/ubuntu-core-initramfs/main/* "$kerneldir/skeleton/main"
+
+# repack the initrd into the kernel.efi
+"$TESTSLIB/repack-kernel.sh" prepare $kerneldir
+
+# repack the kernel snap itself
+"$TESTSLIB/repack-kernel.sh" pack $kerneldir --filename=pc-kernel.snap
+rm -rf $kerneldir
+
+# penultimately, re-pack the gadget snap with snakeoil signed shim
+
+gadgetdir=/tmp/gadget-workdir
+unsquashfs -d "$gadgetdir" upstream-pc-gadget.snap
+
+sbattach --remove "$gadgetdir/shim.efi.signed"
+SNAKE_OIL_DIR=/usr/lib/ubuntu-core-initramfs/snakeoil
+sbsign --key "$SNAKE_OIL_DIR/PkKek-1-snakeoil.key" --cert "$SNAKE_OIL_DIR/PkKek-1-snakeoil.pem" --output "$gadgetdir/shim.efi.signed" "$gadgetdir/shim.efi.signed"
+
+snap pack --filename=pc-gadget.snap "$gadgetdir"
+rm -rf "$gadgetdir"
+
+# finally build the uc20 image
+ubuntu-image snap \
+    -i 8G \
+    --snap upstream-core20.snap \
+    --snap snapd.snap \
+    --snap pc-kernel.snap \
+    --snap pc-gadget.snap \
+    ubuntu-core-20-amd64-dangerous.model
+
+# setup some data we will inject into ubuntu-seed partition of the image above
+# that snapd.spread-tests-run-mode-tweaks.service will ingest
+
+# this sets up some /etc/passwd and group magic that ensures the test and ubuntu
+# users are working, mostly copied from snapd spread magic
+mkdir -p /root/test-etc
+# NOTE that we don't use the real extrausers db on the host VM here because that
+# could be used to actually login to the L1 VM, which we don't want to allow, so
+# put it in a fake dir that login() doesn't actually look at for the host L1 VM.
+mkdir -p /root/test-var/lib/extrausers
+touch /root/test-var/lib/extrausers/sub{uid,gid}
+for f in group gshadow passwd shadow; do
+    # don't include the ubuntu user here, we manually add that later on
+    grep -v "^root:" /etc/"$f" | grep -v "^ubuntu:" /etc/"$f" > /root/test-etc/"$f"
+    grep "^root:" /etc/"$f" >> /root/test-etc/"$f"
+    chgrp --reference /etc/"$f" /root/test-etc/"$f"
+    # append test user for testing
+    grep "^test:" /etc/"$f" >> /root/test-var/lib/extrausers/"$f"
+    # check test was copied
+    MATCH "^test:" < /root/test-var/lib/extrausers/"$f"
+done
+
+# TODO: could we just do this in the script above with adduser --extrausers and
+# echo ubuntu:ubuntu | chpasswd ?
+# dynamically create the ubuntu user in our fake extrausers with password of 
+# ubuntu
+#shellcheck disable=SC2016
+echo 'ubuntu:$6$5jPdGxhc$8DgCHDdjj9IQxefS9atknQq4JVVYqy6KiPV/p4fDf5NUI6dqKTAf0vUZNx8FUru/pNgOQMwSMzS5pFj3hp4pw.:18492:0:99999:7:::' >> /root/test-var/lib/extrausers/shadow
+#shellcheck disable=SC2016
+echo 'ubuntu:$6$5jPdGxhc$8DgCHDdjj9IQxefS9atknQq4JVVYqy6KiPV/p4fDf5NUI6dqKTAf0vUZNx8FUru/pNgOQMwSMzS5pFj3hp4pw.:18492:0:99999:7:::' >> /root/test-etc/shadow
+echo 'ubuntu:!::' >> /root/test-var/lib/extrausers/gshadow
+# use gid of 1001 in case sometimes the lxd group sneaks into the extrausers image somehow...
+echo "ubuntu:x:1000:1001:Ubuntu:/home/ubuntu:/bin/bash" >> /root/test-var/lib/extrausers/passwd
+echo "ubuntu:x:1000:1001:Ubuntu:/home/ubuntu:/bin/bash" >> /root/test-etc/passwd
+echo "ubuntu:x:1001:" >> /root/test-var/lib/extrausers/group
+
+# add the test user to the systemd-journal group if it isn't already
+sed -r -i -e 's/^systemd-journal:x:([0-9]+):$/systemd-journal:x:\1:test/' /root/test-etc/group
+
+# mount fresh image and add all our SPREAD_PROJECT data
+kpartx -avs pc.img
+# losetup --list --noheadings returns:
+# /dev/loop1   0 0  1  1 /var/lib/snapd/snaps/ohmygiraffe_3.snap                0     512
+# /dev/loop57  0 0  1  1 /var/lib/snapd/snaps/http_25.snap                      0     512
+# /dev/loop19  0 0  1  1 /var/lib/snapd/snaps/test-snapd-netplan-apply_75.snap  0     512
+devloop=$(losetup --list --noheadings | grep pc.img | awk '{print $1}')
+dev=$(basename "$devloop")
+
+# mount it so we can use it now
+mkdir -p /mnt
+mount "/dev/mapper/${dev}p2" /mnt
+
+# add the data that snapd.spread-tests-run-mode-tweaks.service reads to the 
+# mounted partition
+tar -c -z \
+    -f /mnt/run-mode-overlay-data.tar.gz \
+    /root/test-etc /root/test-var/lib/extrausers
+
+# tear down the mounts
+umount /mnt
+kpartx -d pc.img
+
+# the image is now ready to be booted

--- a/tests/lib/repack-kernel.sh
+++ b/tests/lib/repack-kernel.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+# Author: Maciej Borzecki
+# Modified by Ian Johnson <ian.johnson@canonical.com>
+
+set -e
+
+if [[ -n "$D" ]]; then
+    set -x
+fi
+
+##HELP: Usage: repack-kernel <command> <opts>
+##HELP:
+##HELP: Handle extraction of the kernel snap to a workspace directory, and later
+##HELP: repacking it back to a snap.
+##HELP:
+##HELP: Commands:
+##HELP:    setup                          - setup system dependencies
+##HELP:    extract <snap-file> <target>   - extract under <target> workspace tree
+##HELP:    prepare <target>               - prepare initramfs & kernel for repacking
+##HELP:    pack <target>                  - pack the kernel
+##HELP:    cull-firmware <target>         - remove unnecessary firmware
+##HELP:    cull-modules                   - remove unnecessary mofules
+##HELP:
+
+setup_deps() {
+    if [[ "$UID" != "0" ]]; then
+        echo "run as root (only this command)"
+        exit 1
+    fi
+
+    # carries ubuntu-core-initframfs
+    add-apt-repository ppa:snappy-dev/image -y
+    apt install ubuntu-core-initramfs -y
+}
+
+get_kver() {
+    kerneldir="$1"
+    (
+        cd "$kerneldir"
+        #shellcheck disable=SC2010
+        ls "config"-* | grep -Po 'config-\K.*'
+    )
+}
+
+extract_kernel() {
+    local snap_file="$1"
+    local target="$2"
+
+    if [[ -z "$target" ]] || [[ -z "$snap_file" ]]; then
+        echo "usage: prepare <target-dir> <kernel-snap>"
+        exit 1
+    fi
+
+    target=$(realpath "$target")
+
+    mkdir -p "$target" "$target/work" "$target/backup"
+
+    # kernel snap is huge, unpacking to current dir
+    unsquashfs -d "$target/kernel" "$snap_file"
+
+    kver="$(get_kver "$target/kernel")"
+
+    # repack initrd magic, beware
+    # assumptions: initrd is compressed with LZ4, cpio block size 512, microcode
+    # at the beginning of initrd image
+    (
+        cd "$target/kernel"
+
+        # XXX: ideally we should unpack the initrd, replace snap-boostrap and
+        # repack it using ubuntu-core-initramfs --skeleton=<unpacked> this does not
+        # work and the rebuilt kernel.efi panics unable to start init, but we
+        # still need the unpacked initrd to get the right kernel modules
+        objcopy -j .initrd -O binary kernel.efi "$target/work/initrd"
+
+        # copy out the kernel image for create-efi command
+        objcopy -j .linux -O binary kernel.efi "$target/work/vmlinuz-$kver"
+
+        cp -a kernel.efi "$target/backup/"
+    )
+
+    (
+        cd "$target/work"
+        # this works on 20.04 but not on 18.04
+        unmkinitramfs initrd unpacked-initrd
+    )
+
+    # copy the unpacked initrd to use as the target skeleton
+    cp -ar "$target/work/unpacked-initrd" "$target/skeleton"
+
+    echo "prepared workspace at $target"
+    echo "  kernel:              $target/kernel ($kver)"
+    echo "  kernel.efi backup:   $target/backup/kernel.efi"
+    echo "  temporary artifacts: $target/work"
+    echo "  initramfs skeleton:  $target/skeleton"
+
+}
+
+prepare_kernel() {
+    local target="$1"
+
+    if [[ -z "$target" ]]; then
+        echo "usage: repack <extract-tree>"
+        exit 1
+    fi
+
+    target=$(realpath "$target")
+    kver="$(get_kver "$target/kernel")"
+
+    (
+        # all the skeleton edits go to a local copy of distro directory
+        skeletondir="$target/skeleton"
+
+        cd "$target/work"
+        # XXX: need to be careful to build an initrd using the right kernel
+        # modules from the unpacked initrd, rather than the host which may be
+        # running a different kernel
+        (
+            # accommodate assumptions about tree layout, use the unpacked initrd
+            # to pick up the right modules
+            cd unpacked-initrd/main
+            ubuntu-core-initramfs create-initrd \
+                                  --kernelver "$kver" \
+                                  --skeleton "$skeletondir" \
+                                  --kerneldir "lib/modules" \
+                                  --output "$target/work/repacked-initrd"
+        )
+
+        # assumes all files are named <name>-$kver
+        ubuntu-core-initramfs create-efi \
+                              --kernelver "$kver" \
+                              --initrd repacked-initrd \
+                              --kernel vmlinuz \
+                              --output repacked-kernel.efi
+
+        cp "repacked-kernel.efi-$kver" "$target/kernel/kernel.efi"
+
+        # XXX: needed?
+        chmod +x "$target/kernel/kernel.efi"
+    )
+}
+
+cull_firmware() {
+    local target="$1"
+
+    if [[ -z "$target" ]]; then
+        echo "usage: cull-firmware <extract-tree>"
+        exit 1
+    fi
+    (
+        # XXX: drop ~450MB+ of firmware which should not be needed in under qemu
+        # or the cloud system
+        cd "$target/kernel"
+        rm -rf firmware/*
+    )
+}
+
+cull_modules() {
+    local target="$1"
+
+    if [[ -z "$target" ]]; then
+        echo "usage: cull-modules <extract-tree>"
+        exit 1
+    fi
+
+    target=$(realpath "$target")
+    kver="$(get_kver "$target/kernel")"
+
+    (
+        cd "$target/kernel"
+        # drop unnecessary modules
+        awk '{print $1}' <  /proc/modules  | sort > "$target/work/current-modules"
+        #shellcheck disable=SC2044
+        for m in $(find modules/ -name '*.ko'); do
+            noko=$(basename "$m"); noko="${noko%.ko}"
+            if echo "$noko" | grep -f "$target/work/current-modules" -q ; then
+                echo "keeping $m - $noko"
+            else
+                rm -f "$m"
+            fi
+        done
+
+        # depmod assumes that /lib/modules/$kver is under basepath
+        mkdir -p fake/lib
+        ln -s "$PWD/modules" fake/lib/modules
+        depmod -b "$PWD/fake" -A -v "$kver"
+        rm -rf fake
+    )
+}
+
+pack() {
+    local target="$1"
+
+    if [[ -z "$target" ]]; then
+        echo "usage: pack <extract-tree> <opts to snap pack>"
+        exit 1
+    fi
+    snap pack "${@:2}" "$target/kernel" 
+}
+
+show_help() {
+    grep '^##HELP:' "$0" | sed -e 's/##HELP: \?//'
+}
+
+
+opt="$1"
+shift || true
+
+if [[ -z "$opt" ]] || [[ "$opt" == "--help" ]]; then
+    show_help
+    exit 1
+fi
+
+case "$opt" in
+    setup)
+        setup_deps
+        ;;
+    extract)
+        extract_kernel "$@"
+        ;;
+    prepare)
+        prepare_kernel "$@"
+        ;;
+    cull-modules)
+        cull_modules "$@"
+        ;;
+    cull-firmware)
+        cull_firmware "$@"
+        ;;
+    pack)
+        pack "$@"
+        ;;
+esac

--- a/tests/spread/basic/task.yaml
+++ b/tests/spread/basic/task.yaml
@@ -1,0 +1,36 @@
+summary: Ensure that things worked
+
+execute: |
+  # for various utilities
+  . "$TESTSLIB/nested.sh"
+
+  # Start the nested UC20 VM
+  start_nested_core_vm_unit
+
+  # At this point we are able to SSH to the nested VM, so things probably worked
+  # but we should wait for snapd to finish seeding anyways, but first we need to
+  # wait for the snap command to exist
+  retry=400
+  wait=1
+  while ! execute_remote command -v snap; do
+      retry=$(( retry - 1 ))
+      if [ $retry -le 0 ]; then
+          echo "Timed out waiting for snap command to be available. Aborting!"
+          exit 1
+      fi
+      sleep "$wait"
+  done
+
+  # Now formally wait for seeding
+  execute_remote sudo snap wait system seed.loaded
+
+  # We should be in run mode
+  execute_remote cat /proc/cmdline | MATCH snapd_recovery_mode=run
+
+  # We should have a modeenv
+  execute_remote test -f /var/lib/snapd/modeenv
+
+  # TODO: what else qualifies a "successful boot"? 
+  # * no failed systemd units?
+  # * all expected partitions mounted?
+  # * systemd not in degraded mode?


### PR DESCRIPTION
This sets up the project to be testable via spread, both locally via nested QEMU
VM's, as well as in the cloud with GCE nested VM's.

There are some TODO's still around simplifying this even more and getting rid of
more cruft from snapd's setup, but this is sufficient right now to get a nested
UC20 VM with our version of the initramfs in it for testing.

To run the tests locally via qemu, first install qemu, then get spread via 

```
$ sudo apt update && sudo apt install -y qemu-kvm autopkgtest
$ curl https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz | tar -xz -C $GOPATH/bin
```

Then make your qemu spread images dir with

```
$ mkdir -p ~/.spread/qemu
$ cd ~/.spread/qemu
```

and make a suitable spread image with:

```
$ autopkgtest-buildvm-ubuntu-cloud -r focal
$ mv autopkgtest-focal-amd64.img ubuntu-20.04-64.img
```

then finally you can run spread tests like so:

```
$ spread qemu-nested
2020-08-19 13:31:03 Project content is packed for delivery (9.00MB).
2020-08-19 13:31:03 Sequence of jobs produced with -seed=1597861863
2020-08-19 13:31:03 If killed, discard servers with: spread -reuse-pid=86651 -discard
2020-08-19 13:31:03 Allocating qemu-nested:ubuntu-20.04-64...
2020-08-19 13:31:03 Serial and monitor for qemu-nested:ubuntu-20.04-64 available at ports 59414 and 59514.
2020-08-19 13:31:03 Waiting for qemu-nested:ubuntu-20.04-64 to make SSH available...
2020-08-19 13:31:04 Allocated qemu-nested:ubuntu-20.04-64.
2020-08-19 13:31:04 Connecting to qemu-nested:ubuntu-20.04-64...
2020-08-19 13:31:22 Connected to qemu-nested:ubuntu-20.04-64 at localhost:59314.
2020-08-19 13:31:22 Sending project content to qemu-nested:ubuntu-20.04-64...
2020-08-19 13:31:23 Preparing qemu-nested:ubuntu-20.04-64 (qemu-nested:ubuntu-20.04-64)...
2020-08-19 13:45:03 Executing qemu-nested:ubuntu-20.04-64:tests/spread/basic:noenc (qemu-nested:ubuntu-20.04-64) (1/4)...
2020-08-19 13:53:49 Restoring qemu-nested:ubuntu-20.04-64:tests/spread/basic:noenc (qemu-nested:ubuntu-20.04-64)...
2020-08-19 13:53:49 Executing qemu-nested:ubuntu-20.04-64:tests/spread/basic:fullenc (qemu-nested:ubuntu-20.04-64) (2/4)...
2020-08-19 14:04:44 Restoring qemu-nested:ubuntu-20.04-64:tests/spread/basic:fullenc (qemu-nested:ubuntu-20.04-64)...
2020-08-19 14:04:45 Executing qemu-nested:ubuntu-20.04-64:tests/spread/basic:onlysecboot (qemu-nested:ubuntu-20.04-64) (3/4)...
2020-08-19 14:13:36 Restoring qemu-nested:ubuntu-20.04-64:tests/spread/basic:onlysecboot (qemu-nested:ubuntu-20.04-64)...
2020-08-19 14:13:36 Executing qemu-nested:ubuntu-20.04-64:tests/spread/basic:onlytpm (qemu-nested:ubuntu-20.04-64) (4/4)...
2020-08-19 14:24:44 Restoring qemu-nested:ubuntu-20.04-64:tests/spread/basic:onlytpm (qemu-nested:ubuntu-20.04-64)...
2020-08-19 14:24:45 Discarding qemu-nested:ubuntu-20.04-64...
2020-08-19 14:24:45 Successful tasks: 4
2020-08-19 14:24:45 Aborted tasks: 0
```

This takes approximately an hour for me on my well spec'd desktop machine, largely because we can't use nested KVM accelerated VM's, so the L2 nested VM runs significantly slower.

To run the tests via GCE, you would just run

```
$ spread google-nested
```

but to do so you need GCE credentials, see https://github.com/snapcore/spread#google