### PR TITLE
recovery-chooser-trigger.service: Survive the switch root

### DIFF
--- a/factory/usr/lib/systemd/system/initrd-switch-root.target.wants/snapd.recovery-chooser-trigger.service
+++ b/factory/usr/lib/systemd/system/initrd-switch-root.target.wants/snapd.recovery-chooser-trigger.service
@@ -1,0 +1,1 @@
+../snapd.recovery-chooser-trigger.service

--- a/factory/usr/lib/systemd/system/snapd.recovery-chooser-trigger.service.d/survive-switch-root.conf
+++ b/factory/usr/lib/systemd/system/snapd.recovery-chooser-trigger.service.d/survive-switch-root.conf
@@ -1,0 +1,13 @@
+[Unit]
+# Because it is not killed by the switch root, we have to make sure
+# not to not depend on local-fs.target, sysinit.target,
+# etc. so that `isolate initrd-switch-root.target` will still take
+# down all those targets.
+# We still need to run after basic.target but this will be already wanted
+# by initrd.target
+DefaultDependencies=no
+After=sysinit.target
+After=basic.target
+
+[Service]
+ExecStart=@/usr/lib/snapd/snap-bootstrap @snap-bootstrap recovery-chooser-trigger


### PR DESCRIPTION
`snap-bootstrap recovery-chooser-trigger` is only expected to use
`/run` so it can safely survive the switch root.

When using stateful re-execution of systemd, this will keep the same
service started from initramfs and continue into the main boot.

Because we need to pull it into `initrd-switch-root.target`, we also
need to remove default dependencies so that we do not indirectly pull
`sysinit.target` or `local-fs.target` into
`initrd-switch-root.target`.

Note, we should probably add a signal handler in `snap-bootstrap
recovery-chooser-trigger` to be notified when `initrd-root-fs.target`
is reached to `chdir` into `/sysroot` so that we do not drag the old
initramfs in memory until it is stopped. This is because systemd will
lazily umount the old root.