### PR TITLE
Simplify dependencies of the-tool.service

### DIFF
--- a/factory/usr/lib/systemd/system/the-tool.service
+++ b/factory/usr/lib/systemd/system/the-tool.service
@@ -1,13 +1,10 @@
 [Unit]
 OnFailure=emergency.target
 OnFailureJobMode=replace-irreversibly
+
 DefaultDependencies=no
+After=sysinit.target
 Before=initrd-root-device.target
-After=systemd-tmpfiles-setup.service
-After=systemd-modules-load.service
-Wants=systemd-modules-load.service
-After=systemd-udev-settle.service
-Wants=systemd-udev-settle.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
sysinit.target already runs after systemd-tmpfiles-setup.service,
systemd-modules-load.service, and systemd-udev-settle.service.

We also explicitly put the-tool.service in initrd-root-device.target,
because it is a dependency of initrd-fs.target but does not need to
stay alive through the switch root.

initrd.target already wants sysinit.target (through basic.target) so
we do not need to add a "Wants". It also helps not to not inject an
indirect "Wants" from initrd-fs.target to sysinit.target which we do
not want, since all the services from sysinit.target have to be re-run
in main, thus need to be taken down in switch root.

This is extracted from #59 