### PR TITLE
features: enabled server feature on x86_64 and any generic kernels.

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -238,7 +238,11 @@ def main():
 
     args = parser.parse_args()
     if args.subcmd == "create-initrd" and not args.features:
+        # Set arch specific default set of features
         args.features = features.split()
+        # For generic kernels, enable more server drivers too
+        if args.kernelver.endswith("-generic") and "server" not in args.features:
+            args.features.append("server")
     globals()[args.subcmd.replace("-", "_")](parser, args)
 
 


### PR DESCRIPTION
Currently server feature is only enabled by default on x86_64
architecture. Also enable server feature for generic kernels, as they
are likely to boot in Qemu too.

BugLink: https://bugs.launchpad.net/bugs/1938530
Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@canonical.com>