### PR TITLE
Start bootchart earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ TODO: Write documentation for how to integrate initrd.img to your (custom or can
 
 # Bootchart
 
-It is possible to enable bootcharts by adding
-`rd.systemd.wants=systemd-bootchart.service` to the kernel command
-line. The sample collector will run until the systemd switches root,
-and the chart will be saved in `/run/log`. If bootcharts are also
-enabled for the core snap, that file will be eventually moved to the
-`ubuntu-save` partition (see Core snap documentation).
+It is possible to enable bootcharts by adding `core.bootchart` to the
+kernel command line. The sample collector will run until the systemd
+switches root, and the chart will be saved in `/run/log`. If
+bootcharts are also enabled for the core snap, that file will be
+eventually moved to the `ubuntu-save` partition (see Core snap
+documentation).

--- a/factory/usr/lib/systemd/system/initrd-switch-root.target.wants/systemd-bootchart-quit.service
+++ b/factory/usr/lib/systemd/system/initrd-switch-root.target.wants/systemd-bootchart-quit.service
@@ -1,0 +1,1 @@
+../systemd-bootchart-quit.service

--- a/factory/usr/lib/systemd/system/sysinit.target.wants/systemd-bootchart.service
+++ b/factory/usr/lib/systemd/system/sysinit.target.wants/systemd-bootchart.service
@@ -1,0 +1,1 @@
+../systemd-bootchart.service

--- a/factory/usr/lib/systemd/system/systemd-bootchart-quit.service
+++ b/factory/usr/lib/systemd/system/systemd-bootchart-quit.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Stop Boot Process Profiler
+DefaultDependencies=no
+Before=initrd-switch-root.service
+ConditionKernelCommandLine=core.bootchart
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/bin/systemctl stop systemd-bootchart.service

--- a/factory/usr/lib/systemd/system/systemd-bootchart.service
+++ b/factory/usr/lib/systemd/system/systemd-bootchart.service
@@ -2,6 +2,7 @@
 Description=Boot Process Profiler
 Documentation=man:systemd-bootchart.service(1) man:bootchart.conf(5)
 DefaultDependencies=no
+ConditionKernelCommandLine=core.bootchart
 
 [Service]
 ExecStartPre=/usr/sbin/mkdir -p /run/log


### PR DESCRIPTION
Previously, we started systemd-bootchart by adding
rd.systemd.wants=systemd-bootchart.service to the kernel command
line. This has as a side effect that the service is added to the
initrd default target and is started later than desired. Instead,
enable the service by default and use a new kernel command line
parameter (core.bootchart) as condition to start it. We also need to
make sure that the service is stopped properly to the bootchart is
written to the /run folder.