### PR TITLE
debian: add git to build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Build-Depends: debhelper-compat (= 12), dh-python, python3:any, dracut-core, qui
                meson (>= 0.49),
                gettext,
                gperf,
+               git,
                gnu-efi [amd64 i386 arm64 armhf],
                libcap-dev (>= 1:2.24-9~),
                libpam0g-dev,


### PR DESCRIPTION
git is currently needed to build the core-initrd so it should be
part of the build-depends. Without that e.g. `spread qemu-nested:`
fails early.

Thanks for Sertac for spotting this.