### PR TITLE
Make sure tmp.mount is stopped before switch

### DIFF
--- a/factory/usr/lib/systemd/system/tmp.mount.d/umount.conf
+++ b/factory/usr/lib/systemd/system/tmp.mount.d/umount.conf
@@ -1,0 +1,6 @@
+# Mounts do not seem to be stopped when isolating, so we need to force
+# a conflict to umount tmp.mount so that main boot does not think it
+# is already mounted from the state.
+[Unit]
+Conflicts=initrd-switch-root.target
+Before=initrd-switch-root.target


### PR DESCRIPTION
This is a follow-up to #58. It will be unmarked as draft once #58 is merged.

Otherwise with stateful re-execution, systemd will think for a short
time that it is mounted. It will start `systemd-tmpfiles-setup` and
`systemd-timesyncd` too early.
