### PR TITLE
Changes to support arm64 in the systemd EFI stub

### DIFF
--- a/bin/ubuntu-core-aarch64-efi
+++ b/bin/ubuntu-core-aarch64-efi
@@ -1,0 +1,179 @@
+#!/usr/bin/python3
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+
+# Sizes of different parts of the PE+ file
+sz_signature = 4
+sz_coff_fhead = 20
+sz_opt_head = 112
+sz_sect_head = 40
+
+# File offset to the PE header pointer
+off_pe_pointer = 0x3c
+# Offsets inside file header
+off_fhead_NumberOfSections = 2
+off_fhead_NumberOfSymbols = 12
+# Offsets inside optional headers
+off_opth_SizeOfInitializedData = 8
+off_opth_SectionAlignment = 32
+off_opth_FileAlignment = 36
+off_opth_SizeOfImage = 56
+off_opth_NumberOfRvaAndSizes = 108
+# Offsets inside section header
+off_secth_Name = 0
+off_secth_VirtualSize = 8
+off_secth_VirtualAddress = 12
+off_secth_SizeOfRawData = 16
+
+
+def create_temporary_copy(path):
+    (tmp_file, tmp_path) = tempfile.mkstemp()
+    os.close(tmp_file)
+    shutil.copy2(path, tmp_path)
+    return tmp_path
+
+
+def align_to_size(address, size):
+    rest = address % size
+    if rest:
+        address -= rest
+        address += size
+    return address
+
+
+def fix_aarch64_pe_stub(stub_orig, kernel, initramfs, out_file):
+    # Copy over as we need to modify the stub before calling llvm-objcopy
+    stub = create_temporary_copy(stub_orig)
+
+    with open(stub, "r+b") as stub_f:
+
+        stub_f.seek(off_pe_pointer)
+        pe_off = int.from_bytes(stub_f.read(4), 'little')
+
+        stub_f.seek(pe_off + sz_signature + off_fhead_NumberOfSections)
+        num_sect = int.from_bytes(stub_f.read(2), 'little')
+
+        # Set number of symbols to 0 (gnu-efi sets it wrongly to 1) as required
+        # by the PE specification for images, so llvm-objcopy does not complain
+        # gnu-efi after 3.0.13 solves this.
+        stub_f.seek(pe_off + sz_signature + off_fhead_NumberOfSymbols)
+        stub_f.write(bytearray(4))
+
+    # Copy now kernel/initramfs to the ouput file
+    subprocess.check_call(
+        [
+            'llvm-objcopy',
+            '--add-section',
+            '.linux={}'.format(kernel),
+            '--add-section',
+            '.initrd={}'.format(initramfs),
+            stub,
+            out_file,
+        ]
+    )
+
+    os.remove(stub)
+
+    # We need to fill properly some values in the PE/COFF headers due to llvm
+    # bugs. See:
+    # https://reviews.llvm.org/D106942
+    # https://reviews.llvm.org/D106940 (does not affect focal, but will affect
+    # future ubuntu releases)
+    with open(out_file, "r+b") as out_f:
+        out_f.seek(off_pe_pointer)
+        pe_off = int.from_bytes(out_f.read(4), 'little')
+
+        out_f.seek(pe_off + sz_signature + off_fhead_NumberOfSections)
+        num_sect = int.from_bytes(out_f.read(2), 'little')
+
+        # Get alignment values
+        out_f.seek(pe_off + sz_signature + sz_coff_fhead +
+                   off_opth_SectionAlignment)
+        section_align = int.from_bytes(out_f.read(4), 'little')
+        file_align = int.from_bytes(out_f.read(4), 'little')
+
+        out_f.seek(pe_off + sz_signature + sz_coff_fhead +
+                   off_opth_NumberOfRvaAndSizes)
+        num_dirs = int.from_bytes(out_f.read(4), 'little')
+        sect_off = (pe_off + sz_signature + sz_coff_fhead + sz_opt_head +
+                    8*num_dirs)
+
+        # Set load size and VMA for .linux and .initrd
+        # We assume the order of sections is
+        # .test, .data, .linux, .initrd
+        data_sz = 0
+        data_va = 0
+        disk_data = 0
+        for s in range(num_sect):
+            out_f.seek(sect_off)
+            sect_name = out_f.read(8)
+
+            if s == 0:
+                out_f.seek(sect_off + off_secth_VirtualAddress)
+                vma_start = int.from_bytes(out_f.read(4), 'little')
+
+            if sect_name == b'.data\x00\x00\x00':
+                out_f.seek(sect_off + off_secth_VirtualSize)
+                data_sz = int.from_bytes(out_f.read(4), 'little')
+                data_va = int.from_bytes(out_f.read(4), 'little')
+                disk_data += data_sz
+                next_va = data_va + align_to_size(data_sz, section_align)
+
+            if sect_name == b'.linux\x00\x00' or sect_name == b'.initrd\x00':
+                out_f.seek(sect_off + off_secth_SizeOfRawData)
+                raw_sect_sz = int.from_bytes(out_f.read(4), 'little')
+                out_f.seek(sect_off + off_secth_VirtualSize)
+                out_f.write(raw_sect_sz.to_bytes(4, 'little'))
+                out_f.write(next_va.to_bytes(4, 'little'))
+                # Now rewrite SizeOfRawData with an aligned value
+                disk_size = align_to_size(raw_sect_sz, file_align)
+                out_f.write(disk_size.to_bytes(4, 'little'))
+                disk_data += disk_size
+
+                next_va += align_to_size(raw_sect_sz, section_align)
+
+            sect_off += sz_sect_head
+
+        # Set size of data sections
+        out_f.seek(pe_off + sz_signature + sz_coff_fhead +
+                   off_opth_SizeOfInitializedData)
+        out_f.write(disk_data.to_bytes(4, 'little'))
+
+        # Size in memory (sect_off points now at end of headers)
+        image_sz = next_va - vma_start + align_to_size(sect_off, section_align)
+        out_f.seek(pe_off + sz_signature + sz_coff_fhead +
+                   off_opth_SizeOfImage)
+        out_f.write(image_sz.to_bytes(4, 'little'))
+
+
+def main():
+    parser = argparse.ArgumentParser(usage='Create kernel.efi for aarch64')
+    parser.add_argument('stub', help='Stub with systemd EFI stub')
+    parser.add_argument('kernel', help='Linux kernel image')
+    parser.add_argument('initramfs', help='Initramfs')
+    parser.add_argument('out_file', help='Out EFI executable')
+    args = parser.parse_args()
+
+    fix_aarch64_pe_stub(args.stub, args.kernel, args.initramfs, args.out_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -1,4 +1,18 @@
 #!/usr/bin/python3
+# Copyright 2021 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import argparse
 import os
 import subprocess
@@ -102,30 +116,47 @@ def create_efi(parser, args):
         args.initrd = "-".join([args.initrd, args.kernelver])
         args.output = "-".join([args.output, args.kernelver])
 
-    # kernel.efi map
-    # 0x0000000 stub
-    # 0x0020000 .osrel
-    # 0x0030000 .cmdline
-    # 0x0040000 .splash
-    # 0x0050000 .sbat
-    # 0x2000000 .linux
-    # 0x3000000 .initrd
-    objcopy_cmd = [
+    arch = os.getenv("ARCH")
+    if not arch:
+        arch = subprocess.check_output(
+            ["uname", "-m"], universal_newlines=True
+        ).strip()
+
+    if arch == 'aarch64':
+        subprocess.check_call(
+            [
+                "ubuntu-core-aarch64-efi",
+                args.stub,
+                args.kernel,
+                args.initrd,
+                args.output,
+            ]
+        )
+    else:
+        # kernel.efi map
+        # 0x0000000 stub
+        # 0x0020000 .osrel
+        # 0x0030000 .cmdline
+        # 0x0040000 .splash
+        # 0x0050000 .sbat
+        # 0x2000000 .linux
+        # 0x3000000 .initrd
+        objcopy_cmd = [
             "objcopy",
         ]
-    # TODO add .osrel
-    if args.cmdline:
-        cmdline = tempfile.NamedTemporaryFile(mode='w')
-        cmdline.write('%s' % args.cmdline)
-        cmdline.flush()
-        objcopy_cmd += [
-            "--add-section",
-            ".cmdline=%s" % cmdline.name,
-            "--change-section-vma",
-            ".cmdline=0x30000"
+        # TODO add .osrel
+        if args.cmdline:
+            cmdline = tempfile.NamedTemporaryFile(mode='w')
+            cmdline.write('%s' % args.cmdline)
+            cmdline.flush()
+            objcopy_cmd += [
+                "--add-section",
+                ".cmdline=%s" % cmdline.name,
+                "--change-section-vma",
+                ".cmdline=0x30000"
             ]
-    # TODO add .splash
-    objcopy_cmd += [
+        # TODO add .splash
+        objcopy_cmd += [
             "--add-section",
             ".sbat=%s" % args.sbat,
             "--set-section-flags",
@@ -145,7 +176,8 @@ def create_efi(parser, args):
             args.stub,
             args.output,
         ]
-    subprocess.check_call(objcopy_cmd)
+        subprocess.check_call(objcopy_cmd)
+
     if not args.unsigned:
         subprocess.check_call(
             [

--- a/debian/control
+++ b/debian/control
@@ -65,7 +65,7 @@ Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf
-Depends: ${python3:Depends}, ${misc:Depends}, binutils, dracut-core (>= 051-1), lz4, sbsigntool, linux-firmware
+Depends: ${python3:Depends}, ${misc:Depends}, binutils, dracut-core (>= 051-1), lz4, sbsigntool, linux-firmware, llvm [arm64 armhf]
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core
  systems. Currently targetting creating BLS Type2 like binaries.

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Build-Depends: debhelper-compat (= 12), dh-python, python3:any, dracut-core, qui
                gperf,
                gnu-efi [amd64 i386 arm64 armhf],
                libcap-dev (>= 1:2.24-9~),
+               libfdt-dev [arm64 armhf],
                libpam0g-dev,
                libapparmor-dev (>= 2.9.0-3+exp2) <!stage1>,
                libidn2-dev <!stage1>,

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,5 @@
 bin/ubuntu-core-initramfs usr/bin
+bin/ubuntu-core-aarch64-efi usr/bin
 postinst.d etc/kernel/
 snakeoil/* usr/lib/ubuntu-core-initramfs/snakeoil/
 debian/tmp/* usr/lib/ubuntu-core-initramfs/main

--- a/vendor/systemd/src/boot/efi/linux-aarch64.c
+++ b/vendor/systemd/src/boot/efi/linux-aarch64.c
@@ -1,0 +1,161 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
+#include <efi.h>
+#include <efilib.h>
+#include <libfdt.h>
+
+#include "linux.h"
+#include "linux-aarch64.h"
+
+/* DTB table GUID, as defined by UEFI specification 2.9 */
+/* gnu-efi after 3.0.13 should already define this */
+#ifndef EFI_DTB_TABLE_GUID
+#define EFI_DTB_TABLE_GUID \
+    { 0xb1b621d5, 0xf19c, 0x41a5, {0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0} }
+static EFI_GUID EfiDtbTableGuid = EFI_DTB_TABLE_GUID;
+#endif
+
+/* Create new fdt, either empty or with the content of old_fdt if not null */
+static void *create_new_fdt(void *old_fdt, int fdt_sz) {
+        EFI_STATUS err;
+        void *fdt = (void *) 0xFFFFFFFFUL;
+        int ret;
+
+        err = uefi_call_wrapper(BS->AllocatePages, 4,
+                                AllocateMaxAddress,
+                                EfiACPIReclaimMemory,
+                                EFI_SIZE_TO_PAGES(fdt_sz),
+                                (EFI_PHYSICAL_ADDRESS*)&fdt);
+        if (EFI_ERROR(err)) {
+                Print(L"Cannot allocate when creating fdt\n");
+                return 0;
+        }
+
+        if (old_fdt) {
+                ret = fdt_open_into(old_fdt, fdt, fdt_sz);
+                if (ret != 0) {
+                        Print(L"Error %d when copying fdt\n", ret);
+                        return 0;
+                }
+        } else {
+                ret = fdt_create_empty_tree(fdt, fdt_sz);
+                if (ret != 0) {
+                        Print(L"Error %d when creating empty fdt\n", ret);
+                        return 0;
+                }
+        }
+
+        /* Set in EFI configuration table */
+        err = uefi_call_wrapper(BS->InstallConfigurationTable, 2,
+                                &EfiDtbTableGuid, fdt);
+        if (EFI_ERROR(err)) {
+                Print(L"Cannot set fdt in EFI configuration\n");
+                return 0;
+        }
+
+        return fdt;
+}
+
+static void *open_fdt(void) {
+        EFI_STATUS status;
+        void *fdt;
+
+        /* Look for a device tree configuration table entry. */
+        status = LibGetSystemConfigurationTable(&EfiDtbTableGuid,
+                                                (VOID**)&fdt);
+        if (EFI_ERROR(status)) {
+                Print(L"DTB table not found, create new one\n");
+                fdt = create_new_fdt(NULL, 2048);
+                if (!fdt)
+                        return 0;
+        }
+
+        if (fdt_check_header(fdt) != 0) {
+                Print(L"Invalid header detected on UEFI supplied FDT\n");
+                return 0;
+        }
+
+        return fdt;
+}
+
+static int update_chosen(void *fdt, UINTN initrd_addr, UINTN initrd_size) {
+        uint64_t initrd_start, initrd_end;
+        int ret, node;
+
+        node = fdt_subnode_offset(fdt, 0, "chosen");
+        if (node < 0) {
+                node = fdt_add_subnode(fdt, 0, "chosen");
+                if (node < 0) {
+                        /* 'node' is an error code when negative: */
+                        ret = node;
+                        Print(L"Error creating chosen\n");
+                        return ret;
+                }
+        }
+
+        initrd_start = cpu_to_fdt64(initrd_addr);
+        initrd_end = cpu_to_fdt64(initrd_addr + initrd_size);
+
+        ret = fdt_setprop(fdt, node, "linux,initrd-start",
+                          &initrd_start, sizeof initrd_start);
+        if (ret) {
+                Print(L"Cannot create initrd-start property\n");
+                return ret;
+        }
+
+        ret = fdt_setprop(fdt, node, "linux,initrd-end",
+                          &initrd_end, sizeof initrd_end);
+        if (ret) {
+                Print(L"Cannot create initrd-end property\n");
+                return ret;
+        }
+
+        return 0;
+}
+
+#define FDT_EXTRA_SIZE 0x400
+
+/* Update fdt /chosen node with initrd address and size */
+static void update_fdt(UINTN initrd_addr, UINTN initrd_size) {
+        void *fdt;
+
+        fdt = open_fdt();
+        if (fdt == 0)
+                return;
+
+        if (update_chosen(fdt, initrd_addr, initrd_size) == -FDT_ERR_NOSPACE) {
+                /* Copy to new tree and re-try */
+                Print(L"Not enough space, creating a new fdt\n");
+                fdt = create_new_fdt(fdt, fdt_totalsize(fdt) + FDT_EXTRA_SIZE);
+                if (!fdt)
+                        return;
+                update_chosen(fdt, initrd_addr, initrd_size);
+        }
+}
+
+/* linux_addr is the .linux section address */
+/* We don't use cmdline in aarch64 (kernel EFI stub takes it itself from the
+ * EFI LoadOptions) */
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+EFI_STATUS linux_exec(EFI_HANDLE image,
+                      CHAR8 *cmdline, UINTN cmdline_len,
+                      UINTN linux_addr,
+                      UINTN initrd_addr, UINTN initrd_size) {
+        struct arm64_kernel_header *hdr;
+        struct arm64_linux_pe_header *pe;
+        handover_f handover;
+
+        if (initrd_size != 0)
+                update_fdt(initrd_addr, initrd_size);
+
+        hdr = (struct arm64_kernel_header *)linux_addr;
+
+        pe = (void *)((UINTN)linux_addr + hdr->hdr_offset);
+        handover = (handover_f)((UINTN)linux_addr + pe->opt.entry_point_addr);
+
+        Print(L"Starting EFI kernel stub\n");
+
+        handover(image, ST, image);
+
+        return EFI_LOAD_ERROR;
+}

--- a/vendor/systemd/src/boot/efi/linux-aarch64.h
+++ b/vendor/systemd/src/boot/efi/linux-aarch64.h
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+#pragma once
+
+/* See linux Documentation/arm64/booting.txt */
+struct arm64_kernel_header {
+        UINT32 code0;		/* Executable code */
+        UINT32 code1;		/* Executable code */
+        UINT64 text_offset;     /* Image load offset, little endian */
+        UINT64 image_size;	/* Effective Image size, little endian */
+        UINT64 flags;		/* kernel flags, little endian */
+        UINT64 res2;		/* reserved */
+        UINT64 res3;		/* reserved */
+        UINT64 res4;		/* reserved */
+        UINT32 magic;		/* Magic number, little endian, "ARM\x64" */
+        UINT32 hdr_offset;	/* Offset of PE/COFF header */
+} __attribute__((packed));
+
+/* PE image format structures, see
+ * https://docs.microsoft.com/en-us/windows/win32/debug/pe-format
+ */
+
+struct pe32_data_directory {
+        UINT32 rva;
+        UINT32 size;
+}  __attribute__((packed));
+
+struct pe64_optional_header {
+        UINT16 magic;
+        UINT8 major_linker_version;
+        UINT8 minor_linker_version;
+        UINT32 code_size;
+        UINT32 initialized_data_size;
+        UINT32 uninitialized_data_size;
+        UINT32 entry_point_addr;
+        UINT32 code_base;
+
+        UINT64 image_base;
+
+        UINT32 section_alignment;
+        UINT32 file_alignment;
+        UINT16 major_os_version;
+        UINT16 minor_os_version;
+        UINT16 major_image_version;
+        UINT16 minor_image_version;
+        UINT16 major_subsystem_version;
+        UINT16 minor_subsystem_version;
+        UINT32 win32_version_value;
+        UINT32 image_size;
+        UINT32 headers_size;
+        UINT32 checksum;
+        UINT16 subsystem;
+        UINT16 dll_characteristics;
+
+        UINT64 stack_reserve_size;
+        UINT64 stack_commit_size;
+        UINT64 heap_reserve_size;
+        UINT64 heap_commit_size;
+
+        UINT32 loader_flags;
+        UINT32 num_rva_and_sizes;
+
+        /* Data directories.  */
+        struct pe32_data_directory export_table;
+        struct pe32_data_directory import_table;
+        struct pe32_data_directory resource_table;
+        struct pe32_data_directory exception_table;
+        struct pe32_data_directory certificate_table;
+        struct pe32_data_directory base_relocation_table;
+        struct pe32_data_directory debug;
+        struct pe32_data_directory architecture;
+        struct pe32_data_directory global_ptr;
+        struct pe32_data_directory tls_table;
+        struct pe32_data_directory load_config_table;
+        struct pe32_data_directory bound_import;
+        struct pe32_data_directory iat;
+        struct pe32_data_directory delay_import_descriptor;
+        struct pe32_data_directory clr_runtime_header;
+        struct pe32_data_directory reserved;
+} __attribute__((packed));
+
+struct pe32_coff_header {
+        UINT16 machine;
+        UINT16 num_sections;
+        UINT32 time_date_stamp;
+        UINT32 symbol_table_ptr;
+        UINT32 num_symbols;
+        UINT16 optional_header_size;
+        UINT16 characteristics;
+} __attribute__((packed));
+
+struct arm64_linux_pe_header {
+        UINT32 magic;
+        struct pe32_coff_header coff;
+        struct pe64_optional_header opt;
+} __attribute__((packed));

--- a/vendor/systemd/src/boot/efi/linux.c
+++ b/vendor/systemd/src/boot/efi/linux.c
@@ -25,7 +25,7 @@ static VOID linux_efi_handover(EFI_HANDLE image, struct boot_params *params) {
         handover(image, ST, params);
 }
 
-EFI_STATUS linux_exec(EFI_HANDLE *image,
+EFI_STATUS linux_exec(EFI_HANDLE image,
                       CHAR8 *cmdline, UINTN cmdline_len,
                       UINTN linux_addr,
                       UINTN initrd_addr, UINTN initrd_size) {

--- a/vendor/systemd/src/boot/efi/linux.c
+++ b/vendor/systemd/src/boot/efi/linux.c
@@ -6,13 +6,6 @@
 #include "linux.h"
 #include "util.h"
 
-#ifdef __i386__
-#define __regparm0__ __attribute__((regparm(0)))
-#else
-#define __regparm0__
-#endif
-
-typedef VOID(*handover_f)(VOID *image, EFI_SYSTEM_TABLE *table, struct boot_params *params) __regparm0__;
 static VOID linux_efi_handover(EFI_HANDLE image, struct boot_params *params) {
         handover_f handover;
         UINTN start = (UINTN)params->hdr.code32_start;

--- a/vendor/systemd/src/boot/efi/linux.h
+++ b/vendor/systemd/src/boot/efi/linux.h
@@ -85,3 +85,11 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
                       CHAR8 *cmdline, UINTN cmdline_size,
                       UINTN linux_addr,
                       UINTN initrd_addr, UINTN initrd_size);
+
+#ifdef __i386__
+#define __regparm0__ __attribute__((regparm(0)))
+#else
+#define __regparm0__
+#endif
+
+typedef VOID(*handover_f)(VOID *image, EFI_SYSTEM_TABLE *table, struct boot_params *params) __regparm0__;

--- a/vendor/systemd/src/boot/efi/linux.h
+++ b/vendor/systemd/src/boot/efi/linux.h
@@ -81,7 +81,7 @@ struct boot_params {
         UINT8  _pad9[276];
 } __attribute__((packed));
 
-EFI_STATUS linux_exec(EFI_HANDLE *image,
+EFI_STATUS linux_exec(EFI_HANDLE image,
                       CHAR8 *cmdline, UINTN cmdline_size,
                       UINTN linux_addr,
                       UINTN initrd_addr, UINTN initrd_size);

--- a/vendor/systemd/src/boot/efi/meson.build
+++ b/vendor/systemd/src/boot/efi/meson.build
@@ -34,7 +34,6 @@ systemd_boot_sources = '''
 '''.split()
 
 stub_sources = '''
-        linux.c
         splash.c
         stub.c
 '''.split()
@@ -134,7 +133,6 @@ if have_gnu_efi
         compile_args = ['-Wall',
                         '-Wextra',
                         '-std=gnu90',
-                        '-nostdinc',
                         '-fpic',
                         '-fshort-wchar',
                         '-ffreestanding',
@@ -176,13 +174,23 @@ if have_gnu_efi
                        '-znocombreloc',
                        '-L', efi_libdir,
                        efi_crt0]
+        efi_staticlib = []
         if efi_arch == 'aarch64' or efi_arch == 'arm'
                 # Aarch64 and ARM32 don't have an EFI capable objcopy. Use 'binary'
                 # instead, and add required symbols manually.
                 efi_ldflags += ['--defsym=EFI_SUBSYSTEM=0xa']
                 efi_format = ['-O', 'binary']
+
+                stub_sources += 'linux-aarch64.c'
+                stub_sources += 'stdclib.c'
+
+                # libfdt needed for arm to pass initrd to kernel
+                cc.find_library('fdt')
+                efi_staticlib += ['/usr/lib/@0@-linux-gnu/libfdt.a'.format(efi_arch)]
         else
                 efi_format = ['--target=efi-app-@0@'.format(gnu_efi_arch)]
+
+                stub_sources += 'linux.c'
         endif
 
         systemd_boot_objects = []
@@ -215,7 +223,7 @@ if have_gnu_efi
                         output : tuple[0],
                         command : [efi_ld, '-o', '@OUTPUT@'] +
                                   efi_ldflags + tuple[2] +
-                                  ['-lefi', '-lgnuefi', libgcc_file_name])
+                                  ['-lefi', '-lgnuefi', libgcc_file_name] + efi_staticlib)
 
                 if want_tests != 'false'
                         test('no-undefined-symbols-' + tuple[0],

--- a/vendor/systemd/src/boot/efi/stdclib.c
+++ b/vendor/systemd/src/boot/efi/stdclib.c
@@ -1,0 +1,74 @@
+/* Public domain */
+/* Taken from https://clc-wiki.net/wiki */
+#include <stdint.h>
+
+#include "stdclib.h"
+
+/* These are C library functions required by libfdt */
+
+void *memmove(void *dest, const void *src, size_t n) {
+        unsigned char *pd = dest;
+        const unsigned char *ps = src;
+        if (ps < pd)
+                for (pd += n, ps += n; n--;)
+                        *--pd = *--ps;
+        else
+                while(n--)
+                        *pd++ = *ps++;
+        return dest;
+}
+
+int memcmp(const void* s1, const void* s2, size_t n) {
+        const unsigned char *p1 = s1, *p2 = s2;
+        while(n--)
+                if (*p1 != *p2)
+                        return *p1 - *p2;
+                else
+                        p1++,p2++;
+        return 0;
+}
+
+void *memchr(const void *s, int c, size_t n) {
+        unsigned char *p = (unsigned char*)s;
+        while (n--)
+                if (*p != (unsigned char)c)
+                        p++;
+                else
+                        return p;
+        return 0;
+}
+
+size_t strlen(const char *s) {
+        size_t i;
+        for (i = 0; s[i] != '\0'; i++);
+        return i;
+}
+
+size_t strnlen(const char *s, size_t maxlen) {
+        size_t i;
+        for (i = 0; i < maxlen && s[i] != '\0'; i++);
+        return i;
+}
+
+char *strchr(const char *s, int c) {
+        while (*s != (char)c)
+                if (!*s++)
+                        return 0;
+        return (char *)s;
+}
+
+char *strrchr(const char *s, int c) {
+        const char *ret = 0;
+        do {
+                if (*s == (char)c)
+                        ret = s;
+        } while(*s++);
+        return (char *)ret;
+}
+
+/* Define __stack_chk_* so all symbols required by libfdt exist */
+
+uintptr_t __stack_chk_guard = 0xdeadbeefa55a857;
+
+void __stack_chk_fail(void) {
+}

--- a/vendor/systemd/src/boot/efi/stdclib.h
+++ b/vendor/systemd/src/boot/efi/stdclib.h
@@ -1,0 +1,12 @@
+/* Public domain  */
+#pragma once
+
+#include <stddef.h>
+
+void *memmove(void *dest, const void *src, size_t n);
+int memcmp(const void *s1, const void *s2, size_t n);
+void *memchr(const void *s, int c, size_t n);
+size_t strlen(const char *s);
+size_t strnlen(const char *s, size_t maxlen);
+char *strchr(const char *s, int c);
+char *strrchr(const char *s, int c);

--- a/vendor/systemd/src/boot/efi/stub.c
+++ b/vendor/systemd/src/boot/efi/stub.c
@@ -46,6 +46,8 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
                 return err;
         }
 
+        Print(L"systemd EFI stub\n");
+
         if (efivar_get_raw(&global_guid, L"SecureBoot", &b, &size) == EFI_SUCCESS)
                 if (*b > 0)
                         secure = TRUE;


### PR DESCRIPTION
First draft to support aarch64 in EFI stub. Main changes are

* The way the kernel is started in arm64 is different to x86 one: instead of using boot parameters, it takes a device tree that needs to be modified to specify the initrd location. Also, we are not calling it directly but via the kernel EFI stub, that takes command line from the EFI parameters so we do not need to touch them in systemd stub.
* objcopy does not support PE/COFF for aarch64, so to create kernel.efi we use llvm-objcopy instead. Even in that case, llvm-objcopy seems to be buggy and some fields in the PE headers need to be modified from the script.

I think that changes in sources need to go to a patch, but for the moment I am proposing directly to ease review.