### PR TITLE
the-modeenv: mount piboot from seed if present

### DIFF
--- a/factory/usr/lib/the-modeenv
+++ b/factory/usr/lib/the-modeenv
@@ -13,9 +13,11 @@ if grep -q snapd_recovery_mode=run /proc/cmdline; then
     if [ -f /run/mnt/ubuntu-boot/EFI/ubuntu/grub.cfg ]; then
         echo '/run/mnt/ubuntu-boot/EFI/ubuntu /boot/grub none bind 0 0' >> /run/image.fstab
         # ensure ESP efi dir is available for fwupdate (LP: 1892392)
-        echo '/run/mnt/ubuntu-seed/ /boot/efi none bind 0 0' >> /run/image.fstab        
+        echo '/run/mnt/ubuntu-seed/ /boot/efi none bind 0 0' >> /run/image.fstab
     elif [ -f /run/mnt/ubuntu-boot/uboot/ubuntu/boot.sel ]; then
         echo '/run/mnt/ubuntu-boot/uboot/ubuntu /boot/uboot none bind 0 0' >> /run/image.fstab
+    elif [ -f /run/mnt/ubuntu-seed/piboot/ubuntu/piboot.conf ]; then
+        echo '/run/mnt/ubuntu-seed/piboot/ubuntu /boot/piboot none bind 0 0' >> /run/image.fstab
     fi
 fi
 mount -o bind /run/image.fstab /sysroot/etc/fstab


### PR DESCRIPTION
Mount piboot from seed if the piboot bootloader is being used. Depends on https://github.com/snapcore/core-base/pull/30.

Leaving as draft for the moment - we can decide to merge it or not depending on how quickly https://github.com/snapcore/core-base/pull/25 is merged.