### PR TITLE
spread: increase timeouts and fixes

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -83,6 +83,10 @@ restore-each: |
   . "$TESTSLIB/nested.sh"
   cleanup_nested_core_vm
 
+debug-each: |
+  . "$TESTSLIB/nested.sh"
+  print_nested_status
+
 # it takes a while to build everything while preparing the project
 warn-timeout: 40m
 # but it shouldn't take _too_ long...

--- a/spread.yaml
+++ b/spread.yaml
@@ -84,9 +84,9 @@ restore-each: |
   cleanup_nested_core_vm
 
 # it takes a while to build everything while preparing the project
-warn-timeout: 20m
+warn-timeout: 40m
 # but it shouldn't take _too_ long...
-kill-timeout: 30m
+kill-timeout: 50m
 
 suites:
   tests/spread/:

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -28,9 +28,15 @@ wait_for_service() {
 }
 
 wait_for_ssh(){
+    local service_name="$1"
     retry=800
     wait=1
     while ! execute_remote true; do
+        if ! systemctl show -p ActiveState "$service_name" | grep -q "ActiveState=active"; then
+            echo "Service no longer active"
+            return 1
+        fi
+
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
             echo "Timed out waiting for ssh. Aborting!"
@@ -169,7 +175,7 @@ EOF
     fi
 
     # Wait until ssh is ready
-    if ! wait_for_ssh; then
+    if ! wait_for_ssh "${SVC_NAME}"; then
         return 1
     fi
 }

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -29,7 +29,7 @@ wait_for_service() {
 
 wait_for_ssh(){
     local service_name="$1"
-    retry=400
+    retry=800
     wait=1
     while ! execute_remote true; do
         if ! systemctl show -p ActiveState "$service_name" | grep -q "ActiveState=active"; then
@@ -129,7 +129,7 @@ start_nested_core_vm_unit(){
     if [ "${ENABLE_TPM}" = "true" ]; then
         if ! snap list swtpm-mvo > /dev/null; then
             snap install swtpm-mvo --beta
-            retry=10
+            retry=60
             while ! test -S /var/snap/swtpm-mvo/current/swtpm-sock; do
                 retry=$(( retry - 1 ))
                 if [ $retry -le 0 ]; then

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -28,7 +28,7 @@ wait_for_service() {
 }
 
 wait_for_ssh(){
-    retry=400
+    retry=800
     wait=1
     while ! execute_remote true; do
         retry=$(( retry - 1 ))

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -29,7 +29,7 @@ wait_for_service() {
 
 wait_for_ssh(){
     local service_name="$1"
-    retry=800
+    retry=400
     wait=1
     while ! execute_remote true; do
         if ! systemctl show -p ActiveState "$service_name" | grep -q "ActiveState=active"; then
@@ -131,6 +131,11 @@ start_nested_core_vm_unit(){
             snap install swtpm-mvo --beta
             retry=10
             while ! test -S /var/snap/swtpm-mvo/current/swtpm-sock; do
+                retry=$(( retry - 1 ))
+                if [ $retry -le 0 ]; then
+                    echo "Timed out waiting for the swtpm socket. Aborting!"
+                    return 1
+                fi
                 sleep 1
             done
         fi

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -129,6 +129,10 @@ start_nested_core_vm_unit(){
     if [ "${ENABLE_TPM}" = "true" ]; then
         if ! snap list swtpm-mvo > /dev/null; then
             snap install swtpm-mvo --beta
+            retry=10
+            while ! test -S /var/snap/swtpm-mvo/current/swtpm-sock; do
+                sleep 1
+            done
         fi
         PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
     fi

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -53,6 +53,12 @@ cleanup_nested_core_vm(){
     rm -rf "${IMAGE_FILE}"
 }
 
+print_nested_status(){
+    SVC_NAME="nested-vm-$(systemd-escape "${SPREAD_JOB:-unknown}")"
+    systemctl status "${SVC_NAME}" || true
+    journalctl -u "${SVC_NAME}" || true
+}
+
 start_nested_core_vm_unit(){
     # copy the image file to create a new one to use
     # TODO: maybe create a snapshot qcow image instead?


### PR DESCRIPTION
There are currently a bunch of spread failures. It looks like they
might be related to the fact that the test take a long time. This
is also evident from seeing some "green" runs. This commit increases
the timeouts to have more consistent results.