### PR TITLE
Remove tmp.mount

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -160,6 +160,8 @@ override_dh_auto_install:
 		usr/lib/systemd/user-preset \
 		usr/lib/systemd/network \
 		usr/lib/systemd/system-generators/systemd-gpt-auto-generator \
+		usr/lib/systemd/system/tmp.mount \
+		usr/lib/systemd/system/local-fs.target.wants/tmp.mount \
 		usr/lib/sysusers.d \
 		usr/lib/*/pkgconfig \
 		usr/include \

--- a/factory/usr/lib/systemd/system/tmp.mount.d/umount.conf
+++ b/factory/usr/lib/systemd/system/tmp.mount.d/umount.conf
@@ -1,6 +1,0 @@
-# Mounts do not seem to be stopped when isolating, so we need to force
-# a conflict to umount tmp.mount so that main boot does not think it
-# is already mounted from the state.
-[Unit]
-Conflicts=initrd-switch-root.target
-Before=initrd-switch-root.target


### PR DESCRIPTION
/tmp is not useful in initrd for any of its service. It also requires
some hack to unmount properly. It is better to get rid of it.