### PR TITLE
debian/rules: also install snapd info file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -185,7 +185,7 @@ override_dh_auto_install:
 	done
 
 	set -e; \
-	for f in "/lib/$(DEB_HOST_MULTIARCH)/libnss_files.so.* /lib/$(DEB_HOST_MULTIARCH)/libnss_compat.so.* /lib/$(DEB_HOST_MULTIARCH)/libgcc_s.so.1 /sbin/e2fsck /sbin/fsck.vfat /sbin/fsck /bin/umount /bin/mount /bin/kmod /usr/bin/unsquashfs /sbin/dmsetup /usr/lib/snapd/snap-bootstrap /lib/systemd/system/snapd.recovery-chooser-trigger.service"; do \
+	for f in "/lib/$(DEB_HOST_MULTIARCH)/libnss_files.so.* /lib/$(DEB_HOST_MULTIARCH)/libnss_compat.so.* /lib/$(DEB_HOST_MULTIARCH)/libgcc_s.so.1 /sbin/e2fsck /sbin/fsck.vfat /sbin/fsck /bin/umount /bin/mount /bin/kmod /usr/bin/unsquashfs /sbin/dmsetup /usr/lib/snapd/snap-bootstrap /usr/lib/snapd/info /lib/systemd/system/snapd.recovery-chooser-trigger.service"; do \
 		/usr/lib/dracut/dracut-install -D $(CURDIR)/debian/tmp --ldd $$f; \
 	done
 	dpkg -L dmsetup | grep rules.d | xargs -L1 /usr/lib/dracut/dracut-install -D $(CURDIR)/debian/tmp --ldd


### PR DESCRIPTION
This makes it much easier to tell what version of snap-bootstrap was included in
the initramfs when bugs, etc. happen and we need to figure out what version of
snap-bootstrap is running in the initramfs.