### PR TITLE
the-tool: log stdout, stderr to journal and console

### DIFF
--- a/factory/usr/lib/systemd/system/the-tool.service
+++ b/factory/usr/lib/systemd/system/the-tool.service
@@ -12,3 +12,5 @@ Wants=systemd-udev-settle.service
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/lib/the-tool
+StandardOutput=journal+console
+StandardError=journal+console


### PR DESCRIPTION
This is important for field debugging where we want to be able to see why
"the-tool" failed.