### PR TITLE
many: update initramfs layout for new snap-bootstrap features

### DIFF
--- a/factory/usr/lib/systemd/system/initrd-cleanup.service.d/core-override.conf
+++ b/factory/usr/lib/systemd/system/initrd-cleanup.service.d/core-override.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=systemctl --no-block start initrd-switch-root.target

--- a/factory/usr/lib/systemd/system/initrd-root-device.target.d/40-seed-device.conf
+++ b/factory/usr/lib/systemd/system/initrd-root-device.target.d/40-seed-device.conf
@@ -1,4 +1,0 @@
-[Unit]
-Requires=dev-disk-by\x2dlabel-ubuntu\x2dseed.device
-After=dev-disk-by\x2dlabel-ubuntu\x2dseed.device
-

--- a/factory/usr/lib/systemd/system/initrd-root-fs.target.d/40-seed-device.conf
+++ b/factory/usr/lib/systemd/system/initrd-root-fs.target.d/40-seed-device.conf
@@ -1,3 +1,0 @@
-[Unit]
-Requires=dev-disk-by\x2dlabel-ubuntu\x2dseed.device
-After=dev-disk-by\x2dlabel-ubuntu\x2dseed.device

--- a/factory/usr/lib/systemd/system/populate-writable.service
+++ b/factory/usr/lib/systemd/system/populate-writable.service
@@ -2,12 +2,10 @@
 OnFailure=emergency.target
 OnFailureJobMode=replace-irreversibly
 Before=initrd-cleanup.target
-After=run-mnt-ubuntu\x2dseed.mount
 After=run-mnt-data.mount
 After=run-mnt-base.mount
 After=sysroot.mount
 After=sysroot-writable.mount
-Requires=run-mnt-ubuntu\x2dseed.mount
 Requires=run-mnt-data.mount
 Requires=run-mnt-base.mount
 Requires=sysroot.mount
@@ -20,6 +18,9 @@ Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/bin/mount --type tmpfs tmpfs /sysroot/run
 ExecStart=/usr/bin/touch /sysroot/run/fstab
+# TODO:UC20: re-implement writable-paths in Go in snap-bootstrap and eliminate 
+# the shell script wrapper
 ExecStart=/usr/bin/chroot /sysroot /usr/lib/core/handle-writable-paths / /etc/system-image/writable-paths /run/fstab
+# TODO:UC20: move the-modeenv implementation to snap-bootstrap too
 ExecStart=/usr/lib/the-modeenv
-ExecStartPost=/usr/bin/systemctl --no-block start initrd.target
+ExecStartPost=/usr/bin/systemctl --no-block isolate initrd.target

--- a/factory/usr/lib/systemd/system/run-mnt-ubuntu\x2dseed.mount.d/override.conf
+++ b/factory/usr/lib/systemd/system/run-mnt-ubuntu\x2dseed.mount.d/override.conf
@@ -1,4 +1,0 @@
-[Unit]
-Before=local-fs.target
-Requires=systemd-fsck@dev-disk-by\x2dlabel-ubuntu\x2dseed.service
-After=systemd-fsck@dev-disk-by\x2dlabel-ubuntu\x2dseed.service

--- a/factory/usr/lib/systemd/system/the-tool.service
+++ b/factory/usr/lib/systemd/system/the-tool.service
@@ -5,9 +5,8 @@ DefaultDependencies=no
 After=systemd-tmpfiles-setup.service
 After=systemd-modules-load.service
 Wants=systemd-modules-load.service
-
-Requires=systemd-fsck@dev-disk-by\x2dlabel-ubuntu\x2dseed.service
-After=systemd-fsck@dev-disk-by\x2dlabel-ubuntu\x2dseed.service
+After=systemd-udev-settle.service
+Wants=systemd-udev-settle.service
 
 [Service]
 Type=oneshot

--- a/factory/usr/lib/the-modeenv
+++ b/factory/usr/lib/the-modeenv
@@ -1,11 +1,14 @@
 #!/bin/sh
 umount /sysroot/run/fstab
 cp /sysroot/run/image.fstab /run/
+
+# TODO:UC20: move this logic into snap-bootstrap to be incorporated with 
+# initramfs-mounts
+
 # Always bind-mount all the host filesystems
 mkdir -p /run/mnt/host
 echo '/run/mnt/host /host none rbind 0 0' >> /run/image.fstab
 if grep -q snapd_recovery_mode=run /proc/cmdline; then
-    echo 'LABEL=ubuntu-boot /run/mnt/ubuntu-boot auto defaults 0 0' >> /run/image.fstab
     # TODO:UC20: support other bootloaders too
     if [ -f /run/mnt/ubuntu-boot/EFI/ubuntu/grub.cfg ]; then
         echo '/run/mnt/ubuntu-boot/EFI/ubuntu /boot/grub none bind 0 0' >> /run/image.fstab

--- a/factory/usr/lib/the-tool
+++ b/factory/usr/lib/the-tool
@@ -2,20 +2,10 @@
 set -e
 
 # Run snap-bootstrap
-cmd="systemd-mount --no-pager --no-ask-password "
-pass=0
-while true; do
-    needed="$(/usr/lib/snapd/snap-bootstrap initramfs-mounts)"
-    if [ -z "$needed" ]; then
-       break
-    fi
-    echo "$needed" | sed "s/^/$cmd/" > "/root/bootstrap.cmds.$pass"
-    set +e
-    . /root/bootstrap.cmds.$pass
-    set -e
-    pass=$((pass + 1))
-done
+/usr/lib/snapd/snap-bootstrap initramfs-mounts
 
+# TODO:UC20: move this code into snap-bootstrap proper so this script _just_ 
+# calls snap-bootstrap
 mkdir -p /run/systemd/system/initrd-fs.target.d
 cat >/run/systemd/system/initrd-fs.target.d/core.conf <<EOF
 [Unit]


### PR DESCRIPTION
* Delete manual references to ubuntu-seed fsck jobs, these are manually created
  by snap-bootstrap now
* Delete the handling around snap-bootstrap output and instead just invoke 
  snap-bootstrap directly
* Add TODO's around additional things we want to move to snap-bootstrap 
  eventually
* Switch back to isolating to initrd.target so we don't have leftover units and
  unfreed memory from the initrd now that all mounts from snap-bootstrap 
  properly persist across the pivot_root.
* Make the-tool depend on systemd-udev-settle so that all /dev device nodes are
  populated when we run snap-bootstrap.
* Remove hackish ubuntu-boot mount entry being injected into the fstab from
  the-modeenv now that snap-bootstrap correctly sets up the mounts.

This completes the work for UC20 1.0 release (minus other bugs we may find).