### PR TITLE
Xnox/upgrade snapd snapshot

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-core-initramfs (49) focal; urgency=medium
+ubuntu-core-initramfs (50) focal; urgency=medium
 
   * Initial Release.
 

--- a/debian/rules
+++ b/debian/rules
@@ -241,7 +241,7 @@ override_dh_clean:
 ifneq ($(CI),true)
 	# only needed for the "--feature main cloudimg-rootfs", not used for the
 	# default initrd
-	[ -d vendor/gopath ] || ( mkdir -p vendor/gopath/src/github.com/snapcore/; cd vendor/gopath/src/github.com/snapcore; git clone -b run-cloudimg-rootfs-draft-1 https://github.com/xnox/snapd.git; cd snapd; git checkout ec1bfe7; GOPATH= ./get-deps.sh )
+	[ -d vendor/gopath ] || ( mkdir -p vendor/gopath/src/github.com/snapcore/; cd vendor/gopath/src/github.com/snapcore; git clone -b run-cloudimg-rootfs-draft-1 https://github.com/xnox/snapd.git; cd snapd; git checkout 3949a313afc319482898fc9c1654f82f12a07629; GOPATH= ./get-deps.sh )
 endif
 	dh_clean
 


### PR DESCRIPTION
Upgrade cloudimg-rootfs feature with a newer snapd master snapshot with yet unmerged PR for classic fde.