### PR TITLE
releasing package ubuntu-core-initramfs version 51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-core-initramfs (50) focal; urgency=medium
+ubuntu-core-initramfs (51) focal; urgency=medium
 
   * Initial Release.
 


### PR DESCRIPTION
There is new snapd in snappy-dev/image ppa, and core-initrd rebuild has been requested to include that.