### PR TITLE
debian: explain how forked snapd repo is used

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -205,6 +205,11 @@ override_dh_install:
 	dh_install
 ifneq ($(CI),true)
 ifeq ($(DEB_HOST_ARCH_BITS),64)
+	# This builds a forked snap-bootstrap ito the "cloudimg-rootfs" feature
+	# directory. This is *not* used unless "--feature main cloudimg-rootfs"
+	# is specified . This is only done for the certain cloud kernels during
+	# the "core-initrd create-initrd" time.
+	#
 	# Forked snap-bootstrap until https://github.com/snapcore/snapd/pull/10267 lands
 	GOPATH=$(CURDIR)/vendor/gopath/ HOME=$(CURDIR)/debian CGO_ENABLED=1 go build -buildmode=pie -tags nomanagers -o $(CURDIR)/debian/$(DEB_SOURCE)/usr/lib/$(DEB_SOURCE)/cloudimg-rootfs/usr/lib/snapd/snap-bootstrap github.com/snapcore/snapd/cmd/snap-bootstrap
 	# For some reason tests fail when building in chroot
@@ -219,6 +224,8 @@ endif
 
 override_dh_clean:
 ifneq ($(CI),true)
+	# only needed for the "--feature main cloudimg-rootfs", not used for the
+	# default initrd
 	[ -d vendor/gopath ] || ( mkdir -p vendor/gopath/src/github.com/snapcore/; cd vendor/gopath/src/github.com/snapcore; git clone -b run-cloudimg-rootfs-draft-1 https://github.com/xnox/snapd.git; cd snapd; GOPATH= ./get-deps.sh )
 endif
 	dh_clean


### PR DESCRIPTION
This commit explains how the forked snapd repo for the "cloudimg-rootfs"
feature is used.

Thanks to Dimitri for explaining this patiently.