### PR TITLE
spread.yaml: drop warn-timeout to 5 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ install:
   - popd
 
 script:
-  - env
   - "/tmp/spread google-nested:"

--- a/spread.yaml
+++ b/spread.yaml
@@ -84,7 +84,7 @@ restore-each: |
   cleanup_nested_core_vm
 
 # it takes a while to build everything while preparing the project
-warn-timeout: 20m
+warn-timeout: 5m
 # but it shouldn't take _too_ long...
 kill-timeout: 30m
 


### PR DESCRIPTION
Hopefully now spread will provide output every 5 minutes while waiting for things to finish such that travis doesn't think that the job is infinitely stuck.