### PR TITLE
initrd-switch-root.service.d: provide a bit more context

### DIFF
--- a/factory/usr/lib/systemd/system/initrd-switch-root.service.d/core-override.conf
+++ b/factory/usr/lib/systemd/system/initrd-switch-root.service.d/core-override.conf
@@ -1,5 +1,18 @@
 [Service]
+# This empty "ExecStart" does override the original ExecStat from the
+# "real" initrd-switch-root.service that would do a stateful re-exec.
 ExecStart=
-#Ensure that we do not perform stateful reexec (boot fails)
-#Ensure that we ignore kernel cmdline init= parameter (dangerous)
+# Currently doing a stateful re-exec will fail. The reasons are a bit
+# unclear, it seems to be related to the fact that systemd is confused
+# by the mount units in the initrd that are not there in the new pivot
+# root. So this systemctl call to "/sbin/init" is a workaround to prevent
+# systemd from doing a stateful re-exec (there is no other way to
+# prevent this).
+#
+# Using "/sbin/init" here directly also ensures that the kernel commandline
+# "init=" parameter is ignored as it would allow to bypass our protections.
+#
+# XXX: we should fix this eventually (this may involve upstream work)
+# because this also prevents "systemd-analyze time" from displaying
+# the time spend in the initrd.
 ExecStart=/bin/systemctl --no-block switch-root /sysroot /sbin/init


### PR DESCRIPTION
This is the result of my goose-chase why `systemd-analyze time` does not
break out the time spend in initrd. It turns out that for this to work
systemd needs to re-exec statefully. But because of issues with systemd
and/or the way we use it this can't be done right now. So to ensures
that this knowledge is preserved I added some more comments to the
relevant override.

Thanks to Dimitri for (patiently) explaining all this.