### PR TITLE
Backport patches from sd-stub v250

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,8 @@ include /usr/share/dpkg/default.mk
 	dh $@ --buildsystem=meson+ninja --sourcedirectory=vendor/systemd --with python3
 
 override_dh_auto_configure:
+	find vendor/systemd-patches/ -type f -printf "%f\n" | sort >> vendor/systemd/debian/patches/series
+	cp vendor/systemd-patches/*.patch vendor/systemd/debian/patches/
 	cd vendor/systemd; QUILT_PATCHES=debian/patches quilt push -a || true
 	sed -i '/"minix"/s/^/\/\//' vendor/systemd/src/test/test-path-util.c
 	dh_auto_configure --buildsystem=meson+ninja --sourcedirectory=vendor/systemd -- \

--- a/vendor/systemd-patches/0001-Disable-non-explicit-sbatvars-autodetection-for-cros.patch
+++ b/vendor/systemd-patches/0001-Disable-non-explicit-sbatvars-autodetection-for-cros.patch
@@ -1,0 +1,30 @@
+From 356320ac48c558a8b08bd7f22a80685791a8f04f Mon Sep 17 00:00:00 2001
+From: James Hilliard <james.hilliard1@gmail.com>
+Date: Sat, 10 Jul 2021 04:36:50 -0600
+Subject: [PATCH 01/73] Disable non-explicit sbatvars autodetection for cross
+ builds.
+
+Since autodetection is unlikely to work reliably for cross builds
+disable it unless explicitly enabled.
+
+Signed-off-by: James Hilliard <james.hilliard1@gmail.com>
+---
+ src/boot/efi/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index afdf739d9..62d826bec 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -115,7 +115,7 @@ if have_gnu_efi
+                             ['sbat-distro-url', 'BUG_REPORT_URL']]
+                 foreach sbatvar : sbatvars
+                         value = get_option(sbatvar[0])
+-                        if value == '' or value == 'auto'
++                        if (value == '' and not meson.is_cross_build()) or value == 'auto'
+                                 cmd = 'if [ -e /etc/os-release ]; then . /etc/os-release; else . /usr/lib/os-release; fi; echo $@0@'.format(sbatvar[1])
+                                 value = run_command(sh, '-c', cmd).stdout().strip()
+                                 message('@0@ (from @1@): @2@'.format(sbatvar[0], sbatvar[1], value))
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0002-sd-boot-time-measurements-for-the-ARM64-This-adds-as.patch
+++ b/vendor/systemd-patches/0002-sd-boot-time-measurements-for-the-ARM64-This-adds-as.patch
@@ -1,0 +1,53 @@
+From d28a5dfc1b164b0f985bb654b08e144f6858f97b Mon Sep 17 00:00:00 2001
+From: Max Resch <resch.max@gmail.com>
+Date: Wed, 4 Aug 2021 17:23:27 +0200
+Subject: [PATCH 02/73] sd-boot: time measurements for the ARM64 This adds
+ assembly to read the platform timer from the CP15 coprocessor register
+ `cntpct_el0` and the frequency from `cntfrq_el0`
+
+---
+ src/boot/efi/util.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index aee076060..c6b78154c 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -17,6 +17,12 @@ UINT64 ticks_read(VOID) {
+         __asm__ volatile ("rdtsc" : "=A" (val));
+         return val;
+ }
++#elif defined(__aarch64__)
++UINT64 ticks_read(VOID) {
++        UINT64 val;
++        __asm__ volatile ("mrs %0, cntpct_el0" : "=r" (val));
++        return val;
++}
+ #else
+ UINT64 ticks_read(VOID) {
+         UINT64 val = 1;
+@@ -24,6 +30,13 @@ UINT64 ticks_read(VOID) {
+ }
+ #endif
+ 
++#if defined(__aarch64__)
++UINT64 ticks_freq(VOID) {
++        UINT64 freq;
++        __asm__ volatile ("mrs %0, cntfrq_el0": "=r" (freq));
++        return freq;
++}
++#else
+ /* count TSC ticks during a millisecond delay */
+ UINT64 ticks_freq(VOID) {
+         UINT64 ticks_start, ticks_end;
+@@ -34,6 +47,7 @@ UINT64 ticks_freq(VOID) {
+ 
+         return (ticks_end - ticks_start) * 1000UL;
+ }
++#endif
+ 
+ UINT64 time_usec(VOID) {
+         UINT64 ticks;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0003-alloc-util-make-mfree-typesafe.patch
+++ b/vendor/systemd-patches/0003-alloc-util-make-mfree-typesafe.patch
@@ -1,0 +1,61 @@
+From aef983583e8a71d4f5c3c5f53d54de4b420a45ee Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 10 Aug 2021 14:36:00 +0200
+Subject: [PATCH 03/73] alloc-util: make mfree() typesafe
+
+Make sure we return the same type as we accept.
+
+One incorrect use of mfree() is discovered and fixed this way.
+---
+ src/basic/alloc-util.h        | 9 +++++----
+ src/resolve/resolved-dns-rr.c | 5 +++--
+ 2 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/src/basic/alloc-util.h b/src/basic/alloc-util.h
+index 3c33308f4..fc3531344 100644
+--- a/src/basic/alloc-util.h
++++ b/src/basic/alloc-util.h
+@@ -44,10 +44,11 @@ typedef void (*free_func_t)(void *p);
+ 
+ #define malloc0(n) (calloc(1, (n) ?: 1))
+ 
+-static inline void *mfree(void *memory) {
+-        free(memory);
+-        return NULL;
+-}
++#define mfree(memory)                           \
++        ({                                      \
++                free(memory);                   \
++                (typeof(memory)) NULL;          \
++        })
+ 
+ #define free_and_replace(a, b)                  \
+         ({                                      \
+diff --git a/src/resolve/resolved-dns-rr.c b/src/resolve/resolved-dns-rr.c
+index 4a0327a19..d98914e8b 100644
+--- a/src/resolve/resolved-dns-rr.c
++++ b/src/resolve/resolved-dns-rr.c
+@@ -47,8 +47,8 @@ DnsResourceKey* dns_resource_key_new_redirect(const DnsResourceKey *key, const D
+         if (cname->key->type == DNS_TYPE_CNAME)
+                 return dns_resource_key_new(key->class, key->type, cname->cname.name);
+         else {
++                _cleanup_free_ char *destination = NULL;
+                 DnsResourceKey *k;
+-                char *destination = NULL;
+ 
+                 r = dns_name_change_suffix(dns_resource_key_name(key), dns_resource_key_name(cname->key), cname->dname.name, &destination);
+                 if (r < 0)
+@@ -58,8 +58,9 @@ DnsResourceKey* dns_resource_key_new_redirect(const DnsResourceKey *key, const D
+ 
+                 k = dns_resource_key_new_consume(key->class, key->type, destination);
+                 if (!k)
+-                        return mfree(destination);
++                        return NULL;
+ 
++                TAKE_PTR(destination);
+                 return k;
+         }
+ }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0004-macro-Move-some-macros-to-macro-fundamental.h.patch
+++ b/vendor/systemd-patches/0004-macro-Move-some-macros-to-macro-fundamental.h.patch
@@ -1,0 +1,98 @@
+From 37409e0a1a904ae7b4893ca086631dc76065a6d7 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Wed, 11 Aug 2021 14:59:46 +0200
+Subject: [PATCH 04/73] macro: Move some macros to macro-fundamental.h
+
+Also, make sure STRLEN works with wide strings too.
+---
+ src/basic/macro.h                   | 23 -----------------------
+ src/fundamental/macro-fundamental.h | 23 +++++++++++++++++++++++
+ 2 files changed, 23 insertions(+), 23 deletions(-)
+
+diff --git a/src/basic/macro.h b/src/basic/macro.h
+index 072fed437..ae5b1b788 100644
+--- a/src/basic/macro.h
++++ b/src/basic/macro.h
+@@ -23,27 +23,11 @@
+ #define _packed_ __attribute__((__packed__))
+ #define _malloc_ __attribute__((__malloc__))
+ #define _weak_ __attribute__((__weak__))
+-#define _likely_(x) (__builtin_expect(!!(x), 1))
+-#define _unlikely_(x) (__builtin_expect(!!(x), 0))
+ #define _public_ __attribute__((__visibility__("default")))
+ #define _hidden_ __attribute__((__visibility__("hidden")))
+ #define _weakref_(x) __attribute__((__weakref__(#x)))
+ #define _alignas_(x) __attribute__((__aligned__(__alignof(x))))
+ #define _alignptr_ __attribute__((__aligned__(sizeof(void*))))
+-#if __GNUC__ >= 7
+-#define _fallthrough_ __attribute__((__fallthrough__))
+-#else
+-#define _fallthrough_
+-#endif
+-/* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
+- * compiler versions */
+-#ifndef _noreturn_
+-#if __STDC_VERSION__ >= 201112L
+-#define _noreturn_ _Noreturn
+-#else
+-#define _noreturn_ __attribute__((__noreturn__))
+-#endif
+-#endif
+ 
+ #if !defined(HAS_FEATURE_MEMORY_SANITIZER)
+ #  if defined(__has_feature)
+@@ -208,13 +192,6 @@ static inline size_t GREEDY_ALLOC_ROUND_UP(size_t l) {
+         return m;
+ }
+ 
+-/*
+- * STRLEN - return the length of a string literal, minus the trailing NUL byte.
+- *          Contrary to strlen(), this is a constant expression.
+- * @x: a string literal.
+- */
+-#define STRLEN(x) (sizeof(""x"") - 1)
+-
+ /*
+  * container_of - cast a member of a structure out to the containing structure
+  * @ptr: the pointer to the member.
+diff --git a/src/fundamental/macro-fundamental.h b/src/fundamental/macro-fundamental.h
+index 967518600..533ac1b7e 100644
+--- a/src/fundamental/macro-fundamental.h
++++ b/src/fundamental/macro-fundamental.h
+@@ -14,6 +14,22 @@
+ #define _used_ __attribute__((__used__))
+ #define _unused_ __attribute__((__unused__))
+ #define _cleanup_(x) __attribute__((__cleanup__(x)))
++#define _likely_(x) (__builtin_expect(!!(x), 1))
++#define _unlikely_(x) (__builtin_expect(!!(x), 0))
++#if __GNUC__ >= 7
++#define _fallthrough_ __attribute__((__fallthrough__))
++#else
++#define _fallthrough_
++#endif
++/* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
++ * compiler versions */
++#ifndef _noreturn_
++#if __STDC_VERSION__ >= 201112L
++#define _noreturn_ _Noreturn
++#else
++#define _noreturn_ __attribute__((__noreturn__))
++#endif
++#endif
+ 
+ #define XSTRINGIFY(x) #x
+ #define STRINGIFY(x) XSTRINGIFY(x)
+@@ -216,3 +232,10 @@
+                 (ptr) = NULL;                   \
+                 _ptr_;                          \
+         })
++
++/*
++ * STRLEN - return the length of a string literal, minus the trailing NUL byte.
++ *          Contrary to strlen(), this is a constant expression.
++ * @x: a string literal.
++ */
++#define STRLEN(x) (sizeof(""x"") - sizeof(typeof(x[0])))
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0005-sd-boot-Don-t-use-magic-integer-constants.patch
+++ b/vendor/systemd-patches/0005-sd-boot-Don-t-use-magic-integer-constants.patch
@@ -1,0 +1,77 @@
+From e3a51b71fa6cd37181ff3158fd3b7854e04acca1 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Wed, 11 Aug 2021 14:59:46 +0200
+Subject: [PATCH 05/73] sd-boot: Don't use magic integer constants
+
+---
+ src/boot/efi/util.c | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index c6b78154c..b048df076 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -101,7 +101,7 @@ EFI_STATUS efivar_set(const EFI_GUID *vendor, const CHAR16 *name, const CHAR16 *
+ EFI_STATUS efivar_set_uint_string(const EFI_GUID *vendor, const CHAR16 *name, UINTN i, UINT32 flags) {
+         CHAR16 str[32];
+ 
+-        SPrint(str, 32, L"%u", i);
++        SPrint(str, ELEMENTSOF(str), L"%u", i);
+         return efivar_set(vendor, name, str, flags);
+ }
+ 
+@@ -132,35 +132,35 @@ EFI_STATUS efivar_set_uint64_le(const EFI_GUID *vendor, const CHAR16 *name, UINT
+ }
+ 
+ EFI_STATUS efivar_get(const EFI_GUID *vendor, const CHAR16 *name, CHAR16 **value) {
+-        _cleanup_freepool_ CHAR8 *buf = NULL;
++        _cleanup_freepool_ CHAR16 *buf = NULL;
+         EFI_STATUS err;
+         CHAR16 *val;
+         UINTN size;
+ 
+-        err = efivar_get_raw(vendor, name, &buf, &size);
++        err = efivar_get_raw(vendor, name, (CHAR8**)&buf, &size);
+         if (EFI_ERROR(err))
+                 return err;
+ 
+         /* Make sure there are no incomplete characters in the buffer */
+-        if ((size % 2) != 0)
++        if ((size % sizeof(CHAR16)) != 0)
+                 return EFI_INVALID_PARAMETER;
+ 
+         if (!value)
+                 return EFI_SUCCESS;
+ 
+         /* Return buffer directly if it happens to be NUL terminated already */
+-        if (size >= 2 && buf[size-2] == 0 && buf[size-1] == 0) {
+-                *value = (CHAR16*) TAKE_PTR(buf);
++        if (size >= sizeof(CHAR16) && buf[size/sizeof(CHAR16)] == 0) {
++                *value = TAKE_PTR(buf);
+                 return EFI_SUCCESS;
+         }
+ 
+         /* Make sure a terminating NUL is available at the end */
+-        val = AllocatePool(size + 2);
++        val = AllocatePool(size + sizeof(CHAR16));
+         if (!val)
+                 return EFI_OUT_OF_RESOURCES;
+ 
+         CopyMem(val, buf, size);
+-        val[size/2] = 0; /* NUL terminate */
++        val[size / sizeof(CHAR16)] = 0; /* NUL terminate */
+ 
+         *value = val;
+         return EFI_SUCCESS;
+@@ -255,7 +255,7 @@ VOID efivar_set_time_usec(const EFI_GUID *vendor, const CHAR16 *name, UINT64 use
+         if (usec == 0)
+                 return;
+ 
+-        SPrint(str, 32, L"%ld", usec);
++        SPrint(str, ELEMENTSOF(str), L"%ld", usec);
+         efivar_set(vendor, name, str, 0);
+ }
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0006-sd-boot-Add-assert-implementation.patch
+++ b/vendor/systemd-patches/0006-sd-boot-Add-assert-implementation.patch
@@ -1,0 +1,90 @@
+From 5a47f141b7dcbc632efc4d225daa171dd0cd90e0 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Wed, 11 Aug 2021 14:59:46 +0200
+Subject: [PATCH 06/73] sd-boot: Add assert implementation
+
+There is a ASSERT() macro from gnu-efi, but that does not show any
+output to ConOut. Having to do some additional setup just to get
+some debug output is tedious and outright difficult on real hardware.
+---
+ src/boot/efi/assert.c               | 15 +++++++++++++++
+ src/boot/efi/meson.build            |  9 +++++++--
+ src/fundamental/macro-fundamental.h |  9 ++++++++-
+ 3 files changed, 30 insertions(+), 3 deletions(-)
+ create mode 100644 src/boot/efi/assert.c
+
+diff --git a/src/boot/efi/assert.c b/src/boot/efi/assert.c
+new file mode 100644
+index 000000000..350b2b016
+--- /dev/null
++++ b/src/boot/efi/assert.c
+@@ -0,0 +1,15 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#ifndef NDEBUG
++
++#include <efi.h>
++#include <efilib.h>
++#include "util.h"
++
++void efi_assert(const char *expr, const char *file, unsigned line, const char *function) {
++      log_error_stall(L"systemd-boot assertion '%a' failed at %a:%u, function %a(). Halting.", expr, file, line, function);
++      for (;;)
++            uefi_call_wrapper(BS->Stall, 1, 60 * 1000 * 1000);
++}
++
++#endif
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index 62d826bec..16eeb4ebb 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -17,6 +17,7 @@ efi_headers = files('''
+ '''.split())
+ 
+ common_sources = '''
++        assert.c
+         disk.c
+         graphics.c
+         measure.c
+@@ -219,12 +220,16 @@ if have_gnu_efi
+                 compile_args += ['-Werror']
+         endif
+         if get_option('buildtype') == 'debug'
+-                compile_args += ['-ggdb', '-O0']
++                compile_args += ['-ggdb', '-O0', '-DEFI_DEBUG']
+         elif get_option('buildtype') == 'debugoptimized'
+-                compile_args += ['-ggdb', '-Og']
++                compile_args += ['-ggdb', '-Og', '-DEFI_DEBUG']
+         else
+                 compile_args += ['-O2']
+         endif
++        if get_option('b_ndebug') == 'true' or (
++           get_option('b_ndebug') == 'if-release' and ['plain', 'release'].contains(get_option('buildtype')))
++                compile_args += ['-DNDEBUG']
++        endif
+ 
+         efi_ldflags = ['-T', efi_lds,
+                        '-shared',
+diff --git a/src/fundamental/macro-fundamental.h b/src/fundamental/macro-fundamental.h
+index 533ac1b7e..8fe79cc02 100644
+--- a/src/fundamental/macro-fundamental.h
++++ b/src/fundamental/macro-fundamental.h
+@@ -50,7 +50,14 @@
+ #define CONCATENATE(x, y) XCONCATENATE(x, y)
+ 
+ #ifdef SD_BOOT
+-#define assert(expr) do {} while (false)
++        #ifdef NDEBUG
++                #define assert(expr)
++                #define assert_not_reached() __builtin_unreachable()
++        #else
++                void efi_assert(const char *expr, const char *file, unsigned line, const char *function) _noreturn_;
++                #define assert(expr) ({ _likely_(expr) ? VOID_0 : efi_assert(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__); })
++                #define assert_not_reached() efi_assert("Code should not be reached", __FILE__, __LINE__, __PRETTY_FUNCTION__)
++        #endif
+ #endif
+ 
+ #if defined(static_assert)
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0007-sd-boot-Assert-all-the-things.patch
+++ b/vendor/systemd-patches/0007-sd-boot-Assert-all-the-things.patch
@@ -1,0 +1,906 @@
+From d4d0ccb832f5a57a11e43930f96518cc6557daa6 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Wed, 11 Aug 2021 14:59:46 +0200
+Subject: [PATCH 07/73] sd-boot: Assert all the things!
+
+---
+ src/boot/efi/boot.c        | 101 +++++++++++++++++++++++++++++++++++++
+ src/boot/efi/console.c     |   6 +++
+ src/boot/efi/crc32.c       |   5 ++
+ src/boot/efi/disk.c        |   2 +
+ src/boot/efi/linux.c       |   5 ++
+ src/boot/efi/measure.c     |   9 ++++
+ src/boot/efi/pe.c          |   6 +++
+ src/boot/efi/random-seed.c |  30 ++++++++---
+ src/boot/efi/sha256.c      |  13 +++++
+ src/boot/efi/shim.c        |   7 +++
+ src/boot/efi/splash.c      |  14 +++++
+ src/boot/efi/util.c        |  56 +++++++++++++++++++-
+ 12 files changed, 247 insertions(+), 7 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index b4f3b9605..8a67b665d 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -72,6 +72,9 @@ typedef struct {
+ } Config;
+ 
+ static VOID cursor_left(UINTN *cursor, UINTN *first) {
++        assert(cursor);
++        assert(first);
++
+         if ((*cursor) > 0)
+                 (*cursor)--;
+         else if ((*first) > 0)
+@@ -84,6 +87,9 @@ static VOID cursor_right(
+                 UINTN x_max,
+                 UINTN len) {
+ 
++        assert(cursor);
++        assert(first);
++
+         if ((*cursor)+1 < x_max)
+                 (*cursor)++;
+         else if ((*first) + (*cursor) < len)
+@@ -100,6 +106,8 @@ static BOOLEAN line_edit(
+         UINTN size, len, first, cursor, clear;
+         BOOLEAN exit, enter;
+ 
++        assert(line_out);
++
+         if (!line_in)
+                 line_in = L"";
+         size = StrLen(line_in) + 1024;
+@@ -332,6 +340,8 @@ static BOOLEAN line_edit(
+ }
+ 
+ static UINTN entry_lookup_key(Config *config, UINTN start, CHAR16 key) {
++        assert(config);
++
+         if (key == 0)
+                 return -1;
+ 
+@@ -362,6 +372,9 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         _cleanup_freepool_ CHAR16 *partstr = NULL, *defaultstr = NULL;
+         UINTN x, y;
+ 
++        assert(config);
++        assert(loaded_image_path);
++
+         uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
+         uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+ 
+@@ -493,6 +506,10 @@ static BOOLEAN menu_run(
+                 ConfigEntry **chosen_entry,
+                 CHAR16 *loaded_image_path) {
+ 
++        assert(config);
++        assert(chosen_entry);
++        assert(loaded_image_path);
++
+         EFI_STATUS err;
+         UINTN visible_max;
+         UINTN idx_highlight;
+@@ -868,6 +885,9 @@ static BOOLEAN menu_run(
+ }
+ 
+ static VOID config_add_entry(Config *config, ConfigEntry *entry) {
++        assert(config);
++        assert(entry);
++
+         if ((config->entry_count & 15) == 0) {
+                 UINTN i;
+ 
+@@ -908,6 +928,12 @@ static CHAR8 *line_get_key_value(
+         CHAR8 *line, *value;
+         UINTN linelen;
+ 
++        assert(content);
++        assert(sep);
++        assert(pos);
++        assert(key_ret);
++        assert(value_ret);
++
+ skip:
+         line = content + *pos;
+         if (*line == '\0')
+@@ -970,6 +996,9 @@ static VOID config_defaults_load_from_file(Config *config, CHAR8 *content) {
+         UINTN pos = 0;
+         CHAR8 *key, *value;
+ 
++        assert(config);
++        assert(content);
++
+         while ((line = line_get_key_value(content, (CHAR8 *)" \t", &pos, &key, &value))) {
+                 if (strcmpa((CHAR8 *)"timeout", key) == 0) {
+                         _cleanup_freepool_ CHAR16 *s = NULL;
+@@ -1063,6 +1092,10 @@ static VOID config_entry_parse_tries(
+         UINTN left = UINTN_MAX, done = UINTN_MAX, factor = 1, i, next_left, next_done;
+         _cleanup_freepool_ CHAR16 *prefix = NULL;
+ 
++        assert(entry);
++        assert(path);
++        assert(file);
++
+         /*
+          * Parses a suffix of two counters (one going down, one going up) in the form "+LEFT-DONE" from the end of the
+          * filename (but before the .efi/.conf suffix), where the "-DONE" part is optional and may be left out (in
+@@ -1180,6 +1213,9 @@ static VOID config_entry_bump_counters(
+         UINTN file_info_size, a, b;
+         EFI_STATUS r;
+ 
++        assert(entry);
++        assert(root_dir);
++
+         if (entry->tries_left == UINTN_MAX)
+                 return;
+ 
+@@ -1253,6 +1289,14 @@ static VOID config_entry_add_from_file(
+         EFI_FILE_HANDLE handle;
+         _cleanup_freepool_ CHAR16 *initrd = NULL;
+ 
++        assert(config);
++        assert(device);
++        assert(root_dir);
++        assert(path);
++        assert(file);
++        assert(content);
++        assert(loaded_image_path);
++
+         entry = AllocatePool(sizeof(ConfigEntry));
+ 
+         *entry = (ConfigEntry) {
+@@ -1381,6 +1425,8 @@ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+         UINTN sec;
+         EFI_STATUS err;
+ 
++        assert(root_dir);
++
+         *config = (Config) {
+                 .editor = TRUE,
+                 .auto_entries = TRUE,
+@@ -1418,6 +1464,11 @@ static VOID config_load_entries(
+         EFI_FILE_HANDLE entries_dir;
+         EFI_STATUS err;
+ 
++        assert(config);
++        assert(device);
++        assert(root_dir);
++        assert(loaded_image_path);
++
+         err = uefi_call_wrapper(root_dir->Open, 5, root_dir, &entries_dir, (CHAR16*) L"\\loader\\entries", EFI_FILE_MODE_READ, 0ULL);
+         if (!EFI_ERROR(err)) {
+                 for (;;) {
+@@ -1453,6 +1504,9 @@ static VOID config_load_entries(
+ static INTN config_entry_compare(ConfigEntry *a, ConfigEntry *b) {
+         INTN r;
+ 
++        assert(a);
++        assert(b);
++
+         /* Order entries that have no tries left to the beginning of the list */
+         if (a->tries_left != 0 && b->tries_left == 0)
+                 return 1;
+@@ -1483,6 +1537,8 @@ static INTN config_entry_compare(ConfigEntry *a, ConfigEntry *b) {
+ }
+ 
+ static VOID config_sort_entries(Config *config) {
++        assert(config);
++
+         for (UINTN i = 1; i < config->entry_count; i++) {
+                 BOOLEAN more;
+ 
+@@ -1504,6 +1560,9 @@ static VOID config_sort_entries(Config *config) {
+ }
+ 
+ static INTN config_entry_find(Config *config, CHAR16 *id) {
++        assert(config);
++        assert(id);
++
+         for (UINTN i = 0; i < config->entry_count; i++)
+                 if (StrCmp(config->entries[i]->id, id) == 0)
+                         return (INTN) i;
+@@ -1516,6 +1575,8 @@ static VOID config_default_entry_select(Config *config) {
+         EFI_STATUS err;
+         INTN i;
+ 
++        assert(config);
++
+         /*
+          * The EFI variable to specify a boot entry for the next, and only the
+          * next reboot. The variable is always cleared directly after it is read.
+@@ -1586,6 +1647,8 @@ static VOID config_default_entry_select(Config *config) {
+ static BOOLEAN find_nonunique(ConfigEntry **entries, UINTN entry_count) {
+         BOOLEAN non_unique = FALSE;
+ 
++        assert(entries);
++
+         for (UINTN i = 0; i < entry_count; i++)
+                 entries[i]->non_unique = FALSE;
+ 
+@@ -1604,6 +1667,8 @@ static BOOLEAN find_nonunique(ConfigEntry **entries, UINTN entry_count) {
+ 
+ /* generate a unique title, avoiding non-distinguishable menu entries */
+ static VOID config_title_generate(Config *config) {
++        assert(config);
++
+         /* set title */
+         for (UINTN i = 0; i < config->entry_count; i++) {
+                 CHAR16 *title;
+@@ -1676,6 +1741,11 @@ static BOOLEAN config_entry_add_call(
+ 
+         ConfigEntry *entry;
+ 
++        assert(config);
++        assert(id);
++        assert(title);
++        assert(call);
++
+         entry = AllocatePool(sizeof(ConfigEntry));
+         *entry = (ConfigEntry) {
+                 .id = StrDuplicate(id),
+@@ -1702,6 +1772,12 @@ static ConfigEntry *config_entry_add_loader(
+ 
+         ConfigEntry *entry;
+ 
++        assert(config);
++        assert(device);
++        assert(id);
++        assert(title);
++        assert(loader);
++
+         entry = AllocatePool(sizeof(ConfigEntry));
+         *entry = (ConfigEntry) {
+                 .type = type,
+@@ -1735,6 +1811,13 @@ static BOOLEAN config_entry_add_loader_auto(
+         ConfigEntry *entry;
+         EFI_STATUS err;
+ 
++        assert(config);
++        assert(device);
++        assert(root_dir);
++        assert(id);
++        assert(title);
++        assert(loader);
++
+         if (!config->auto_entries)
+                 return FALSE;
+ 
+@@ -1775,6 +1858,8 @@ static VOID config_entry_add_osx(Config *config) {
+         UINTN handle_count = 0;
+         _cleanup_freepool_ EFI_HANDLE *handles = NULL;
+ 
++        assert(config);
++
+         if (!config->auto_entries)
+                 return;
+ 
+@@ -1805,6 +1890,10 @@ static VOID config_entry_add_linux(
+         EFI_STATUS err;
+         ConfigEntry *entry;
+ 
++        assert(config);
++        assert(device);
++        assert(root_dir);
++
+         err = uefi_call_wrapper(root_dir->Open, 5, root_dir, &linux_dir, (CHAR16*) L"\\EFI\\Linux", EFI_FILE_MODE_READ, 0ULL);
+         if (EFI_ERROR(err))
+                 return;
+@@ -1939,6 +2028,9 @@ static EFI_DEVICE_PATH *path_parent(EFI_DEVICE_PATH *path, EFI_DEVICE_PATH *node
+         EFI_DEVICE_PATH *parent;
+         UINTN len;
+ 
++        assert(path);
++        assert(node);
++
+         len = (UINT8*) NextDevicePathNode(node) - (UINT8*) path;
+         parent = (EFI_DEVICE_PATH*) AllocatePool(len + sizeof(EFI_DEVICE_PATH));
+         CopyMem(parent, path, len);
+@@ -1960,6 +2052,9 @@ static VOID config_load_xbootldr(
+         EFI_FILE *root_dir;
+         EFI_STATUS r;
+ 
++        assert(config);
++        assert(device);
++
+         partition_path = DevicePathFromHandle(device);
+         if (!partition_path)
+                 return;
+@@ -2146,6 +2241,9 @@ static EFI_STATUS image_start(
+         CHAR16 *options;
+         EFI_STATUS err;
+ 
++        assert(config);
++        assert(entry);
++
+         path = FileDevicePath(entry->device, entry->loader);
+         if (!path)
+                 return log_error_status_stall(EFI_INVALID_PARAMETER, L"Error getting device path.");
+@@ -2208,6 +2306,7 @@ static EFI_STATUS reboot_into_firmware(VOID) {
+ }
+ 
+ static VOID config_free(Config *config) {
++        assert(config);
+         for (UINTN i = 0; i < config->entry_count; i++)
+                 config_entry_free(config->entries[i]);
+         FreePool(config->entries);
+@@ -2221,6 +2320,8 @@ static VOID config_write_entries_to_variable(Config *config) {
+         UINTN sz = 0;
+         CHAR16 *p;
+ 
++        assert(config);
++
+         for (UINTN i = 0; i < config->entry_count; i++)
+                 sz += StrLen(config->entries[i]->id) + 1;
+ 
+diff --git a/src/boot/efi/console.c b/src/boot/efi/console.c
+index 369c549da..3f405113b 100644
+--- a/src/boot/efi/console.c
++++ b/src/boot/efi/console.c
+@@ -43,6 +43,8 @@ EFI_STATUS console_key_read(UINT64 *key, UINT64 timeout_usec) {
+         EFI_EVENT events[3] = { ST->ConIn->WaitForKey };
+         UINTN n_events = 1;
+ 
++        assert(key);
++
+         if (!checked) {
+                 err = LibLocateProtocol(EFI_SIMPLE_TEXT_INPUT_EX_GUID, (VOID **)&TextInputEx);
+                 if (EFI_ERROR(err) ||
+@@ -152,6 +154,8 @@ static EFI_STATUS mode_auto(UINTN *mode) {
+         EFI_STATUS err;
+         BOOLEAN keep = FALSE;
+ 
++        assert(mode);
++
+         err = LibLocateProtocol(&GraphicsOutputProtocolGuid, (VOID **)&GraphicsOutput);
+         if (!EFI_ERROR(err) && GraphicsOutput->Mode && GraphicsOutput->Mode->Info) {
+                 Info = GraphicsOutput->Mode->Info;
+@@ -200,6 +204,8 @@ static EFI_STATUS mode_auto(UINTN *mode) {
+ }
+ 
+ EFI_STATUS console_set_mode(UINTN *mode, enum console_mode_change_type how) {
++        assert(mode);
++
+         if (how == CONSOLE_MODE_AUTO)
+                 return mode_auto(mode);
+ 
+diff --git a/src/boot/efi/crc32.c b/src/boot/efi/crc32.c
+index c9e5501ff..5130ae73d 100644
+--- a/src/boot/efi/crc32.c
++++ b/src/boot/efi/crc32.c
+@@ -42,6 +42,7 @@
+  */
+ 
+ #include "crc32.h"
++#include "macro-fundamental.h"
+ 
+ static const UINT32 crc32_tab[] = {
+         0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
+@@ -111,6 +112,8 @@ UINT32 crc32(UINT32 seed, const VOID *buf, UINTN len) {
+         const UINT8 *p = buf;
+         UINT32 crc = seed;
+ 
++        assert(buf);
++
+         while (len > 0) {
+                 crc = crc32_add_char(crc, *p++);
+                 len--;
+@@ -129,6 +132,8 @@ UINT32 crc32_exclude_offset(
+         const UINT8 *p = buf;
+         UINT32 crc = seed;
+ 
++        assert(buf);
++
+         for (UINTN i = 0; i < len; i++) {
+                 UINT8 x = *p++;
+ 
+diff --git a/src/boot/efi/disk.c b/src/boot/efi/disk.c
+index 122f08dd5..196dc52be 100644
+--- a/src/boot/efi/disk.c
++++ b/src/boot/efi/disk.c
+@@ -9,6 +9,8 @@
+ EFI_STATUS disk_get_part_uuid(EFI_HANDLE *handle, CHAR16 uuid[static 37]) {
+         EFI_DEVICE_PATH *device_path;
+ 
++        assert(handle);
++
+         /* export the device path this image is started from */
+         device_path = DevicePathFromHandle(handle);
+         if (device_path) {
+diff --git a/src/boot/efi/linux.c b/src/boot/efi/linux.c
+index b5d612049..529325fef 100644
+--- a/src/boot/efi/linux.c
++++ b/src/boot/efi/linux.c
+@@ -17,6 +17,8 @@ static VOID linux_efi_handover(EFI_HANDLE image, struct boot_params *params) {
+         handover_f handover;
+         UINTN start = (UINTN)params->hdr.code32_start;
+ 
++        assert(params);
++
+ #ifdef __x86_64__
+         asm volatile ("cli");
+         start += 512;
+@@ -35,6 +37,9 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
+         EFI_PHYSICAL_ADDRESS addr;
+         EFI_STATUS err;
+ 
++        assert(image);
++        assert(cmdline);
++
+         image_params = (struct boot_params *) linux_addr;
+ 
+         if (image_params->hdr.boot_flag != 0xAA55 ||
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index c272d0855..4a8a2c7cc 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -5,6 +5,7 @@
+ #include <efi.h>
+ #include <efilib.h>
+ 
++#include "macro-fundamental.h"
+ #include "measure.h"
+ 
+ #define EFI_TCG_GUID \
+@@ -184,6 +185,9 @@ static EFI_STATUS tpm1_measure_to_pcr_and_event_log(const EFI_TCG *tcg, UINT32 p
+         EFI_PHYSICAL_ADDRESS event_log_last;
+         UINTN desc_len;
+ 
++        assert(tcg);
++        assert(description);
++
+         desc_len = (StrLen(description) + 1) * sizeof(CHAR16);
+ 
+         tcg_event = AllocateZeroPool(desc_len + sizeof(TCG_PCR_EVENT));
+@@ -215,6 +219,9 @@ static EFI_STATUS tpm2_measure_to_pcr_and_event_log(const EFI_TCG2 *tcg, UINT32
+         EFI_TCG2_EVENT *tcg_event;
+         UINTN desc_len;
+ 
++        assert(tcg);
++        assert(description);
++
+         desc_len = StrLen(description) * sizeof(CHAR16);
+ 
+         tcg_event = AllocateZeroPool(sizeof(*tcg_event) - sizeof(tcg_event->Event) + desc_len + 1);
+@@ -302,6 +309,8 @@ EFI_STATUS tpm_log_event(UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer, UIN
+         EFI_TCG *tpm1;
+         EFI_TCG2 *tpm2;
+ 
++        assert(description);
++
+         tpm2 = tcg2_interface_check();
+         if (tpm2)
+                 return tpm2_measure_to_pcr_and_event_log(tpm2, pcrindex, buffer, buffer_size, description);
+diff --git a/src/boot/efi/pe.c b/src/boot/efi/pe.c
+index e65701734..5c20acc9f 100644
+--- a/src/boot/efi/pe.c
++++ b/src/boot/efi/pe.c
+@@ -66,6 +66,9 @@ EFI_STATUS pe_memory_locate_sections(CHAR8 *base, CHAR8 **sections, UINTN *addrs
+         struct PeHeader *pe;
+         UINTN offset;
+ 
++        assert(base);
++        assert(sections);
++
+         dos = (struct DosFileHeader *)base;
+ 
+         if (CompareMem(dos->Magic, "MZ", 2) != 0)
+@@ -118,6 +121,9 @@ EFI_STATUS pe_file_locate_sections(EFI_FILE *dir, CHAR16 *path, CHAR8 **sections
+         EFI_STATUS err;
+         _cleanup_freepool_ CHAR8 *header = NULL;
+ 
++        assert(dir);
++        assert(path);
++
+         err = uefi_call_wrapper(dir->Open, 5, dir, &handle, path, EFI_FILE_MODE_READ, 0ULL);
+         if (EFI_ERROR(err))
+                 return err;
+diff --git a/src/boot/efi/random-seed.c b/src/boot/efi/random-seed.c
+index 939daf3e4..55348a64e 100644
+--- a/src/boot/efi/random-seed.c
++++ b/src/boot/efi/random-seed.c
+@@ -22,6 +22,8 @@ static EFI_STATUS acquire_rng(UINTN size, VOID **ret) {
+         EFI_RNG_PROTOCOL *rng;
+         EFI_STATUS err;
+ 
++        assert(ret);
++
+         /* Try to acquire the specified number of bytes from the UEFI RNG */
+ 
+         err = LibLocateProtocol(EFI_RNG_GUID, (VOID**) &rng);
+@@ -63,6 +65,10 @@ static VOID hash_once(
+ 
+         struct sha256_ctx hash;
+ 
++        assert(old_seed);
++        assert(rng);
++        assert(system_token);
++
+         sha256_init_ctx(&hash);
+         sha256_process_bytes(old_seed, size, &hash);
+         if (rng)
+@@ -85,6 +91,11 @@ static EFI_STATUS hash_many(
+ 
+         _cleanup_freepool_ VOID *output = NULL;
+ 
++        assert(old_seed);
++        assert(rng);
++        assert(system_token);
++        assert(ret);
++
+         /* Hashes the specified parameters in counter mode, generating n hash values, with the counter in the
+          * range counter_start…counter_start+n-1. */
+ 
+@@ -115,6 +126,12 @@ static EFI_STATUS mangle_random_seed(
+         EFI_STATUS err;
+         UINTN n;
+ 
++        assert(old_seed);
++        assert(rng);
++        assert(system_token);
++        assert(ret_new_seed);
++        assert(ret_for_kernel);
++
+         /* This takes the old seed file contents, an (optional) random number acquired from the UEFI RNG, an
+          * (optional) system 'token' installed once by the OS installer in an EFI variable, and hashes them
+          * together in counter mode, generating a new seed (to replace the file on disk) and the seed for the
+@@ -144,6 +161,9 @@ static EFI_STATUS acquire_system_token(VOID **ret, UINTN *ret_size) {
+         EFI_STATUS err;
+         UINTN size;
+ 
++        assert(ret);
++        assert(ret_size);
++
+         err = efivar_get_raw(LOADER_GUID, L"LoaderSystemToken", &data, &size);
+         if (EFI_ERROR(err)) {
+                 if (err != EFI_NOT_FOUND)
+@@ -162,7 +182,7 @@ static EFI_STATUS acquire_system_token(VOID **ret, UINTN *ret_size) {
+ 
+ static VOID validate_sha256(void) {
+ 
+-#ifndef __OPTIMIZE__
++#ifdef EFI_DEBUG
+         /* Let's validate our SHA256 implementation. We stole it from glibc, and converted it to UEFI
+          * style. We better check whether it does the right stuff. We use the simpler test vectors from the
+          * SHA spec. Note that we strip this out in optimization builds. */
+@@ -204,13 +224,9 @@ static VOID validate_sha256(void) {
+                 sha256_process_bytes(array[i].string, strlena((const CHAR8*) array[i].string), &hash);
+                 sha256_finish_ctx(&hash, result);
+ 
+-                if (CompareMem(result, array[i].hash, HASH_VALUE_SIZE) != 0) {
+-                        log_error_stall(L"SHA256 failed validation.");
+-                        return;
+-                }
++                assert(CompareMem(result, array[i].hash, HASH_VALUE_SIZE) == 0);
+         }
+ 
+-        Print(L"SHA256 validated\n");
+ #endif
+ }
+ 
+@@ -221,6 +237,8 @@ EFI_STATUS process_random_seed(EFI_FILE *root_dir, RandomSeedMode mode) {
+         _cleanup_freepool_ EFI_FILE_INFO *info = NULL;
+         EFI_STATUS err;
+ 
++        assert(root_dir);
++
+         validate_sha256();
+ 
+         if (mode == RANDOM_SEED_OFF)
+diff --git a/src/boot/efi/sha256.c b/src/boot/efi/sha256.c
+index 6585fdb9b..5df7e5316 100644
+--- a/src/boot/efi/sha256.c
++++ b/src/boot/efi/sha256.c
+@@ -23,6 +23,7 @@
+ 
+ /* Written by Ulrich Drepper <drepper@redhat.com>, 2007.  */
+ 
++#include "macro-fundamental.h"
+ #include "sha256.h"
+ 
+ #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+@@ -73,6 +74,8 @@ static void sha256_process_block(const void *, UINTN, struct sha256_ctx *);
+ /* Initialize structure containing state of computation.
+    (FIPS 180-2:5.3.2)  */
+ void sha256_init_ctx(struct sha256_ctx *ctx) {
++        assert(ctx);
++
+         ctx->H[0] = 0x6a09e667;
+         ctx->H[1] = 0xbb67ae85;
+         ctx->H[2] = 0x3c6ef372;
+@@ -96,6 +99,9 @@ void *sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf) {
+         UINT32 bytes = ctx->buflen;
+         UINTN pad;
+ 
++        assert(ctx);
++        assert(resbuf);
++
+         /* Now count remaining bytes.  */
+         ctx->total64 += bytes;
+ 
+@@ -118,6 +124,9 @@ void *sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf) {
+ }
+ 
+ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx) {
++        assert(buffer);
++        assert(ctx);
++
+         /* When we already have some bits in our internal buffer concatenate
+            both inputs first.  */
+ 
+@@ -191,6 +200,10 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+ static void sha256_process_block(const void *buffer, UINTN len, struct sha256_ctx *ctx) {
+         const UINT32 *words = buffer;
+         UINTN nwords = len / sizeof (UINT32);
++
++        assert(buffer);
++        assert(ctx);
++
+         UINT32 a = ctx->H[0];
+         UINT32 b = ctx->H[1];
+         UINT32 c = ctx->H[2];
+diff --git a/src/boot/efi/shim.c b/src/boot/efi/shim.c
+index 48602627b..9bcbb3476 100644
+--- a/src/boot/efi/shim.c
++++ b/src/boot/efi/shim.c
+@@ -111,6 +111,10 @@ static EFIAPI EFI_STATUS security2_policy_authentication (const EFI_SECURITY2_PR
+                                                           VOID *file_buffer, UINTN file_size, BOOLEAN boot_policy) {
+         EFI_STATUS status;
+ 
++        assert(this);
++        assert(device_path);
++        assert(file_buffer);
++
+         /* Chain original security policy */
+         status = uefi_call_wrapper(es2fa, 5, this, device_path, file_buffer, file_size, boot_policy);
+ 
+@@ -143,6 +147,9 @@ static EFIAPI EFI_STATUS security_policy_authentication (const EFI_SECURITY_PROT
+         _cleanup_freepool_ CHAR8 *file_buffer = NULL;
+         UINTN file_size;
+ 
++        assert(this);
++        assert(device_path_const);
++
+         if (!device_path_const)
+                 return EFI_INVALID_PARAMETER;
+ 
+diff --git a/src/boot/efi/splash.c b/src/boot/efi/splash.c
+index 5e085ec45..920b44082 100644
+--- a/src/boot/efi/splash.c
++++ b/src/boot/efi/splash.c
+@@ -44,6 +44,11 @@ static EFI_STATUS bmp_parse_header(UINT8 *bmp, UINTN size, struct bmp_dib **ret_
+         struct bmp_map *map;
+         UINTN row_size;
+ 
++        assert(bmp);
++        assert(ret_dib);
++        assert(ret_map);
++        assert(pixmap);
++
+         if (size < sizeof(struct bmp_file) + sizeof(struct bmp_dib))
+                 return EFI_INVALID_PARAMETER;
+ 
+@@ -128,6 +133,8 @@ static EFI_STATUS bmp_parse_header(UINT8 *bmp, UINTN size, struct bmp_dib **ret_
+ static VOID pixel_blend(UINT32 *dst, const UINT32 source) {
+         UINT32 alpha, src, src_rb, src_g, dst_rb, dst_g, rb, g;
+ 
++        assert(dst);
++
+         alpha = (source & 0xff);
+ 
+         /* convert src from RGBA to XRGB */
+@@ -152,6 +159,11 @@ static EFI_STATUS bmp_to_blt(EFI_GRAPHICS_OUTPUT_BLT_PIXEL *buf,
+                       UINT8 *pixmap) {
+         UINT8 *in;
+ 
++        assert(buf);
++        assert(dib);
++        assert(map);
++        assert(pixmap);
++
+         /* transform and copy pixels */
+         in = pixmap;
+         for (UINTN y = 0; y < dib->y; y++) {
+@@ -247,6 +259,8 @@ EFI_STATUS graphics_splash(UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_
+         UINTN y_pos = 0;
+         EFI_STATUS err;
+ 
++        assert(content);
++
+         if (!background) {
+                 if (StriCmp(L"Apple", ST->FirmwareVendor) == 0) {
+                         pixel.Red = 0xc0;
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index b048df076..932a4cfa8 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -67,6 +67,8 @@ UINT64 time_usec(VOID) {
+ }
+ 
+ EFI_STATUS parse_boolean(const CHAR8 *v, BOOLEAN *b) {
++        assert(b);
++
+         if (!v)
+                 return EFI_INVALID_PARAMETER;
+ 
+@@ -90,17 +92,27 @@ EFI_STATUS parse_boolean(const CHAR8 *v, BOOLEAN *b) {
+ }
+ 
+ EFI_STATUS efivar_set_raw(const EFI_GUID *vendor, const CHAR16 *name, const VOID *buf, UINTN size, UINT32 flags) {
++        assert(vendor);
++        assert(name);
++        assert(buf || size == 0);
++
+         flags |= EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS;
+         return uefi_call_wrapper(RT->SetVariable, 5, (CHAR16*) name, (EFI_GUID *)vendor, flags, size, (VOID*) buf);
+ }
+ 
+ EFI_STATUS efivar_set(const EFI_GUID *vendor, const CHAR16 *name, const CHAR16 *value, UINT32 flags) {
++        assert(vendor);
++        assert(name);
++
+         return efivar_set_raw(vendor, name, value, value ? (StrLen(value) + 1) * sizeof(CHAR16) : 0, flags);
+ }
+ 
+ EFI_STATUS efivar_set_uint_string(const EFI_GUID *vendor, const CHAR16 *name, UINTN i, UINT32 flags) {
+         CHAR16 str[32];
+ 
++        assert(vendor);
++        assert(name);
++
+         SPrint(str, ELEMENTSOF(str), L"%u", i);
+         return efivar_set(vendor, name, str, flags);
+ }
+@@ -108,6 +120,9 @@ EFI_STATUS efivar_set_uint_string(const EFI_GUID *vendor, const CHAR16 *name, UI
+ EFI_STATUS efivar_set_uint32_le(const EFI_GUID *vendor, const CHAR16 *name, UINT32 value, UINT32 flags) {
+         UINT8 buf[4];
+ 
++        assert(vendor);
++        assert(name);
++
+         buf[0] = (UINT8)(value >> 0U & 0xFF);
+         buf[1] = (UINT8)(value >> 8U & 0xFF);
+         buf[2] = (UINT8)(value >> 16U & 0xFF);
+@@ -119,6 +134,9 @@ EFI_STATUS efivar_set_uint32_le(const EFI_GUID *vendor, const CHAR16 *name, UINT
+ EFI_STATUS efivar_set_uint64_le(const EFI_GUID *vendor, const CHAR16 *name, UINT64 value, UINT32 flags) {
+         UINT8 buf[8];
+ 
++        assert(vendor);
++        assert(name);
++
+         buf[0] = (UINT8)(value >> 0U & 0xFF);
+         buf[1] = (UINT8)(value >> 8U & 0xFF);
+         buf[2] = (UINT8)(value >> 16U & 0xFF);
+@@ -137,6 +155,9 @@ EFI_STATUS efivar_get(const EFI_GUID *vendor, const CHAR16 *name, CHAR16 **value
+         CHAR16 *val;
+         UINTN size;
+ 
++        assert(vendor);
++        assert(name);
++
+         err = efivar_get_raw(vendor, name, (CHAR8**)&buf, &size);
+         if (EFI_ERROR(err))
+                 return err;
+@@ -170,8 +191,12 @@ EFI_STATUS efivar_get_uint_string(const EFI_GUID *vendor, const CHAR16 *name, UI
+         _cleanup_freepool_ CHAR16 *val = NULL;
+         EFI_STATUS err;
+ 
++        assert(vendor);
++        assert(name);
++        assert(i);
++
+         err = efivar_get(vendor, name, &val);
+-        if (!EFI_ERROR(err) && i)
++        if (!EFI_ERROR(err))
+                 *i = Atoi(val);
+ 
+         return err;
+@@ -182,6 +207,9 @@ EFI_STATUS efivar_get_uint32_le(const EFI_GUID *vendor, const CHAR16 *name, UINT
+         UINTN size;
+         EFI_STATUS err;
+ 
++        assert(vendor);
++        assert(name);
++
+         err = efivar_get_raw(vendor, name, &buf, &size);
+         if (!EFI_ERROR(err) && ret) {
+                 if (size != sizeof(UINT32))
+@@ -199,6 +227,9 @@ EFI_STATUS efivar_get_uint64_le(const EFI_GUID *vendor, const CHAR16 *name, UINT
+         UINTN size;
+         EFI_STATUS err;
+ 
++        assert(vendor);
++        assert(name);
++
+         err = efivar_get_raw(vendor, name, &buf, &size);
+         if (!EFI_ERROR(err) && ret) {
+                 if (size != sizeof(UINT64))
+@@ -217,6 +248,9 @@ EFI_STATUS efivar_get_raw(const EFI_GUID *vendor, const CHAR16 *name, CHAR8 **bu
+         UINTN l;
+         EFI_STATUS err;
+ 
++        assert(vendor);
++        assert(name);
++
+         l = sizeof(CHAR16 *) * EFI_MAXIMUM_VARIABLE_SIZE;
+         buf = AllocatePool(l);
+         if (!buf)
+@@ -240,6 +274,10 @@ EFI_STATUS efivar_get_boolean_u8(const EFI_GUID *vendor, const CHAR16 *name, BOO
+         UINTN size;
+         EFI_STATUS err;
+ 
++        assert(vendor);
++        assert(name);
++        assert(ret);
++
+         err = efivar_get_raw(vendor, name, &b, &size);
+         if (!EFI_ERROR(err))
+                 *ret = *b > 0;
+@@ -250,6 +288,9 @@ EFI_STATUS efivar_get_boolean_u8(const EFI_GUID *vendor, const CHAR16 *name, BOO
+ VOID efivar_set_time_usec(const EFI_GUID *vendor, const CHAR16 *name, UINT64 usec) {
+         CHAR16 str[32];
+ 
++        assert(vendor);
++        assert(name);
++
+         if (usec == 0)
+                 usec = time_usec();
+         if (usec == 0)
+@@ -263,6 +304,9 @@ static INTN utf8_to_16(const CHAR8 *stra, CHAR16 *c) {
+         CHAR16 unichar;
+         UINTN len;
+ 
++        assert(stra);
++        assert(c);
++
+         if (!(stra[0] & 0x80))
+                 len = 1;
+         else if ((stra[0] & 0xe0) == 0xc0)
+@@ -316,6 +360,8 @@ CHAR16 *stra_to_str(const CHAR8 *stra) {
+         UINTN i;
+         CHAR16 *str;
+ 
++        assert(stra);
++
+         len = strlena(stra);
+         str = AllocatePool((len + 1) * sizeof(CHAR16));
+ 
+@@ -344,6 +390,8 @@ CHAR16 *stra_to_path(const CHAR8 *stra) {
+         UINTN len;
+         UINTN i;
+ 
++        assert(stra);
++
+         len = strlena(stra);
+         str = AllocatePool((len + 2) * sizeof(CHAR16));
+ 
+@@ -376,6 +424,7 @@ CHAR16 *stra_to_path(const CHAR8 *stra) {
+ }
+ 
+ CHAR8 *strchra(const CHAR8 *s, CHAR8 c) {
++        assert(s);
+         do {
+                 if (*s == c)
+                         return (CHAR8*) s;
+@@ -388,6 +437,9 @@ EFI_STATUS file_read(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN off, UINTN s
+         _cleanup_freepool_ CHAR8 *buf = NULL;
+         EFI_STATUS err;
+ 
++        assert(name);
++        assert(ret);
++
+         err = uefi_call_wrapper(dir->Open, 5, dir, &handle, (CHAR16*) name, EFI_FILE_MODE_READ, 0ULL);
+         if (EFI_ERROR(err))
+                 return err;
+@@ -428,6 +480,8 @@ EFI_STATUS file_read(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN off, UINTN s
+ VOID log_error_stall(const CHAR16 *fmt, ...) {
+         va_list args;
+ 
++        assert(fmt);
++
+         uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTRED|EFI_BACKGROUND_BLACK);
+ 
+         Print(L"\n");
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0008-sd-boot-Use-StrSize-where-it-makes-sense.patch
+++ b/vendor/systemd-patches/0008-sd-boot-Use-StrSize-where-it-makes-sense.patch
@@ -1,0 +1,110 @@
+From 4eadfc1ede2c795b7a1b22ced4ae4244dcf63711 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Wed, 11 Aug 2021 14:59:46 +0200
+Subject: [PATCH 08/73] sd-boot: Use StrSize where it makes sense
+
+---
+ src/boot/efi/boot.c    | 18 ++++++++++--------
+ src/boot/efi/measure.c | 10 ++++------
+ src/boot/efi/util.c    |  2 +-
+ 3 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 8a67b665d..96099e573 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -2268,7 +2268,7 @@ static EFI_STATUS image_start(
+                         goto out_unload;
+                 }
+                 loaded_image->LoadOptions = options;
+-                loaded_image->LoadOptionsSize = (StrLen(loaded_image->LoadOptions)+1) * sizeof(CHAR16);
++                loaded_image->LoadOptionsSize = StrSize(loaded_image->LoadOptions);
+ 
+ #if ENABLE_TPM
+                 /* Try to log any options to the TPM, especially to catch manually edited options */
+@@ -2316,28 +2316,30 @@ static VOID config_free(Config *config) {
+ }
+ 
+ static VOID config_write_entries_to_variable(Config *config) {
+-        _cleanup_freepool_ CHAR16 *buffer = NULL;
++        _cleanup_freepool_ CHAR8 *buffer = NULL;
+         UINTN sz = 0;
+-        CHAR16 *p;
++        CHAR8 *p;
+ 
+         assert(config);
+ 
+         for (UINTN i = 0; i < config->entry_count; i++)
+-                sz += StrLen(config->entries[i]->id) + 1;
++                sz += StrSize(config->entries[i]->id);
+ 
+-        p = buffer = AllocatePool(sz * sizeof(CHAR16));
++        p = buffer = AllocatePool(sz);
+ 
+         for (UINTN i = 0; i < config->entry_count; i++) {
+                 UINTN l;
+ 
+-                l = StrLen(config->entries[i]->id) + 1;
+-                CopyMem(p, config->entries[i]->id, l * sizeof(CHAR16));
++                l = StrSize(config->entries[i]->id);
++                CopyMem(p, config->entries[i]->id, l);
+ 
+                 p += l;
+         }
+ 
++        assert(p == buffer + sz);
++
+         /* Store the full list of discovered entries. */
+-        (void) efivar_set_raw(LOADER_GUID, L"LoaderEntries", buffer, (UINT8 *) p - (UINT8 *) buffer, 0);
++        (void) efivar_set_raw(LOADER_GUID, L"LoaderEntries", buffer, sz, 0);
+ }
+ 
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index 4a8a2c7cc..429e82657 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -188,8 +188,7 @@ static EFI_STATUS tpm1_measure_to_pcr_and_event_log(const EFI_TCG *tcg, UINT32 p
+         assert(tcg);
+         assert(description);
+ 
+-        desc_len = (StrLen(description) + 1) * sizeof(CHAR16);
+-
++        desc_len = StrSize(description);
+         tcg_event = AllocateZeroPool(desc_len + sizeof(TCG_PCR_EVENT));
+ 
+         if (!tcg_event)
+@@ -222,14 +221,13 @@ static EFI_STATUS tpm2_measure_to_pcr_and_event_log(const EFI_TCG2 *tcg, UINT32
+         assert(tcg);
+         assert(description);
+ 
+-        desc_len = StrLen(description) * sizeof(CHAR16);
+-
+-        tcg_event = AllocateZeroPool(sizeof(*tcg_event) - sizeof(tcg_event->Event) + desc_len + 1);
++        desc_len = StrSize(description);
++        tcg_event = AllocateZeroPool(sizeof(*tcg_event) - sizeof(tcg_event->Event) + desc_len);
+ 
+         if (!tcg_event)
+                 return EFI_OUT_OF_RESOURCES;
+ 
+-        tcg_event->Size = sizeof(*tcg_event) - sizeof(tcg_event->Event) + desc_len + 1;
++        tcg_event->Size = sizeof(*tcg_event) - sizeof(tcg_event->Event) + desc_len;
+         tcg_event->Header.HeaderSize = sizeof(EFI_TCG2_EVENT_HEADER);
+         tcg_event->Header.HeaderVersion = EFI_TCG2_EVENT_HEADER_VERSION;
+         tcg_event->Header.PCRIndex = pcrindex;
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index 932a4cfa8..b2977546a 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -104,7 +104,7 @@ EFI_STATUS efivar_set(const EFI_GUID *vendor, const CHAR16 *name, const CHAR16 *
+         assert(vendor);
+         assert(name);
+ 
+-        return efivar_set_raw(vendor, name, value, value ? (StrLen(value) + 1) * sizeof(CHAR16) : 0, flags);
++        return efivar_set_raw(vendor, name, value, value ? StrSize(value) : 0, flags);
+ }
+ 
+ EFI_STATUS efivar_set_uint_string(const EFI_GUID *vendor, const CHAR16 *name, UINTN i, UINT32 flags) {
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0009-sd-boot-Provide-error-messages-when-parsing-a-config.patch
+++ b/vendor/systemd-patches/0009-sd-boot-Provide-error-messages-when-parsing-a-config.patch
@@ -1,0 +1,80 @@
+From c6e0adfaa3a5b4171d54a2d72c329209e1fee078 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Wed, 11 Aug 2021 14:59:46 +0200
+Subject: [PATCH 09/73] sd-boot: Provide error messages when parsing a config
+ option fails
+
+---
+ src/boot/efi/boot.c | 33 ++++++++++++++-------------------
+ 1 file changed, 14 insertions(+), 19 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 96099e573..638070d77 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -995,6 +995,7 @@ static VOID config_defaults_load_from_file(Config *config, CHAR8 *content) {
+         CHAR8 *line;
+         UINTN pos = 0;
+         CHAR8 *key, *value;
++        EFI_STATUS err;
+ 
+         assert(config);
+         assert(content);
+@@ -1017,32 +1018,23 @@ static VOID config_defaults_load_from_file(Config *config, CHAR8 *content) {
+                 }
+ 
+                 if (strcmpa((CHAR8 *)"editor", key) == 0) {
+-                        BOOLEAN on;
+-
+-                        if (EFI_ERROR(parse_boolean(value, &on)))
+-                                continue;
+-
+-                        config->editor = on;
++                        err = parse_boolean(value, &config->editor);
++                        if (EFI_ERROR(err))
++                                log_error_stall(L"Error parsing 'editor' config option: %a", value);
+                         continue;
+                 }
+ 
+                 if (strcmpa((CHAR8 *)"auto-entries", key) == 0) {
+-                        BOOLEAN on;
+-
+-                        if (EFI_ERROR(parse_boolean(value, &on)))
+-                                continue;
+-
+-                        config->auto_entries = on;
++                        err = parse_boolean(value, &config->auto_entries);
++                        if (EFI_ERROR(err))
++                                log_error_stall(L"Error parsing 'auto-entries' config option: %a", value);
+                         continue;
+                 }
+ 
+                 if (strcmpa((CHAR8 *)"auto-firmware", key) == 0) {
+-                        BOOLEAN on;
+-
+-                        if (EFI_ERROR(parse_boolean(value, &on)))
+-                                continue;
+-
+-                        config->auto_firmware = on;
++                        err = parse_boolean(value, &config->auto_firmware);
++                        if (EFI_ERROR(err))
++                                log_error_stall(L"Error parsing 'auto-firmware' config option: %a", value);
+                         continue;
+                 }
+ 
+@@ -1074,8 +1066,11 @@ static VOID config_defaults_load_from_file(Config *config, CHAR8 *content) {
+                         else {
+                                 BOOLEAN on;
+ 
+-                                if (EFI_ERROR(parse_boolean(value, &on)))
++                                err = parse_boolean(value, &on);
++                                if (EFI_ERROR(err)) {
++                                        log_error_stall(L"Error parsing 'random-seed-mode' config option: %a", value);
+                                         continue;
++                                }
+ 
+                                 config->random_seed_mode = on ? RANDOM_SEED_ALWAYS : RANDOM_SEED_OFF;
+                         }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0010-sd-boot-Allow-on-off-and-t-f-for-booleans-too.patch
+++ b/vendor/systemd-patches/0010-sd-boot-Allow-on-off-and-t-f-for-booleans-too.patch
@@ -1,0 +1,54 @@
+From 6d156d0ec471aad6fb0a7a9e3fd7d5de1c9b4216 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Wed, 11 Aug 2021 14:59:46 +0200
+Subject: [PATCH 10/73] sd-boot: Allow on/off and t/f for booleans too
+
+---
+ man/loader.conf.xml | 4 ++--
+ src/boot/efi/util.c | 8 ++++++--
+ 2 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/man/loader.conf.xml b/man/loader.conf.xml
+index 29315ceb1..4c0355800 100644
+--- a/man/loader.conf.xml
++++ b/man/loader.conf.xml
+@@ -41,8 +41,8 @@
+     a comment line. Empty and comment lines are ignored.</para>
+ 
+     <para>Boolean arguments may be written as
+-    <literal>yes</literal>/<literal>y</literal>/<literal>true</literal>/<literal>1</literal> or
+-    <literal>no</literal>/<literal>n</literal>/<literal>false</literal>/<literal>0</literal>.
++    <literal>yes</literal>/<literal>y</literal>/<literal>true</literal>/<literal>t</literal>/<literal>on</literal>/<literal>1</literal> or
++    <literal>no</literal>/<literal>n</literal>/<literal>false</literal>/<literal>f</literal>/<literal>off</literal>/<literal>0</literal>.
+     </para>
+   </refsect1>
+ 
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index b2977546a..0c28cab24 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -75,7 +75,9 @@ EFI_STATUS parse_boolean(const CHAR8 *v, BOOLEAN *b) {
+         if (strcmpa(v, (CHAR8 *)"1") == 0 ||
+             strcmpa(v, (CHAR8 *)"yes") == 0 ||
+             strcmpa(v, (CHAR8 *)"y") == 0 ||
+-            strcmpa(v, (CHAR8 *)"true") == 0) {
++            strcmpa(v, (CHAR8 *)"true") == 0 ||
++            strcmpa(v, (CHAR8 *)"t") == 0 ||
++            strcmpa(v, (CHAR8 *)"on") == 0) {
+                 *b = TRUE;
+                 return EFI_SUCCESS;
+         }
+@@ -83,7 +85,9 @@ EFI_STATUS parse_boolean(const CHAR8 *v, BOOLEAN *b) {
+         if (strcmpa(v, (CHAR8 *)"0") == 0 ||
+             strcmpa(v, (CHAR8 *)"no") == 0 ||
+             strcmpa(v, (CHAR8 *)"n") == 0 ||
+-            strcmpa(v, (CHAR8 *)"false") == 0) {
++            strcmpa(v, (CHAR8 *)"false") == 0 ||
++            strcmpa(v, (CHAR8 *)"f") == 0 ||
++            strcmpa(v, (CHAR8 *)"off") == 0) {
+                 *b = FALSE;
+                 return EFI_SUCCESS;
+         }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0011-sd-boot-Fix-PE-section-parsing.patch
+++ b/vendor/systemd-patches/0011-sd-boot-Fix-PE-section-parsing.patch
@@ -1,0 +1,507 @@
+From 1ae25afdc5e1a9ab607a2c9d7d85fa200de17576 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Fri, 13 Aug 2021 18:55:32 +0200
+Subject: [PATCH 11/73] sd-boot: Fix PE section parsing
+
+We only need the PE header offset from the DOS header, not
+its size. Previously, the section table could be cut off in the middle.
+
+While we are at it, also modernize the remaining code.
+---
+ src/basic/macro.h                   |   1 -
+ src/boot/efi/boot.c                 |   5 +-
+ src/boot/efi/linux.h                |   5 +-
+ src/boot/efi/measure.c              |   4 +-
+ src/boot/efi/missing_efi.h          |   4 +
+ src/boot/efi/pe.c                   | 203 ++++++++++++++++------------
+ src/boot/efi/pe.h                   |  18 ++-
+ src/boot/efi/splash.c               |   6 +-
+ src/boot/efi/stub.c                 |   5 +-
+ src/fundamental/macro-fundamental.h |   1 +
+ 10 files changed, 150 insertions(+), 102 deletions(-)
+
+diff --git a/src/basic/macro.h b/src/basic/macro.h
+index ae5b1b788..e71fc5abe 100644
+--- a/src/basic/macro.h
++++ b/src/basic/macro.h
+@@ -20,7 +20,6 @@
+ #define _sentinel_ __attribute__((__sentinel__))
+ #define _destructor_ __attribute__((__destructor__))
+ #define _deprecated_ __attribute__((__deprecated__))
+-#define _packed_ __attribute__((__packed__))
+ #define _malloc_ __attribute__((__malloc__))
+ #define _weak_ __attribute__((__weak__))
+ #define _public_ __attribute__((__visibility__("default")))
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 638070d77..9a81af42a 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1897,14 +1897,13 @@ static VOID config_entry_add_linux(
+                 CHAR16 buf[256];
+                 UINTN bufsize = sizeof buf;
+                 EFI_FILE_INFO *f;
+-                CHAR8 *sections[] = {
++                const CHAR8 *sections[] = {
+                         (CHAR8 *)".osrel",
+                         (CHAR8 *)".cmdline",
+                         NULL
+                 };
+                 UINTN offs[ELEMENTSOF(sections)-1] = {};
+                 UINTN szs[ELEMENTSOF(sections)-1] = {};
+-                UINTN addrs[ELEMENTSOF(sections)-1] = {};
+                 CHAR8 *content = NULL;
+                 CHAR8 *line;
+                 UINTN pos = 0;
+@@ -1931,7 +1930,7 @@ static VOID config_entry_add_linux(
+                         continue;
+ 
+                 /* look for .osrel and .cmdline sections in the .efi binary */
+-                err = pe_file_locate_sections(linux_dir, f->FileName, sections, addrs, offs, szs);
++                err = pe_file_locate_sections(linux_dir, f->FileName, sections, offs, szs);
+                 if (EFI_ERROR(err))
+                         continue;
+ 
+diff --git a/src/boot/efi/linux.h b/src/boot/efi/linux.h
+index 53270e16b..773c260b7 100644
+--- a/src/boot/efi/linux.h
++++ b/src/boot/efi/linux.h
+@@ -2,6 +2,7 @@
+ #pragma once
+ 
+ #include <efi.h>
++#include "macro-fundamental.h"
+ 
+ #define SETUP_MAGIC             0x53726448      /* "HdrS" */
+ 
+@@ -44,7 +45,7 @@ struct setup_header {
+         UINT64 pref_address;
+         UINT32 init_size;
+         UINT32 handover_offset;
+-} __attribute__((packed));
++} _packed_;
+ 
+ /* adapted from linux' bootparam.h */
+ struct boot_params {
+@@ -81,7 +82,7 @@ struct boot_params {
+         UINT8  _pad8[48];
+         UINT8  eddbuf[6*82];            // was: struct edd_info eddbuf[EDDMAXNR]
+         UINT8  _pad9[276];
+-} __attribute__((packed));
++} _packed_;
+ 
+ EFI_STATUS linux_exec(EFI_HANDLE image,
+                       CHAR8 *cmdline, UINTN cmdline_size,
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index 429e82657..1d19366f7 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -133,13 +133,13 @@ typedef struct {
+         UINT16 HeaderVersion;
+         UINT32 PCRIndex;
+         UINT32 EventType;
+-} __attribute__((packed)) EFI_TCG2_EVENT_HEADER;
++} _packed_ EFI_TCG2_EVENT_HEADER;
+ 
+ typedef struct tdEFI_TCG2_EVENT {
+         UINT32 Size;
+         EFI_TCG2_EVENT_HEADER Header;
+         UINT8 Event[1];
+-} __attribute__((packed)) EFI_TCG2_EVENT;
++} _packed_ EFI_TCG2_EVENT;
+ 
+ typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_CAPABILITY) (IN EFI_TCG2_PROTOCOL * This,
+                                                       IN OUT EFI_TCG2_BOOT_SERVICE_CAPABILITY * ProtocolCapability);
+diff --git a/src/boot/efi/missing_efi.h b/src/boot/efi/missing_efi.h
+index b98393134..37c468f2a 100644
+--- a/src/boot/efi/missing_efi.h
++++ b/src/boot/efi/missing_efi.h
+@@ -120,3 +120,7 @@ typedef struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL {
+ } EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL;
+ 
+ #endif
++
++#ifndef EFI_IMAGE_MACHINE_RISCV64
++        #define EFI_IMAGE_MACHINE_RISCV64 0x5064
++#endif
+diff --git a/src/boot/efi/pe.c b/src/boot/efi/pe.c
+index 5c20acc9f..04b4504c2 100644
+--- a/src/boot/efi/pe.c
++++ b/src/boot/efi/pe.c
+@@ -6,6 +6,24 @@
+ #include "pe.h"
+ #include "util.h"
+ 
++#define DOS_FILE_MAGIC "MZ"
++#define PE_FILE_MAGIC  "PE\0\0"
++#define MAX_SECTIONS 96
++
++#if defined(__i386__)
++        #define TARGET_MACHINE_TYPE EFI_IMAGE_MACHINE_IA32
++#elif defined(__x86_64__)
++        #define TARGET_MACHINE_TYPE EFI_IMAGE_MACHINE_X64
++#elif defined(__aarch64__)
++        #define TARGET_MACHINE_TYPE EFI_IMAGE_MACHINE_AARCH64
++#elif defined(__arm__)
++        #define TARGET_MACHINE_TYPE EFI_IMAGE_MACHINE_ARMTHUMB_MIXED
++#elif defined(__riscv) && __riscv_xlen == 64
++        #define TARGET_MACHINE_TYPE EFI_IMAGE_MACHINE_RISCV64
++#else
++        #error Unknown EFI arch
++#endif
++
+ struct DosFileHeader {
+         UINT8   Magic[2];
+         UINT16  LastSize;
+@@ -26,14 +44,9 @@ struct DosFileHeader {
+         UINT16  OEMInfo;
+         UINT16  reserved2[10];
+         UINT32  ExeHeader;
+-} __attribute__((packed));
++} _packed_;
+ 
+-#define PE_HEADER_MACHINE_I386          0x014c
+-#define PE_HEADER_MACHINE_X64           0x8664
+-#define PE_HEADER_MACHINE_ARM64         0xaa64
+-#define PE_HEADER_MACHINE_ARM           0x01c2
+-#define PE_HEADER_MACHINE_RISCV64       0x5064
+-struct PeFileHeader {
++struct CoffFileHeader {
+         UINT16  Machine;
+         UINT16  NumberOfSections;
+         UINT32  TimeDateStamp;
+@@ -41,12 +54,13 @@ struct PeFileHeader {
+         UINT32  NumberOfSymbols;
+         UINT16  SizeOfOptionalHeader;
+         UINT16  Characteristics;
+-} __attribute__((packed));
++} _packed_;
+ 
+-struct PeHeader {
++struct PeFileHeader {
+         UINT8   Magic[4];
+-        struct PeFileHeader FileHeader;
+-} __attribute__((packed));
++        struct CoffFileHeader FileHeader;
++        /* OptionalHeader omitted */
++} _packed_;
+ 
+ struct PeSectionHeader {
+         UINT8   Name[8];
+@@ -59,120 +73,143 @@ struct PeSectionHeader {
+         UINT16  NumberOfRelocations;
+         UINT16  NumberOfLinenumbers;
+         UINT32  Characteristics;
+-} __attribute__((packed));
++} _packed_;
+ 
+-EFI_STATUS pe_memory_locate_sections(CHAR8 *base, CHAR8 **sections, UINTN *addrs, UINTN *offsets, UINTN *sizes) {
+-        struct DosFileHeader *dos;
+-        struct PeHeader *pe;
+-        UINTN offset;
+-
+-        assert(base);
+-        assert(sections);
+-
+-        dos = (struct DosFileHeader *)base;
+-
+-        if (CompareMem(dos->Magic, "MZ", 2) != 0)
+-                return EFI_LOAD_ERROR;
++static inline BOOLEAN verify_dos(const struct DosFileHeader *dos) {
++        assert(dos);
++        return CompareMem(dos->Magic, DOS_FILE_MAGIC, STRLEN(DOS_FILE_MAGIC)) == 0;
++}
+ 
+-        pe = (struct PeHeader *)&base[dos->ExeHeader];
+-        if (CompareMem(pe->Magic, "PE\0\0", 4) != 0)
+-                return EFI_LOAD_ERROR;
++static inline BOOLEAN verify_pe(const struct PeFileHeader *pe) {
++        assert(pe);
++        return CompareMem(pe->Magic, PE_FILE_MAGIC, STRLEN(PE_FILE_MAGIC)) == 0 &&
++               pe->FileHeader.Machine == TARGET_MACHINE_TYPE &&
++               pe->FileHeader.NumberOfSections > 0 &&
++               pe->FileHeader.NumberOfSections <= MAX_SECTIONS;
++}
+ 
+-        /* PE32+ Subsystem type */
+-        if (pe->FileHeader.Machine != PE_HEADER_MACHINE_X64 &&
+-            pe->FileHeader.Machine != PE_HEADER_MACHINE_ARM64 &&
+-            pe->FileHeader.Machine != PE_HEADER_MACHINE_I386 &&
+-            pe->FileHeader.Machine != PE_HEADER_MACHINE_ARM &&
+-            pe->FileHeader.Machine != PE_HEADER_MACHINE_RISCV64)
+-                return EFI_LOAD_ERROR;
++static inline UINTN section_table_offset(const struct DosFileHeader *dos, const struct PeFileHeader *pe) {
++        assert(dos);
++        assert(pe);
++        return dos->ExeHeader + sizeof(struct PeFileHeader) + pe->FileHeader.SizeOfOptionalHeader;
++}
+ 
+-        if (pe->FileHeader.NumberOfSections > 96)
+-                return EFI_LOAD_ERROR;
++static VOID locate_sections(
++                const struct PeSectionHeader section_table[],
++                UINTN n_table,
++                const CHAR8 **sections,
++                UINTN *addrs,
++                UINTN *offsets,
++                UINTN *sizes) {
+ 
+-        offset = dos->ExeHeader + sizeof(*pe) + pe->FileHeader.SizeOfOptionalHeader;
++        assert(section_table);
++        assert(sections);
++        assert(sizes);
+ 
+-        for (UINTN i = 0; i < pe->FileHeader.NumberOfSections; i++) {
+-                struct PeSectionHeader *sect;
++        for (UINTN i = 0; i < n_table; i++) {
++                const struct PeSectionHeader *sect = section_table + i;
+ 
+-                sect = (struct PeSectionHeader *)&base[offset];
+                 for (UINTN j = 0; sections[j]; j++) {
+                         if (CompareMem(sect->Name, sections[j], strlena(sections[j])) != 0)
+                                 continue;
+ 
+                         if (addrs)
+-                                addrs[j] = (UINTN)sect->VirtualAddress;
++                                addrs[j] = sect->VirtualAddress;
+                         if (offsets)
+-                                offsets[j] = (UINTN)sect->PointerToRawData;
+-                        if (sizes)
+-                                sizes[j] = (UINTN)sect->VirtualSize;
++                                offsets[j] = sect->PointerToRawData;
++                        sizes[j] = sect->VirtualSize;
+                 }
+-                offset += sizeof(*sect);
+         }
++}
++
++EFI_STATUS pe_memory_locate_sections(
++                const CHAR8 *base,
++                const CHAR8 **sections,
++                UINTN *addrs,
++                UINTN *sizes) {
++        const struct DosFileHeader *dos;
++        const struct PeFileHeader *pe;
++        UINTN offset;
++
++        assert(base);
++        assert(sections);
++        assert(addrs);
++        assert(sizes);
++
++        dos = (const struct DosFileHeader*)base;
++        if (!verify_dos(dos))
++                return EFI_LOAD_ERROR;
++
++        pe = (const struct PeFileHeader*)&base[dos->ExeHeader];
++        if (!verify_pe(pe))
++                return EFI_LOAD_ERROR;
++
++        offset = section_table_offset(dos, pe);
++        locate_sections((struct PeSectionHeader*)&base[offset], pe->FileHeader.NumberOfSections,
++                        sections, addrs, NULL, sizes);
+ 
+         return EFI_SUCCESS;
+ }
+ 
+-EFI_STATUS pe_file_locate_sections(EFI_FILE *dir, CHAR16 *path, CHAR8 **sections, UINTN *addrs, UINTN *offsets, UINTN *sizes) {
+-        EFI_FILE_HANDLE handle;
++EFI_STATUS pe_file_locate_sections(
++                EFI_FILE *dir,
++                const CHAR16 *path,
++                const CHAR8 **sections,
++                UINTN *offsets,
++                UINTN *sizes) {
++        _cleanup_freepool_ struct PeSectionHeader *section_table = NULL;
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE handle = NULL;
+         struct DosFileHeader dos;
+-        struct PeHeader pe;
+-        UINTN len;
+-        UINTN headerlen;
++        struct PeFileHeader pe;
++        UINTN len, section_table_len;
+         EFI_STATUS err;
+-        _cleanup_freepool_ CHAR8 *header = NULL;
+ 
+         assert(dir);
+         assert(path);
++        assert(sections);
++        assert(offsets);
++        assert(sizes);
+ 
+-        err = uefi_call_wrapper(dir->Open, 5, dir, &handle, path, EFI_FILE_MODE_READ, 0ULL);
++        err = uefi_call_wrapper(dir->Open, 5, dir, &handle, (CHAR16*)path, EFI_FILE_MODE_READ, 0ULL);
+         if (EFI_ERROR(err))
+                 return err;
+ 
+-        /* MS-DOS stub */
+         len = sizeof(dos);
+         err = uefi_call_wrapper(handle->Read, 3, handle, &len, &dos);
+         if (EFI_ERROR(err))
+-                goto out;
+-        if (len != sizeof(dos)) {
+-                err = EFI_LOAD_ERROR;
+-                goto out;
+-        }
++                return err;
++        if (len != sizeof(dos) || !verify_dos(&dos))
++                return EFI_LOAD_ERROR;
+ 
+         err = uefi_call_wrapper(handle->SetPosition, 2, handle, dos.ExeHeader);
+         if (EFI_ERROR(err))
+-                goto out;
++                return err;
+ 
+         len = sizeof(pe);
+         err = uefi_call_wrapper(handle->Read, 3, handle, &len, &pe);
+         if (EFI_ERROR(err))
+-                goto out;
+-        if (len != sizeof(pe)) {
+-                err = EFI_LOAD_ERROR;
+-                goto out;
+-        }
++                return err;
++        if (len != sizeof(pe) || !verify_pe(&pe))
++                return EFI_LOAD_ERROR;
+ 
+-        headerlen = sizeof(dos) + sizeof(pe) + pe.FileHeader.SizeOfOptionalHeader + pe.FileHeader.NumberOfSections * sizeof(struct PeSectionHeader);
+-        header = AllocatePool(headerlen);
+-        if (!header) {
+-                err = EFI_OUT_OF_RESOURCES;
+-                goto out;
+-        }
+-        len = headerlen;
+-        err = uefi_call_wrapper(handle->SetPosition, 2, handle, 0);
++        section_table_len = pe.FileHeader.NumberOfSections * sizeof(struct PeSectionHeader);
++        section_table = AllocatePool(section_table_len);
++        if (!section_table)
++                return EFI_OUT_OF_RESOURCES;
++
++        err = uefi_call_wrapper(handle->SetPosition, 2, handle, section_table_offset(&dos, &pe));
+         if (EFI_ERROR(err))
+-                goto out;
++                return err;
+ 
+-        err = uefi_call_wrapper(handle->Read, 3, handle, &len, header);
++        len = section_table_len;
++        err = uefi_call_wrapper(handle->Read, 3, handle, &len, section_table);
+         if (EFI_ERROR(err))
+-                goto out;
++                return err;
++        if (len != section_table_len)
++                return EFI_LOAD_ERROR;
+ 
+-        if (len != headerlen) {
+-                err = EFI_LOAD_ERROR;
+-                goto out;
+-        }
++        locate_sections(section_table, pe.FileHeader.NumberOfSections,
++                        sections, NULL, offsets, sizes);
+ 
+-        err = pe_memory_locate_sections(header, sections, addrs, offsets, sizes);
+-out:
+-        uefi_call_wrapper(handle->Close, 1, handle);
+-        return err;
++        return EFI_SUCCESS;
+ }
+diff --git a/src/boot/efi/pe.h b/src/boot/efi/pe.h
+index 06a0fcd70..e35521122 100644
+--- a/src/boot/efi/pe.h
++++ b/src/boot/efi/pe.h
+@@ -1,9 +1,17 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
+-#include <efi.h>
++#include <efidef.h>
+ 
+-EFI_STATUS pe_memory_locate_sections(CHAR8 *base,
+-                                     CHAR8 **sections, UINTN *addrs, UINTN *offsets, UINTN *sizes);
+-EFI_STATUS pe_file_locate_sections(EFI_FILE *dir, CHAR16 *path,
+-                                   CHAR8 **sections, UINTN *addrs, UINTN *offsets, UINTN *sizes);
++EFI_STATUS pe_memory_locate_sections(
++                const CHAR8 *base,
++                const CHAR8 **sections,
++                UINTN *addrs,
++                UINTN *sizes);
++
++EFI_STATUS pe_file_locate_sections(
++                EFI_FILE *dir,
++                const CHAR16 *path,
++                const CHAR8 **sections,
++                UINTN *offsets,
++                UINTN *sizes);
+diff --git a/src/boot/efi/splash.c b/src/boot/efi/splash.c
+index 920b44082..23627a794 100644
+--- a/src/boot/efi/splash.c
++++ b/src/boot/efi/splash.c
+@@ -12,7 +12,7 @@ struct bmp_file {
+         UINT32 size;
+         UINT16 reserved[2];
+         UINT32 offset;
+-} __attribute__((packed));
++} _packed_;
+ 
+ /* we require at least BITMAPINFOHEADER, later versions are
+    accepted, but their features ignored */
+@@ -28,14 +28,14 @@ struct bmp_dib {
+         INT32 y_pixel_meter;
+         UINT32 colors_used;
+         UINT32 colors_important;
+-} __attribute__((packed));
++} _packed_;
+ 
+ struct bmp_map {
+         UINT8 blue;
+         UINT8 green;
+         UINT8 red;
+         UINT8 reserved;
+-} __attribute__((packed));
++} _packed_;
+ 
+ static EFI_STATUS bmp_parse_header(UINT8 *bmp, UINTN size, struct bmp_dib **ret_dib,
+                             struct bmp_map **ret_map, UINT8 **pixmap) {
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 82da1d3ec..5758b5cd9 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -17,7 +17,7 @@ static const char __attribute__((used)) magic[] = "#### LoaderInfo: systemd-stub
+ 
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         EFI_LOADED_IMAGE *loaded_image;
+-        CHAR8 *sections[] = {
++        const CHAR8 *sections[] = {
+                 (CHAR8 *)".cmdline",
+                 (CHAR8 *)".linux",
+                 (CHAR8 *)".initrd",
+@@ -25,7 +25,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 NULL
+         };
+         UINTN addrs[ELEMENTSOF(sections)-1] = {};
+-        UINTN offs[ELEMENTSOF(sections)-1] = {};
+         UINTN szs[ELEMENTSOF(sections)-1] = {};
+         CHAR8 *cmdline = NULL;
+         UINTN cmdline_len;
+@@ -39,7 +38,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Error getting a LoadedImageProtocol handle: %r", err);
+ 
+-        err = pe_memory_locate_sections(loaded_image->ImageBase, sections, addrs, offs, szs);
++        err = pe_memory_locate_sections(loaded_image->ImageBase, sections, addrs, szs);
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Unable to locate embedded .linux section: %r", err);
+ 
+diff --git a/src/fundamental/macro-fundamental.h b/src/fundamental/macro-fundamental.h
+index 8fe79cc02..bef1b55cb 100644
+--- a/src/fundamental/macro-fundamental.h
++++ b/src/fundamental/macro-fundamental.h
+@@ -11,6 +11,7 @@
+ #define _const_ __attribute__((__const__))
+ #define _pure_ __attribute__((__pure__))
+ #define _section_(x) __attribute__((__section__(x)))
++#define _packed_ __attribute__((__packed__))
+ #define _used_ __attribute__((__used__))
+ #define _unused_ __attribute__((__unused__))
+ #define _cleanup_(x) __attribute__((__cleanup__(x)))
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0012-sd-boot-Try-harder-to-detect-ourselves.patch
+++ b/vendor/systemd-patches/0012-sd-boot-Try-harder-to-detect-ourselves.patch
@@ -1,0 +1,116 @@
+From 2d639568e96142b3cd2de5773c5d298d941d36ce Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Fri, 13 Aug 2021 19:03:35 +0200
+Subject: [PATCH 12/73] sd-boot: Try harder to detect ourselves
+
+By moving our magic string into its own PE section, we can forego
+grepping for it.
+---
+ src/boot/efi/boot.c      | 51 ++++++++++++++++++++++++++++------------
+ src/boot/efi/meson.build |  1 +
+ 2 files changed, 37 insertions(+), 15 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 9a81af42a..70f5a2ba5 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -22,7 +22,7 @@
+ #endif
+ 
+ /* magic string to find in the binary image */
+-static const char __attribute__((used)) magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
++static const char _used_ _section_(".sdmagic") magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
+ 
+ enum loader_type {
+         LOADER_UNDEFINED,
+@@ -1792,6 +1792,29 @@ static ConfigEntry *config_entry_add_loader(
+         return entry;
+ }
+ 
++static BOOLEAN is_sd_boot(EFI_FILE *root_dir, const CHAR16 *loader_path) {
++        EFI_STATUS err;
++        const CHAR8 *sections[] = {
++                (CHAR8 *)".sdmagic",
++                NULL
++        };
++        UINTN offset = 0, size = 0, read;
++        _cleanup_freepool_ CHAR8 *content = NULL;
++
++        assert(root_dir);
++        assert(loader_path);
++
++        err = pe_file_locate_sections(root_dir, loader_path, sections, &offset, &size);
++        if (EFI_ERROR(err) || size != sizeof(magic))
++                return FALSE;
++
++        err = file_read(root_dir, loader_path, offset, size, &content, &read);
++        if (EFI_ERROR(err) || size != read)
++                return FALSE;
++
++        return CompareMem(content, magic, sizeof(magic)) == 0;
++}
++
+ static BOOLEAN config_entry_add_loader_auto(
+                 Config *config,
+                 EFI_HANDLE *device,
+@@ -1811,25 +1834,23 @@ static BOOLEAN config_entry_add_loader_auto(
+         assert(root_dir);
+         assert(id);
+         assert(title);
+-        assert(loader);
++        assert(loader || loaded_image_path);
+ 
+         if (!config->auto_entries)
+                 return FALSE;
+ 
+-        /* do not add an entry for ourselves */
+         if (loaded_image_path) {
+-                UINTN len;
+-                _cleanup_freepool_ CHAR8 *content = NULL;
+-
+-                if (StriCmp(loader, loaded_image_path) == 0)
++                loader = L"\\EFI\\BOOT\\BOOT" EFI_MACHINE_TYPE_NAME ".efi";
++
++                /* We are trying to add the default EFI loader here,
++                 * but we do not want to do that if that would be us.
++                 *
++                 * If the default loader is not us, it might be shim. It would
++                 * chainload GRUBX64.EFI in that case, which might be us.*/
++                if (StriCmp(loader, loaded_image_path) == 0 ||
++                    is_sd_boot(root_dir, loader) ||
++                    is_sd_boot(root_dir, L"\\EFI\\BOOT\\GRUB" EFI_MACHINE_TYPE_NAME L".EFI"))
+                         return FALSE;
+-
+-                /* look for systemd-boot magic string */
+-                err = file_read(root_dir, loader, 0, 100*1024, &content, &len);
+-                if (!EFI_ERROR(err))
+-                        for (CHAR8 *start = content; start <= content + len - sizeof(magic) - 1; start++)
+-                                if (start[0] == magic[0] && CompareMem(start, magic, sizeof(magic) - 1) == 0)
+-                                        return FALSE;
+         }
+ 
+         /* check existence */
+@@ -2414,7 +2435,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         config_entry_add_loader_auto(&config, loaded_image->DeviceHandle, root_dir, NULL,
+                                      L"auto-efi-shell", 's', L"EFI Shell", L"\\shell" EFI_MACHINE_TYPE_NAME ".efi");
+         config_entry_add_loader_auto(&config, loaded_image->DeviceHandle, root_dir, loaded_image_path,
+-                                     L"auto-efi-default", '\0', L"EFI Default Loader", L"\\EFI\\Boot\\boot" EFI_MACHINE_TYPE_NAME ".efi");
++                                     L"auto-efi-default", '\0', L"EFI Default Loader", NULL);
+         config_entry_add_osx(&config);
+ 
+         if (config.auto_firmware && efivar_get_uint64_le(EFI_GLOBAL_GUID, L"OsIndicationsSupported", &osind) == EFI_SUCCESS) {
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index 16eeb4ebb..efa270df6 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -292,6 +292,7 @@ if have_gnu_efi
+                                    '-j', '.text',
+                                    '-j', '.sdata',
+                                    '-j', '.sbat',
++                                   '-j', '.sdmagic',
+                                    '-j', '.data',
+                                    '-j', '.dynamic',
+                                    '-j', '.dynsym',
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0013-sd-boot-Add-memmem_safe-and-memory_startswith.patch
+++ b/vendor/systemd-patches/0013-sd-boot-Add-memmem_safe-and-memory_startswith.patch
@@ -1,0 +1,111 @@
+From dfc133b5a0355249bfa7032547c42d4c898ca3ac Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Fri, 13 Aug 2021 19:03:35 +0200
+Subject: [PATCH 13/73] sd-boot: Add memmem_safe and memory_startswith
+
+---
+ src/basic/string-util.h                   | 16 ----------------
+ src/boot/efi/util.c                       | 14 ++++++++++++++
+ src/boot/efi/util.h                       |  7 +++++++
+ src/fundamental/string-util-fundamental.h | 17 +++++++++++++++++
+ 4 files changed, 38 insertions(+), 16 deletions(-)
+
+diff --git a/src/basic/string-util.h b/src/basic/string-util.h
+index 9155e50ba..5c11adf39 100644
+--- a/src/basic/string-util.h
++++ b/src/basic/string-util.h
+@@ -189,22 +189,6 @@ static inline void strncpy_exact(char *buf, const char *src, size_t buf_len) {
+ }
+ REENABLE_WARNING;
+ 
+-/* Like startswith(), but operates on arbitrary memory blocks */
+-static inline void *memory_startswith(const void *p, size_t sz, const char *token) {
+-        assert(token);
+-
+-        size_t n = strlen(token);
+-        if (sz < n)
+-                return NULL;
+-
+-        assert(p);
+-
+-        if (memcmp(p, token, n) != 0)
+-                return NULL;
+-
+-        return (uint8_t*) p + n;
+-}
+-
+ /* Like startswith_no_case(), but operates on arbitrary memory blocks.
+  * It works only for ASCII strings.
+  */
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index 0c28cab24..823689e22 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -501,3 +501,17 @@ EFI_STATUS log_oom(void) {
+         log_error_stall(L"Out of memory.");
+         return EFI_OUT_OF_RESOURCES;
+ }
++
++VOID *memmem_safe(const VOID *haystack, UINTN haystack_len, const VOID *needle, UINTN needle_len) {
++        assert(haystack || haystack_len == 0);
++        assert(needle || needle_len == 0);
++
++        if (needle_len == 0)
++                return (VOID*)haystack;
++
++        for (const CHAR8 *h = haystack, *n = needle; haystack_len >= needle_len; h++, haystack_len--)
++                if (*h == *n && CompareMem(h + 1, n + 1, needle_len - 1) == 0)
++                        return (VOID*)h;
++
++        return NULL;
++}
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index d3bf848a9..f620f1421 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -84,3 +84,10 @@ EFI_STATUS log_oom(void);
+                 log_error_stall(fmt, ##__VA_ARGS__); \
+                 err; \
+         })
++
++VOID *memmem_safe(const VOID *haystack, UINTN haystack_len, const VOID *needle, UINTN needle_len);
++
++static inline VOID *mempmem_safe(const VOID *haystack, UINTN haystack_len, const VOID *needle, UINTN needle_len) {
++        CHAR8 *p = memmem_safe(haystack, haystack_len, needle, needle_len);
++        return p ? p + needle_len : NULL;
++}
+diff --git a/src/fundamental/string-util-fundamental.h b/src/fundamental/string-util-fundamental.h
+index 407cede48..7455c0549 100644
+--- a/src/fundamental/string-util-fundamental.h
++++ b/src/fundamental/string-util-fundamental.h
+@@ -16,6 +16,7 @@
+ #define strncmp(a, b, n) StrnCmp((a), (b), (n))
+ #define strcasecmp(a, b) StriCmp((a), (b))
+ #define STR_C(str)       (L ## str)
++#define memcmp(a, b, n)  CompareMem(a, b, n)
+ #else
+ #define STR_C(str)       (str)
+ #endif
+@@ -65,3 +66,19 @@ static inline const sd_char *yes_no(sd_bool b) {
+ }
+ 
+ sd_int strverscmp_improved(const sd_char *a, const sd_char *b);
++
++/* Like startswith(), but operates on arbitrary memory blocks */
++static inline void *memory_startswith(const void *p, sd_size_t sz, const sd_char *token) {
++        assert(token);
++
++        sd_size_t n = strlen(token) * sizeof(sd_char);
++        if (sz < n)
++                return NULL;
++
++        assert(p);
++
++        if (memcmp(p, token, n) != 0)
++                return NULL;
++
++        return (uint8_t*) p + n;
++}
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0014-sd-boot-Detect-windows-boot-loader-title-from-BCD.patch
+++ b/vendor/systemd-patches/0014-sd-boot-Detect-windows-boot-loader-title-from-BCD.patch
@@ -1,0 +1,88 @@
+From 31b5d10b06b05525980dd7269ff4099355cb1379 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Fri, 13 Aug 2021 19:03:35 +0200
+Subject: [PATCH 14/73] sd-boot: Detect windows boot loader title from BCD
+
+---
+ src/boot/efi/boot.c | 54 ++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 51 insertions(+), 3 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 70f5a2ba5..82da98432 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1897,6 +1897,55 @@ static VOID config_entry_add_osx(Config *config) {
+         }
+ }
+ 
++static VOID config_entry_add_windows(Config *config, EFI_HANDLE *device, EFI_FILE *root_dir) {
++        _cleanup_freepool_ CHAR8 *bcd = NULL;
++        const CHAR16 *title = NULL;
++        EFI_STATUS err;
++        UINTN len;
++
++        assert(config);
++        assert(device);
++        assert(root_dir);
++
++        if (!config->auto_entries)
++                return;
++
++        /* Try to find a better title. */
++        err = file_read(root_dir, L"\\EFI\\Microsoft\\Boot\\BCD", 0, 100*1024, &bcd, &len);
++        if (!EFI_ERROR(err)) {
++                static const CHAR16 *versions[] = {
++                        L"Windows 11",
++                        L"Windows 10",
++                        L"Windows 8.1",
++                        L"Windows 8",
++                        L"Windows 7",
++                        L"Windows Vista",
++                };
++
++                CHAR8 *p = bcd;
++                while (!title) {
++                        CHAR8 *q = mempmem_safe(p, len, versions[0], STRLEN(L"Windows "));
++                        if (!q)
++                                break;
++
++                        len -= q - p;
++                        p = q;
++
++                        /* We found the prefix, now try all the version strings. */
++                        for (UINTN i = 0; i < ELEMENTSOF(versions); i++) {
++                                if (memory_startswith(p, len, versions[i] + STRLEN("Windows "))) {
++                                        title = versions[i];
++                                        break;
++                                }
++                        }
++                }
++        }
++
++        config_entry_add_loader_auto(config, device, root_dir, NULL,
++                                     L"auto-windows", 'w', title ?: L"Windows Boot Manager",
++                                     L"\\EFI\\Microsoft\\Boot\\bootmgfw.efi");
++}
++
+ static VOID config_entry_add_linux(
+                 Config *config,
+                 EFI_HANDLE *device,
+@@ -2430,13 +2479,12 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         config_sort_entries(&config);
+ 
+         /* if we find some well-known loaders, add them to the end of the list */
+-        config_entry_add_loader_auto(&config, loaded_image->DeviceHandle, root_dir, NULL,
+-                                     L"auto-windows", 'w', L"Windows Boot Manager", L"\\EFI\\Microsoft\\Boot\\bootmgfw.efi");
++        config_entry_add_osx(&config);
++        config_entry_add_windows(&config, loaded_image->DeviceHandle, root_dir);
+         config_entry_add_loader_auto(&config, loaded_image->DeviceHandle, root_dir, NULL,
+                                      L"auto-efi-shell", 's', L"EFI Shell", L"\\shell" EFI_MACHINE_TYPE_NAME ".efi");
+         config_entry_add_loader_auto(&config, loaded_image->DeviceHandle, root_dir, loaded_image_path,
+                                      L"auto-efi-default", '\0', L"EFI Default Loader", NULL);
+-        config_entry_add_osx(&config);
+ 
+         if (config.auto_firmware && efivar_get_uint64_le(EFI_GLOBAL_GUID, L"OsIndicationsSupported", &osind) == EFI_SUCCESS) {
+                 if (osind & EFI_OS_INDICATIONS_BOOT_TO_FW_UI)
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0015-sd-boot-Improve-selection-of-initial-entries-to-show.patch
+++ b/vendor/systemd-patches/0015-sd-boot-Improve-selection-of-initial-entries-to-show.patch
@@ -1,0 +1,80 @@
+From 222c857fda04db98b71a8d7f8881cf5749927c0d Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 14 Aug 2021 13:04:29 +0200
+Subject: [PATCH 15/73] sd-boot: Improve selection of initial entries to show
+
+---
+ src/boot/efi/boot.c | 32 +++++++++++++++-----------------
+ 1 file changed, 15 insertions(+), 17 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 82da98432..56cd4a489 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -512,19 +512,19 @@ static BOOLEAN menu_run(
+ 
+         EFI_STATUS err;
+         UINTN visible_max;
+-        UINTN idx_highlight;
+-        UINTN idx_highlight_prev;
++        UINTN idx_highlight = config->idx_default;
++        UINTN idx_highlight_prev = 0;
+         UINTN idx_first;
+         UINTN idx_last;
+-        BOOLEAN refresh;
+-        BOOLEAN highlight;
++        BOOLEAN refresh = TRUE;
++        BOOLEAN highlight = FALSE;
+         UINTN line_width;
+         CHAR16 **lines;
+         UINTN x_start;
+         UINTN y_start;
+         UINTN x_max;
+         UINTN y_max;
+-        CHAR16 *status;
++        CHAR16 *status = NULL;
+         CHAR16 *clearline;
+         UINTN timeout_remain = config->timeout_sec;
+         INT16 idx;
+@@ -554,20 +554,19 @@ static BOOLEAN menu_run(
+                 y_max = 25;
+         }
+ 
+-        idx_highlight = config->idx_default;
+-        idx_highlight_prev = 0;
+-
+         visible_max = y_max - 2;
+ 
+-        if ((UINTN)config->idx_default >= visible_max)
+-                idx_first = config->idx_default-1;
+-        else
++        /* Drawing entries starts at idx_first until idx_last. We want to make
++         * sure that idx_highlight is centered, but not if we are close to the
++         * beginning/end of the entry list. Otherwise we would have a half-empty
++         * screen. */
++        if (config->entry_count <= visible_max || idx_highlight <= visible_max / 2)
+                 idx_first = 0;
+-
+-        idx_last = idx_first + visible_max-1;
+-
+-        refresh = TRUE;
+-        highlight = FALSE;
++        else if (idx_highlight >= config->entry_count - (visible_max / 2))
++                idx_first = config->entry_count - visible_max;
++        else
++                idx_first = idx_highlight - (visible_max / 2);
++        idx_last = idx_first + visible_max - 1;
+ 
+         /* length of the longest entry */
+         line_width = 5;
+@@ -605,7 +604,6 @@ static BOOLEAN menu_run(
+                 lines[i][x_max] = '\0';
+         }
+ 
+-        status = NULL;
+         clearline = AllocatePool((x_max+1) * sizeof(CHAR16));
+         for (UINTN i = 0; i < x_max; i++)
+                 clearline[i] = ' ';
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0016-sd-boot-Allow-automatic-entries-to-be-default.patch
+++ b/vendor/systemd-patches/0016-sd-boot-Allow-automatic-entries-to-be-default.patch
@@ -1,0 +1,86 @@
+From b3bdcabe90a2707941ebc8d21c9332a5cbd01659 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 14 Aug 2021 13:06:37 +0200
+Subject: [PATCH 16/73] sd-boot: Allow automatic entries to be default
+
+---
+ man/loader.conf.xml | 39 ++++++++++++++++++++++++++++++++++++++-
+ src/boot/efi/boot.c |  5 +----
+ 2 files changed, 39 insertions(+), 5 deletions(-)
+
+diff --git a/man/loader.conf.xml b/man/loader.conf.xml
+index 4c0355800..ffbd897a1 100644
+--- a/man/loader.conf.xml
++++ b/man/loader.conf.xml
+@@ -58,7 +58,44 @@
+         <listitem><para>A glob pattern to select the default entry. The default entry
+         may be changed in the boot menu itself, in which case the name of the
+         selected entry will be stored as an EFI variable, overriding this option.
+-        </para></listitem>
++        </para>
++
++        <table>
++          <title>Automatically detected entries will use the following names:</title>
++
++          <tgroup cols='2'>
++            <colspec colname='name' />
++            <colspec colname='expl' />
++            <thead>
++              <row>
++                <entry>Name</entry>
++                <entry>Description</entry>
++              </row>
++            </thead>
++            <tbody>
++              <row>
++                <entry>auto-efi-default</entry>
++                <entry>EFI Default Loader</entry>
++              </row>
++              <row>
++                <entry>auto-efi-shell</entry>
++                <entry>EFI Shell</entry>
++              </row>
++              <row>
++                <entry>auto-osx</entry>
++                <entry>macOS</entry>
++              </row>
++              <row>
++                <entry>auto-reboot-to-firmware-setup</entry>
++                <entry>Reboot Into Firmware Interface</entry>
++              </row>
++              <row>
++                <entry>auto-windows</entry>
++                <entry>Windows Boot Manager</entry>
++              </row>
++            </tbody>
++          </tgroup>
++        </table></listitem>
+       </varlistentry>
+ 
+       <varlistentry>
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 56cd4a489..474a7e7d3 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1590,8 +1590,7 @@ static VOID config_default_entry_select(Config *config) {
+         /*
+          * The EFI variable to select the default boot entry overrides the
+          * configured pattern. The variable can be set and cleared by pressing
+-         * the 'd' key in the loader selection menu, the entry is marked with
+-         * an '*'.
++         * the 'd' key in the loader selection menu.
+          */
+         err = efivar_get(LOADER_GUID, L"LoaderEntryDefault", &entry_default);
+         if (!EFI_ERROR(err)) {
+@@ -1615,8 +1614,6 @@ static VOID config_default_entry_select(Config *config) {
+         if (config->entry_default_pattern) {
+                 i = config->entry_count;
+                 while (i--) {
+-                        if (config->entries[i]->no_autoselect)
+-                                continue;
+                         if (MetaiMatch(config->entries[i]->id, config->entry_default_pattern)) {
+                                 config->idx_default = i;
+                                 return;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0017-sd-boot-Fix-marking-EFI-var-default-entry.patch
+++ b/vendor/systemd-patches/0017-sd-boot-Fix-marking-EFI-var-default-entry.patch
@@ -1,0 +1,66 @@
+From b37d0cd90cd761aa45831c512f1962f073b67fd8 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 14 Aug 2021 13:44:12 +0200
+Subject: [PATCH 17/73] sd-boot: Fix marking EFI var default entry
+
+Fixes: #18072
+---
+ src/boot/efi/boot.c | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 474a7e7d3..5b34cdb18 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1425,6 +1425,7 @@ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+                 .auto_entries = TRUE,
+                 .auto_firmware = TRUE,
+                 .random_seed_mode = RANDOM_SEED_WITH_SYSTEM_TOKEN,
++                .idx_default_efivar = -1,
+         };
+ 
+         err = file_read(root_dir, L"\\loader\\loader.conf", 0, 0, &content, NULL);
+@@ -1564,7 +1565,7 @@ static INTN config_entry_find(Config *config, CHAR16 *id) {
+ }
+ 
+ static VOID config_default_entry_select(Config *config) {
+-        _cleanup_freepool_ CHAR16 *entry_oneshot = NULL, *entry_default = NULL;
++        _cleanup_freepool_ CHAR16 *entry_default = NULL;
+         EFI_STATUS err;
+         INTN i;
+ 
+@@ -1574,13 +1575,11 @@ static VOID config_default_entry_select(Config *config) {
+          * The EFI variable to specify a boot entry for the next, and only the
+          * next reboot. The variable is always cleared directly after it is read.
+          */
+-        err = efivar_get(LOADER_GUID, L"LoaderEntryOneShot", &entry_oneshot);
++        err = efivar_get(LOADER_GUID, L"LoaderEntryOneShot", &config->entry_oneshot);
+         if (!EFI_ERROR(err)) {
+-
+-                config->entry_oneshot = StrDuplicate(entry_oneshot);
+                 efivar_set(LOADER_GUID, L"LoaderEntryOneShot", NULL, EFI_VARIABLE_NON_VOLATILE);
+ 
+-                i = config_entry_find(config, entry_oneshot);
++                i = config_entry_find(config, config->entry_oneshot);
+                 if (i >= 0) {
+                         config->idx_default = i;
+                         return;
+@@ -1594,7 +1593,6 @@ static VOID config_default_entry_select(Config *config) {
+          */
+         err = efivar_get(LOADER_GUID, L"LoaderEntryDefault", &entry_default);
+         if (!EFI_ERROR(err)) {
+-
+                 i = config_entry_find(config, entry_default);
+                 if (i >= 0) {
+                         config->idx_default = i;
+@@ -1602,7 +1600,6 @@ static VOID config_default_entry_select(Config *config) {
+                         return;
+                 }
+         }
+-        config->idx_default_efivar = -1;
+ 
+         if (config->entry_count == 0)
+                 return;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0018-sd-boot-Introduce-print_at-helper-function.patch
+++ b/vendor/systemd-patches/0018-sd-boot-Introduce-print_at-helper-function.patch
@@ -1,0 +1,221 @@
+From 030c6c92fddae5bc3bfd83f129f2c1a650ec8462 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 14 Aug 2021 14:02:16 +0200
+Subject: [PATCH 18/73] sd-boot: Introduce print_at helper function
+
+---
+ src/boot/efi/boot.c | 73 +++++++++++++++------------------------------
+ src/boot/efi/util.c |  7 +++++
+ src/boot/efi/util.h |  2 ++
+ 3 files changed, 33 insertions(+), 49 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 5b34cdb18..4732dfa33 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -24,6 +24,9 @@
+ /* magic string to find in the binary image */
+ static const char _used_ _section_(".sdmagic") magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
+ 
++#define COLOR_NORMAL (EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK)
++#define COLOR_HIGHLIGHT (EFI_BLACK|EFI_BACKGROUND_LIGHTGRAY)
++
+ enum loader_type {
+         LOADER_UNDEFINED,
+         LOADER_EFI,
+@@ -138,8 +141,7 @@ static BOOLEAN line_edit(
+                 }
+                 print[j] = '\0';
+ 
+-                uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_pos);
+-                uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, print);
++                print_at(0, y_pos, COLOR_NORMAL, print);
+                 uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor, y_pos);
+ 
+                 err = console_key_read(&key, 0);
+@@ -182,7 +184,6 @@ static BOOLEAN line_edit(
+                                 cursor_right(&cursor, &first, x_max, len);
+                         while (line[first + cursor] && line[first + cursor] != ' ')
+                                 cursor_right(&cursor, &first, x_max, len);
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor, y_pos);
+                         continue;
+ 
+                 case KEYPRESS(0, SCAN_UP, 0):
+@@ -196,7 +197,6 @@ static BOOLEAN line_edit(
+                         }
+                         while ((first + cursor) > 0 && line[first + cursor-1] != ' ')
+                                 cursor_left(&cursor, &first);
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor, y_pos);
+                         continue;
+ 
+                 case KEYPRESS(0, SCAN_RIGHT, 0):
+@@ -206,7 +206,6 @@ static BOOLEAN line_edit(
+                         if (first + cursor == len)
+                                 continue;
+                         cursor_right(&cursor, &first, x_max, len);
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor, y_pos);
+                         continue;
+ 
+                 case KEYPRESS(0, SCAN_LEFT, 0):
+@@ -214,7 +213,6 @@ static BOOLEAN line_edit(
+                 case KEYPRESS(EFI_CONTROL_PRESSED, 0, CHAR_CTRL('b')):
+                         /* backward-char */
+                         cursor_left(&cursor, &first);
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor, y_pos);
+                         continue;
+ 
+                 case KEYPRESS(EFI_ALT_PRESSED, 0, 'd'):
+@@ -250,7 +248,6 @@ static BOOLEAN line_edit(
+                                 cursor_left(&cursor, &first);
+                                 clear++;
+                         }
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor, y_pos);
+ 
+                         for (UINTN i = first + cursor; i + clear < len; i++)
+                                 line[i] = line[i + clear];
+@@ -375,7 +372,7 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         assert(config);
+         assert(loaded_image_path);
+ 
+-        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
++        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, COLOR_NORMAL);
+         uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+ 
+         Print(L"systemd-boot version:   " GIT_VERSION "\n");
+@@ -534,10 +531,9 @@ static BOOLEAN menu_run(
+         graphics_mode(FALSE);
+         uefi_call_wrapper(ST->ConIn->Reset, 2, ST->ConIn, FALSE);
+         uefi_call_wrapper(ST->ConOut->EnableCursor, 2, ST->ConOut, FALSE);
+-        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
+ 
+         /* draw a single character to make ClearScreen work on some firmware */
+-        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, (CHAR16*) L" ");
++        Print(L" ");
+ 
+         if (config->console_mode_change != CONSOLE_MODE_KEEP) {
+                 err = console_set_mode(&config->console_mode, config->console_mode_change);
+@@ -616,36 +612,22 @@ static BOOLEAN menu_run(
+                         for (UINTN i = 0; i < config->entry_count; i++) {
+                                 if (i < idx_first || i > idx_last)
+                                         continue;
+-                                uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_start + i - idx_first);
+-                                if (i == idx_highlight)
+-                                        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut,
+-                                                          EFI_BLACK|EFI_BACKGROUND_LIGHTGRAY);
+-                                else
+-                                        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut,
+-                                                          EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
+-                                uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, lines[i]);
+-                                if ((INTN)i == config->idx_default_efivar) {
+-                                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, x_start-3, y_start + i - idx_first);
+-                                        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, (CHAR16*) L"=>");
+-                                }
++                                print_at(0, y_start + i - idx_first,
++                                         (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_NORMAL,
++                                         lines[i]);
++                                if ((INTN)i == config->idx_default_efivar)
++                                        print_at(x_start - 3, y_start + i - idx_first,
++                                                 (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_NORMAL,
++                                                 (CHAR16*) L"=>");
+                         }
+                         refresh = FALSE;
+                 } else if (highlight) {
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_start + idx_highlight_prev - idx_first);
+-                        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
+-                        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, lines[idx_highlight_prev]);
+-                        if ((INTN)idx_highlight_prev == config->idx_default_efivar) {
+-                                uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, x_start-3, y_start + idx_highlight_prev - idx_first);
+-                                uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, (CHAR16*) L"=>");
+-                        }
+-
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_start + idx_highlight - idx_first);
+-                        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_BLACK|EFI_BACKGROUND_LIGHTGRAY);
+-                        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, lines[idx_highlight]);
+-                        if ((INTN)idx_highlight == config->idx_default_efivar) {
+-                                uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, x_start-3, y_start + idx_highlight - idx_first);
+-                                uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, (CHAR16*) L"=>");
+-                        }
++                        print_at(0, y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, lines[idx_highlight_prev]);
++                        print_at(0, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
++                        if ((INTN)idx_highlight_prev == config->idx_default_efivar)
++                                print_at(x_start-3, y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, (CHAR16*) L"=>");
++                        if ((INTN)idx_highlight == config->idx_default_efivar)
++                                print_at(x_start-3, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, (CHAR16*) L"=>");
+                         highlight = FALSE;
+                 }
+ 
+@@ -665,9 +647,7 @@ static BOOLEAN menu_run(
+                                 x = (x_max - len) / 2;
+                         else
+                                 x = 0;
+-                        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_max-1);
+-                        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, clearline + (x_max - x));
++                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + (x_max - x));
+                         uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, status);
+                         uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, clearline+1 + x + len);
+                 }
+@@ -689,9 +669,7 @@ static BOOLEAN menu_run(
+                 if (status) {
+                         FreePool(status);
+                         status = NULL;
+-                        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_max-1);
+-                        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, clearline+1);
++                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + 1);
+                 }
+ 
+                 idx_highlight_prev = idx_highlight;
+@@ -822,13 +800,10 @@ static BOOLEAN menu_run(
+                         /* only the options of configured entries can be edited */
+                         if (!config->editor || config->entries[idx_highlight]->type == LOADER_UNDEFINED)
+                                 break;
+-                        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK);
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_max-1);
+-                        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, clearline+1);
++                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + 1);
+                         if (line_edit(config->entries[idx_highlight]->options, &config->options_edit, x_max-1, y_max-1))
+                                 exit = TRUE;
+-                        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, 0, y_max-1);
+-                        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, clearline+1);
++                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + 1);
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'v'):
+@@ -877,7 +852,7 @@ static BOOLEAN menu_run(
+         FreePool(lines);
+         FreePool(clearline);
+ 
+-        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, EFI_WHITE|EFI_BACKGROUND_BLACK);
++        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, COLOR_NORMAL);
+         uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+         return run;
+ }
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index 823689e22..c0d1d6dad 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -515,3 +515,10 @@ VOID *memmem_safe(const VOID *haystack, UINTN haystack_len, const VOID *needle,
+ 
+         return NULL;
+ }
++
++VOID print_at(UINTN x, UINTN y, UINTN attr, const CHAR16 *str) {
++        assert(str);
++        uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, x, y);
++        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, attr);
++        uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, (CHAR16*)str);
++}
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index f620f1421..9eef51cc7 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -91,3 +91,5 @@ static inline VOID *mempmem_safe(const VOID *haystack, UINTN haystack_len, const
+         CHAR8 *p = memmem_safe(haystack, haystack_len, needle, needle_len);
+         return p ? p + needle_len : NULL;
+ }
++
++VOID print_at(UINTN x, UINTN y, UINTN attr, const CHAR16 *str);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0019-sd-boot-Render-title-entries-centered-and-not-to-ent.patch
+++ b/vendor/systemd-patches/0019-sd-boot-Render-title-entries-centered-and-not-to-ent.patch
@@ -1,0 +1,100 @@
+From b107b57c45a6ae982f54e8731baea322a8b14c9d Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 14 Aug 2021 14:10:35 +0200
+Subject: [PATCH 19/73] sd-boot: Render title entries centered and not to
+ entire screen width
+
+---
+ src/boot/efi/boot.c | 40 ++++++++++++++++++----------------------
+ 1 file changed, 18 insertions(+), 22 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 4732dfa33..5b2fb6482 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -515,7 +515,8 @@ static BOOLEAN menu_run(
+         UINTN idx_last;
+         BOOLEAN refresh = TRUE;
+         BOOLEAN highlight = FALSE;
+-        UINTN line_width;
++        UINTN line_width = 0;
++        UINTN entry_padding = 3;
+         CHAR16 **lines;
+         UINTN x_start;
+         UINTN y_start;
+@@ -565,16 +566,9 @@ static BOOLEAN menu_run(
+         idx_last = idx_first + visible_max - 1;
+ 
+         /* length of the longest entry */
+-        line_width = 5;
+-        for (UINTN i = 0; i < config->entry_count; i++) {
+-                UINTN entry_len;
+-
+-                entry_len = StrLen(config->entries[i]->title_show);
+-                if (line_width < entry_len)
+-                        line_width = entry_len;
+-        }
+-        if (line_width > x_max-6)
+-                line_width = x_max-6;
++        for (UINTN i = 0; i < config->entry_count; i++)
++                line_width = MAX(line_width, StrLen(config->entries[i]->title_show));
++        line_width = MIN(line_width + 2 * entry_padding, x_max);
+ 
+         /* offsets to center the entries on the screen */
+         x_start = (x_max - (line_width)) / 2;
+@@ -588,16 +582,18 @@ static BOOLEAN menu_run(
+         for (UINTN i = 0; i < config->entry_count; i++) {
+                 UINTN j;
+ 
+-                lines[i] = AllocatePool(((x_max+1) * sizeof(CHAR16)));
+-                for (j = 0; j < x_start; j++)
++                lines[i] = AllocatePool(((line_width + 1) * sizeof(CHAR16)));
++                UINTN padding = (line_width - MIN(StrLen(config->entries[i]->title_show), line_width)) / 2;
++
++                for (j = 0; j < padding; j++)
+                         lines[i][j] = ' ';
+ 
+-                for (UINTN k = 0; config->entries[i]->title_show[k] != '\0' && j < x_max; j++, k++)
++                for (UINTN k = 0; config->entries[i]->title_show[k] != '\0' && j < line_width; j++, k++)
+                         lines[i][j] = config->entries[i]->title_show[k];
+ 
+-                for (; j < x_max; j++)
++                for (; j < line_width; j++)
+                         lines[i][j] = ' ';
+-                lines[i][x_max] = '\0';
++                lines[i][line_width] = '\0';
+         }
+ 
+         clearline = AllocatePool((x_max+1) * sizeof(CHAR16));
+@@ -612,22 +608,22 @@ static BOOLEAN menu_run(
+                         for (UINTN i = 0; i < config->entry_count; i++) {
+                                 if (i < idx_first || i > idx_last)
+                                         continue;
+-                                print_at(0, y_start + i - idx_first,
++                                print_at(x_start, y_start + i - idx_first,
+                                          (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_NORMAL,
+                                          lines[i]);
+                                 if ((INTN)i == config->idx_default_efivar)
+-                                        print_at(x_start - 3, y_start + i - idx_first,
++                                        print_at(x_start, y_start + i - idx_first,
+                                                  (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_NORMAL,
+                                                  (CHAR16*) L"=>");
+                         }
+                         refresh = FALSE;
+                 } else if (highlight) {
+-                        print_at(0, y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, lines[idx_highlight_prev]);
+-                        print_at(0, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
++                        print_at(x_start, y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, lines[idx_highlight_prev]);
++                        print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
+                         if ((INTN)idx_highlight_prev == config->idx_default_efivar)
+-                                print_at(x_start-3, y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, (CHAR16*) L"=>");
++                                print_at(x_start , y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, (CHAR16*) L"=>");
+                         if ((INTN)idx_highlight == config->idx_default_efivar)
+-                                print_at(x_start-3, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, (CHAR16*) L"=>");
++                                print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, (CHAR16*) L"=>");
+                         highlight = FALSE;
+                 }
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0020-sd-boot-Improve-key-bindings.patch
+++ b/vendor/systemd-patches/0020-sd-boot-Improve-key-bindings.patch
@@ -1,0 +1,122 @@
+From c9933bb7642b2bade63b2e980c4ce79736d9bb03 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 14 Aug 2021 14:26:12 +0200
+Subject: [PATCH 20/73] sd-boot: Improve key bindings
+
+Making keys case insensitive should help if caps lock is on.
+We are not advertising them at runtime or in the manual to
+reduce the noise.
+
+This also hides the quit and version commands from the help
+string. They are mostly for devs and otherwise have little
+to no use to normal users. The latter overlaps with print
+status which is still advertised.
+---
+ man/systemd-boot.xml | 19 +++----------------
+ src/boot/efi/boot.c  |  9 ++++++++-
+ 2 files changed, 11 insertions(+), 17 deletions(-)
+
+diff --git a/man/systemd-boot.xml b/man/systemd-boot.xml
+index 5169bbbd0..d3306593e 100644
+--- a/man/systemd-boot.xml
++++ b/man/systemd-boot.xml
+@@ -108,6 +108,8 @@
+     <title>Key bindings</title>
+     <para>The following keys may be used in the boot menu:</para>
+ 
++    <!-- Developer commands Q/v/Ctrl+l deliberately not advertised. -->
++
+     <variablelist>
+       <varlistentry>
+         <term><keycap>↑</keycap> (Up)</term>
+@@ -150,31 +152,16 @@
+       </varlistentry>
+ 
+       <varlistentry>
+-        <term><keycap>v</keycap></term>
+-        <listitem><para>Show systemd-boot, UEFI, and firmware versions</para></listitem>
+-      </varlistentry>
+-
+-      <varlistentry>
+-        <term><keycap>P</keycap></term>
++        <term><keycap>p</keycap></term>
+         <listitem><para>Print status</para></listitem>
+       </varlistentry>
+ 
+-      <varlistentry>
+-        <term><keycap>Q</keycap></term>
+-        <listitem><para>Quit</para></listitem>
+-      </varlistentry>
+-
+       <varlistentry>
+         <term><keycap>h</keycap></term>
+         <term><keycap>?</keycap></term>
+         <term><keycap>F1</keycap></term>
+         <listitem><para>Show a help screen</para></listitem>
+       </varlistentry>
+-
+-      <varlistentry>
+-        <term><keycombo><keycap>Ctrl</keycap><keycap>l</keycap></keycombo></term>
+-        <listitem><para>Reprint the screen</para></listitem>
+-      </varlistentry>
+     </variablelist>
+ 
+     <para>The following keys may be pressed during bootup or in the boot menu to directly boot a specific
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 5b2fb6482..908a268a4 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -673,12 +673,14 @@ static BOOLEAN menu_run(
+                 switch (key) {
+                 case KEYPRESS(0, SCAN_UP, 0):
+                 case KEYPRESS(0, 0, 'k'):
++                case KEYPRESS(0, 0, 'K'):
+                         if (idx_highlight > 0)
+                                 idx_highlight--;
+                         break;
+ 
+                 case KEYPRESS(0, SCAN_DOWN, 0):
+                 case KEYPRESS(0, 0, 'j'):
++                case KEYPRESS(0, 0, 'J'):
+                         if (idx_highlight < config->entry_count-1)
+                                 idx_highlight++;
+                         break;
+@@ -722,8 +724,10 @@ static BOOLEAN menu_run(
+ 
+                 case KEYPRESS(0, SCAN_F1, 0):
+                 case KEYPRESS(0, 0, 'h'):
++                case KEYPRESS(0, 0, 'H'):
+                 case KEYPRESS(0, 0, '?'):
+-                        status = StrDuplicate(L"(d)efault, (t/T)timeout, (e)dit, (v)ersion (Q)uit (P)rint (h)elp");
++                        /* This must stay below 80 characters! Q/v/Ctrl+l deliberately not advertised. */
++                        status = StrDuplicate(L"(d)efault (t/T)timeout (e)dit (p)rint (h)elp");
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'Q'):
+@@ -732,6 +736,7 @@ static BOOLEAN menu_run(
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'd'):
++                case KEYPRESS(0, 0, 'D'):
+                         if (config->idx_default_efivar != (INTN)idx_highlight) {
+                                 /* store the selected entry in a persistent EFI variable */
+                                 efivar_set(
+@@ -793,6 +798,7 @@ static BOOLEAN menu_run(
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'e'):
++                case KEYPRESS(0, 0, 'E'):
+                         /* only the options of configured entries can be edited */
+                         if (!config->editor || config->entries[idx_highlight]->type == LOADER_UNDEFINED)
+                                 break;
+@@ -808,6 +814,7 @@ static BOOLEAN menu_run(
+                                            ST->FirmwareVendor, ST->FirmwareRevision >> 16, ST->FirmwareRevision & 0xffff);
+                         break;
+ 
++                case KEYPRESS(0, 0, 'p'):
+                 case KEYPRESS(0, 0, 'P'):
+                         print_status(config, loaded_image_path);
+                         refresh = TRUE;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0021-sd-boot-Add-compile-time-color-support.patch
+++ b/vendor/systemd-patches/0021-sd-boot-Add-compile-time-color-support.patch
@@ -1,0 +1,129 @@
+From f7f57b9fa27c140a2f8700368a1a9b60dd5937cd Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 14 Aug 2021 14:38:43 +0200
+Subject: [PATCH 21/73] sd-boot: Add compile-time color support
+
+Fixes: #10139
+---
+ meson_options.txt        |  8 ++++++++
+ src/boot/efi/boot.c      | 29 ++++++++++++++++-------------
+ src/boot/efi/meson.build |  7 +++++++
+ 3 files changed, 31 insertions(+), 13 deletions(-)
+
+diff --git a/meson_options.txt b/meson_options.txt
+index 2f0f4e7b8..026bddf3b 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -422,6 +422,14 @@ option('sbat-distro-version', type : 'string',
+        description : 'SBAT distribution package version, e.g. 248-7.fc34')
+ option('sbat-distro-url', type : 'string',
+        description : 'SBAT distribution URL, e.g. https://src.fedoraproject.org/rpms/systemd')
++option('efi-color-normal', type : 'string', value : 'lightgray,black',
++       description : 'general boot loader color in "foreground,background" form, see constants from eficon.h')
++option('efi-color-entry', type : 'string', value : 'lightgray,black',
++       description : 'boot loader color for entries')
++option('efi-color-highlight', type : 'string', value : 'black,lightgray',
++       description : 'boot loader color for selected entries')
++option('efi-color-edit', type : 'string', value : 'lightgray,black',
++       description : 'boot loader color for option line edit')
+ 
+ option('bashcompletiondir', type : 'string',
+        description : 'directory for bash completion scripts ["no" disables]')
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 908a268a4..549a4814e 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -24,9 +24,6 @@
+ /* magic string to find in the binary image */
+ static const char _used_ _section_(".sdmagic") magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
+ 
+-#define COLOR_NORMAL (EFI_LIGHTGRAY|EFI_BACKGROUND_BLACK)
+-#define COLOR_HIGHLIGHT (EFI_BLACK|EFI_BACKGROUND_LIGHTGRAY)
+-
+ enum loader_type {
+         LOADER_UNDEFINED,
+         LOADER_EFI,
+@@ -141,8 +138,9 @@ static BOOLEAN line_edit(
+                 }
+                 print[j] = '\0';
+ 
+-                print_at(0, y_pos, COLOR_NORMAL, print);
+-                uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor, y_pos);
++                /* See comment at call site. */
++                print_at(1, y_pos, COLOR_EDIT, print);
++                uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor + 1, y_pos);
+ 
+                 err = console_key_read(&key, 0);
+                 if (EFI_ERROR(err))
+@@ -532,6 +530,7 @@ static BOOLEAN menu_run(
+         graphics_mode(FALSE);
+         uefi_call_wrapper(ST->ConIn->Reset, 2, ST->ConIn, FALSE);
+         uefi_call_wrapper(ST->ConOut->EnableCursor, 2, ST->ConOut, FALSE);
++        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, COLOR_NORMAL);
+ 
+         /* draw a single character to make ClearScreen work on some firmware */
+         Print(L" ");
+@@ -609,19 +608,19 @@ static BOOLEAN menu_run(
+                                 if (i < idx_first || i > idx_last)
+                                         continue;
+                                 print_at(x_start, y_start + i - idx_first,
+-                                         (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_NORMAL,
++                                         (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                          lines[i]);
+                                 if ((INTN)i == config->idx_default_efivar)
+                                         print_at(x_start, y_start + i - idx_first,
+-                                                 (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_NORMAL,
++                                                 (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                                  (CHAR16*) L"=>");
+                         }
+                         refresh = FALSE;
+                 } else if (highlight) {
+-                        print_at(x_start, y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, lines[idx_highlight_prev]);
++                        print_at(x_start, y_start + idx_highlight_prev - idx_first, COLOR_ENTRY, lines[idx_highlight_prev]);
+                         print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, lines[idx_highlight]);
+                         if ((INTN)idx_highlight_prev == config->idx_default_efivar)
+-                                print_at(x_start , y_start + idx_highlight_prev - idx_first, COLOR_NORMAL, (CHAR16*) L"=>");
++                                print_at(x_start , y_start + idx_highlight_prev - idx_first, COLOR_ENTRY, (CHAR16*) L"=>");
+                         if ((INTN)idx_highlight == config->idx_default_efivar)
+                                 print_at(x_start, y_start + idx_highlight - idx_first, COLOR_HIGHLIGHT, (CHAR16*) L"=>");
+                         highlight = FALSE;
+@@ -802,10 +801,14 @@ static BOOLEAN menu_run(
+                         /* only the options of configured entries can be edited */
+                         if (!config->editor || config->entries[idx_highlight]->type == LOADER_UNDEFINED)
+                                 break;
+-                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + 1);
+-                        if (line_edit(config->entries[idx_highlight]->options, &config->options_edit, x_max-1, y_max-1))
+-                                exit = TRUE;
+-                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + 1);
++                        /* The edit line may end up on the last line of the screen. And even though we're
++                         * not telling the firmware to advance the line, it still does in this one case,
++                         * causing a scroll to happen that screws with our beautiful boot loader output.
++                         * Since we cannot paint the last character of the edit line, we simply start
++                         * at x-offset 1 for symmetry. */
++                        print_at(1, y_max - 1, COLOR_EDIT, clearline + 2);
++                        exit = line_edit(config->entries[idx_highlight]->options, &config->options_edit, x_max-2, y_max-1);
++                        print_at(1, y_max - 1, COLOR_NORMAL, clearline + 2);
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'v'):
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index efa270df6..e632006e0 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -103,6 +103,13 @@ if have_gnu_efi
+         efi_conf.set10('ENABLE_TPM', get_option('tpm'))
+         efi_conf.set('SD_TPM_PCR', get_option('tpm-pcrindex'))
+ 
++        foreach ctype : ['color-normal', 'color-entry', 'color-highlight', 'color-edit']
++                c = get_option('efi-' + ctype).split(',')
++                fg = 'EFI_' + c[0].strip().underscorify().to_upper()
++                bg = 'EFI_BACKGROUND_' + c[1].strip().underscorify().to_upper()
++                efi_conf.set(ctype.underscorify().to_upper(), '(' + fg + '|' + bg + ')')
++        endforeach
++
+         if get_option('sbat-distro') != ''
+                 efi_conf.set_quoted('SBAT_PROJECT', meson.project_name())
+                 efi_conf.set_quoted('PROJECT_VERSION', meson.project_version())
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0022-sd-boot-Draw-custom-edit-cursor.patch
+++ b/vendor/systemd-patches/0022-sd-boot-Draw-custom-edit-cursor.patch
@@ -1,0 +1,105 @@
+From 62d19b97475ad2456f710507038d81049839a690 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sun, 15 Aug 2021 13:44:35 +0200
+Subject: [PATCH 22/73] sd-boot: Draw custom edit cursor
+
+Firmware likes to draw the EFI provided cursor in a weird way that
+makes it invisible sometimes. This is even more likely to happen
+if unusual colors are picked. It also fails to draw attention to the
+user by being very small and not blinking.
+
+Additionally, to make it more clear that we are in edit mode, we
+now default to inverting the general default color and use that for
+our line edit.
+
+Fixes: #19301
+---
+ meson_options.txt   |  2 +-
+ src/boot/efi/boot.c | 28 ++++++++++++++++------------
+ 2 files changed, 17 insertions(+), 13 deletions(-)
+
+diff --git a/meson_options.txt b/meson_options.txt
+index 026bddf3b..f9a8bb6ef 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -428,7 +428,7 @@ option('efi-color-entry', type : 'string', value : 'lightgray,black',
+        description : 'boot loader color for entries')
+ option('efi-color-highlight', type : 'string', value : 'black,lightgray',
+        description : 'boot loader color for selected entries')
+-option('efi-color-edit', type : 'string', value : 'lightgray,black',
++option('efi-color-edit', type : 'string', value : 'black,lightgray',
+        description : 'boot loader color for option line edit')
+ 
+ option('bashcompletiondir', type : 'string',
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 549a4814e..13ba792b1 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -21,6 +21,8 @@
+ #define EFI_OS_INDICATIONS_BOOT_TO_FW_UI 0x0000000000000001ULL
+ #endif
+ 
++#define TEXT_ATTR_SWAP(c) EFI_TEXT_ATTR(((c) & 0b11110000) >> 4, (c) & 0b1111)
++
+ /* magic string to find in the binary image */
+ static const char _used_ _section_(".sdmagic") magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
+ 
+@@ -116,8 +118,6 @@ static BOOLEAN line_edit(
+         len = StrLen(line);
+         print = AllocatePool((x_max+1) * sizeof(CHAR16));
+ 
+-        uefi_call_wrapper(ST->ConOut->EnableCursor, 2, ST->ConOut, TRUE);
+-
+         first = 0;
+         cursor = 0;
+         clear = 0;
+@@ -127,24 +127,29 @@ static BOOLEAN line_edit(
+                 EFI_STATUS err;
+                 UINT64 key;
+                 UINTN j;
++                UINTN cursor_color = TEXT_ATTR_SWAP(COLOR_EDIT);
+ 
+-                j = len - first;
+-                if (j >= x_max-1)
+-                        j = x_max-1;
++                j = MIN(len - first, x_max);
+                 CopyMem(print, line + first, j * sizeof(CHAR16));
+-                while (clear > 0 && j < x_max-1) {
++                while (clear > 0 && j < x_max) {
+                         clear--;
+                         print[j++] = ' ';
+                 }
+                 print[j] = '\0';
+ 
+-                /* See comment at call site. */
++                /* See comment at edit_line() call site for why we start at 1. */
+                 print_at(1, y_pos, COLOR_EDIT, print);
+-                uefi_call_wrapper(ST->ConOut->SetCursorPosition, 3, ST->ConOut, cursor + 1, y_pos);
+ 
+-                err = console_key_read(&key, 0);
+-                if (EFI_ERROR(err))
+-                        continue;
++                if (!print[cursor])
++                        print[cursor] = ' ';
++                print[cursor+1] = '\0';
++                do {
++                        print_at(cursor + 1, y_pos, cursor_color, print + cursor);
++                        cursor_color = TEXT_ATTR_SWAP(cursor_color);
++
++                        err = console_key_read(&key, 750 * 1000);
++                        print_at(cursor + 1, y_pos, COLOR_EDIT, print + cursor);
++                } while (EFI_ERROR(err));
+ 
+                 switch (key) {
+                 case KEYPRESS(0, SCAN_ESC, 0):
+@@ -330,7 +335,6 @@ static BOOLEAN line_edit(
+                 }
+         }
+ 
+-        uefi_call_wrapper(ST->ConOut->EnableCursor, 2, ST->ConOut, FALSE);
+         return enter;
+ }
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0023-sd-boot-Use-UEFI-provided-CRC32.patch
+++ b/vendor/systemd-patches/0023-sd-boot-Use-UEFI-provided-CRC32.patch
@@ -1,0 +1,268 @@
+From 3c430c23ce7d058447d5f37d6e98417f007c1997 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Tue, 17 Aug 2021 11:44:21 +0200
+Subject: [PATCH 23/73] sd-boot: Use UEFI provided CRC32
+
+---
+ src/boot/efi/boot.c      |  23 +++---
+ src/boot/efi/crc32.c     | 147 ---------------------------------------
+ src/boot/efi/crc32.h     |   8 ---
+ src/boot/efi/meson.build |   2 -
+ 4 files changed, 10 insertions(+), 170 deletions(-)
+ delete mode 100644 src/boot/efi/crc32.c
+ delete mode 100644 src/boot/efi/crc32.h
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 13ba792b1..ecd18f592 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -5,7 +5,6 @@
+ #include <efilib.h>
+ 
+ #include "console.h"
+-#include "crc32.h"
+ #include "disk.h"
+ #include "efi-loader-features.h"
+ #include "graphics.h"
+@@ -2136,10 +2135,10 @@ static VOID config_load_xbootldr(
+                                 EFI_PARTITION_TABLE_HEADER gpt_header;
+                                 uint8_t space[((sizeof(EFI_PARTITION_TABLE_HEADER) + 511) / 512) * 512];
+                         } gpt_header_buffer;
+-                        const EFI_PARTITION_TABLE_HEADER *h = &gpt_header_buffer.gpt_header;
++                        EFI_PARTITION_TABLE_HEADER *h = &gpt_header_buffer.gpt_header;
+                         UINT64 where;
+                         UINTN sz;
+-                        UINT32 c;
++                        UINT32 crc32, crc32_saved;
+ 
+                         if (nr == 0)
+                                 /* Read the first copy at LBA 1 */
+@@ -2158,8 +2157,7 @@ static VOID config_load_xbootldr(
+                                 continue;
+ 
+                         /* Some superficial validation of the GPT header */
+-                        c = CompareMem(&h->Header.Signature, "EFI PART", sizeof(h->Header.Signature));
+-                        if (c != 0)
++                        if(CompareMem(&h->Header.Signature, "EFI PART", sizeof(h->Header.Signature) != 0))
+                                 continue;
+ 
+                         if (h->Header.HeaderSize < 92 ||
+@@ -2170,12 +2168,11 @@ static VOID config_load_xbootldr(
+                                 continue;
+ 
+                         /* Calculate CRC check */
+-                        c = ~crc32_exclude_offset(UINT32_MAX,
+-                                                  (const UINT8*) &gpt_header_buffer,
+-                                                  h->Header.HeaderSize,
+-                                                  OFFSETOF(EFI_PARTITION_TABLE_HEADER, Header.CRC32),
+-                                                  sizeof(h->Header.CRC32));
+-                        if (c != h->Header.CRC32)
++                        crc32_saved = h->Header.CRC32;
++                        h->Header.CRC32 = 0;
++                        r = BS->CalculateCrc32(&gpt_header_buffer, h->Header.HeaderSize, &crc32);
++                        h->Header.CRC32 = crc32_saved;
++                        if (EFI_ERROR(r) || crc32 != crc32_saved)
+                                 continue;
+ 
+                         if (h->MyLBA != where)
+@@ -2204,8 +2201,8 @@ static VOID config_load_xbootldr(
+                                 continue;
+ 
+                         /* Calculate CRC of entries array, too */
+-                        c = ~crc32(UINT32_MAX, entries, sz);
+-                        if (c != h->PartitionEntryArrayCRC32)
++                        r = BS->CalculateCrc32(&entries, sz, &crc32);
++                        if (EFI_ERROR(r) || crc32 != h->PartitionEntryArrayCRC32)
+                                 continue;
+ 
+                         for (UINTN i = 0; i < h->NumberOfPartitionEntries; i++) {
+diff --git a/src/boot/efi/crc32.c b/src/boot/efi/crc32.c
+deleted file mode 100644
+index 5130ae73d..000000000
+--- a/src/boot/efi/crc32.c
++++ /dev/null
+@@ -1,147 +0,0 @@
+-/* SPDX-License-Identifier: LicenseRef-crc32-no-restriction */
+-/* This is copied from util-linux, which in turn copied in the version from Gary S. Brown */
+-
+-/*
+- *  COPYRIGHT (C) 1986 Gary S. Brown.  You may use this program, or
+- *  code or tables extracted from it, as desired without restriction.
+- *
+- *  First, the polynomial itself and its table of feedback terms.  The
+- *  polynomial is
+- *  X^32+X^26+X^23+X^22+X^16+X^12+X^11+X^10+X^8+X^7+X^5+X^4+X^2+X^1+X^0
+- *
+- *  Note that we take it "backwards" and put the highest-order term in
+- *  the lowest-order bit.  The X^32 term is "implied"; the LSB is the
+- *  X^31 term, etc.  The X^0 term (usually shown as "+1") results in
+- *  the MSB being 1.
+- *
+- *  Note that the usual hardware shift register implementation, which
+- *  is what we're using (we're merely optimizing it by doing eight-bit
+- *  chunks at a time) shifts bits into the lowest-order term.  In our
+- *  implementation, that means shifting towards the right.  Why do we
+- *  do it this way?  Because the calculated CRC must be transmitted in
+- *  order from highest-order term to lowest-order term.  UARTs transmit
+- *  characters in order from LSB to MSB.  By storing the CRC this way,
+- *  we hand it to the UART in the order low-byte to high-byte; the UART
+- *  sends each low-bit to high-bit; and the result is transmission bit
+- *  by bit from highest- to lowest-order term without requiring any bit
+- *  shuffling on our part.  Reception works similarly.
+- *
+- *  The feedback terms table consists of 256, 32-bit entries.  Notes
+- *
+- *      The table can be generated at runtime if desired; code to do so
+- *      is shown later.  It might not be obvious, but the feedback
+- *      terms simply represent the results of eight shift/xor opera-
+- *      tions for all combinations of data and CRC register values.
+- *
+- *      The values must be right-shifted by eight bits by the "updcrc"
+- *      logic; the shift must be unsigned (bring in zeroes).  On some
+- *      hardware you could probably optimize the shift in assembler by
+- *      using byte-swap instructions.
+- *      polynomial $edb88320
+- *
+- */
+-
+-#include "crc32.h"
+-#include "macro-fundamental.h"
+-
+-static const UINT32 crc32_tab[] = {
+-        0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
+-        0x706af48fL, 0xe963a535L, 0x9e6495a3L, 0x0edb8832L, 0x79dcb8a4L,
+-        0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L,
+-        0x90bf1d91L, 0x1db71064L, 0x6ab020f2L, 0xf3b97148L, 0x84be41deL,
+-        0x1adad47dL, 0x6ddde4ebL, 0xf4d4b551L, 0x83d385c7L, 0x136c9856L,
+-        0x646ba8c0L, 0xfd62f97aL, 0x8a65c9ecL, 0x14015c4fL, 0x63066cd9L,
+-        0xfa0f3d63L, 0x8d080df5L, 0x3b6e20c8L, 0x4c69105eL, 0xd56041e4L,
+-        0xa2677172L, 0x3c03e4d1L, 0x4b04d447L, 0xd20d85fdL, 0xa50ab56bL,
+-        0x35b5a8faL, 0x42b2986cL, 0xdbbbc9d6L, 0xacbcf940L, 0x32d86ce3L,
+-        0x45df5c75L, 0xdcd60dcfL, 0xabd13d59L, 0x26d930acL, 0x51de003aL,
+-        0xc8d75180L, 0xbfd06116L, 0x21b4f4b5L, 0x56b3c423L, 0xcfba9599L,
+-        0xb8bda50fL, 0x2802b89eL, 0x5f058808L, 0xc60cd9b2L, 0xb10be924L,
+-        0x2f6f7c87L, 0x58684c11L, 0xc1611dabL, 0xb6662d3dL, 0x76dc4190L,
+-        0x01db7106L, 0x98d220bcL, 0xefd5102aL, 0x71b18589L, 0x06b6b51fL,
+-        0x9fbfe4a5L, 0xe8b8d433L, 0x7807c9a2L, 0x0f00f934L, 0x9609a88eL,
+-        0xe10e9818L, 0x7f6a0dbbL, 0x086d3d2dL, 0x91646c97L, 0xe6635c01L,
+-        0x6b6b51f4L, 0x1c6c6162L, 0x856530d8L, 0xf262004eL, 0x6c0695edL,
+-        0x1b01a57bL, 0x8208f4c1L, 0xf50fc457L, 0x65b0d9c6L, 0x12b7e950L,
+-        0x8bbeb8eaL, 0xfcb9887cL, 0x62dd1ddfL, 0x15da2d49L, 0x8cd37cf3L,
+-        0xfbd44c65L, 0x4db26158L, 0x3ab551ceL, 0xa3bc0074L, 0xd4bb30e2L,
+-        0x4adfa541L, 0x3dd895d7L, 0xa4d1c46dL, 0xd3d6f4fbL, 0x4369e96aL,
+-        0x346ed9fcL, 0xad678846L, 0xda60b8d0L, 0x44042d73L, 0x33031de5L,
+-        0xaa0a4c5fL, 0xdd0d7cc9L, 0x5005713cL, 0x270241aaL, 0xbe0b1010L,
+-        0xc90c2086L, 0x5768b525L, 0x206f85b3L, 0xb966d409L, 0xce61e49fL,
+-        0x5edef90eL, 0x29d9c998L, 0xb0d09822L, 0xc7d7a8b4L, 0x59b33d17L,
+-        0x2eb40d81L, 0xb7bd5c3bL, 0xc0ba6cadL, 0xedb88320L, 0x9abfb3b6L,
+-        0x03b6e20cL, 0x74b1d29aL, 0xead54739L, 0x9dd277afL, 0x04db2615L,
+-        0x73dc1683L, 0xe3630b12L, 0x94643b84L, 0x0d6d6a3eL, 0x7a6a5aa8L,
+-        0xe40ecf0bL, 0x9309ff9dL, 0x0a00ae27L, 0x7d079eb1L, 0xf00f9344L,
+-        0x8708a3d2L, 0x1e01f268L, 0x6906c2feL, 0xf762575dL, 0x806567cbL,
+-        0x196c3671L, 0x6e6b06e7L, 0xfed41b76L, 0x89d32be0L, 0x10da7a5aL,
+-        0x67dd4accL, 0xf9b9df6fL, 0x8ebeeff9L, 0x17b7be43L, 0x60b08ed5L,
+-        0xd6d6a3e8L, 0xa1d1937eL, 0x38d8c2c4L, 0x4fdff252L, 0xd1bb67f1L,
+-        0xa6bc5767L, 0x3fb506ddL, 0x48b2364bL, 0xd80d2bdaL, 0xaf0a1b4cL,
+-        0x36034af6L, 0x41047a60L, 0xdf60efc3L, 0xa867df55L, 0x316e8eefL,
+-        0x4669be79L, 0xcb61b38cL, 0xbc66831aL, 0x256fd2a0L, 0x5268e236L,
+-        0xcc0c7795L, 0xbb0b4703L, 0x220216b9L, 0x5505262fL, 0xc5ba3bbeL,
+-        0xb2bd0b28L, 0x2bb45a92L, 0x5cb36a04L, 0xc2d7ffa7L, 0xb5d0cf31L,
+-        0x2cd99e8bL, 0x5bdeae1dL, 0x9b64c2b0L, 0xec63f226L, 0x756aa39cL,
+-        0x026d930aL, 0x9c0906a9L, 0xeb0e363fL, 0x72076785L, 0x05005713L,
+-        0x95bf4a82L, 0xe2b87a14L, 0x7bb12baeL, 0x0cb61b38L, 0x92d28e9bL,
+-        0xe5d5be0dL, 0x7cdcefb7L, 0x0bdbdf21L, 0x86d3d2d4L, 0xf1d4e242L,
+-        0x68ddb3f8L, 0x1fda836eL, 0x81be16cdL, 0xf6b9265bL, 0x6fb077e1L,
+-        0x18b74777L, 0x88085ae6L, 0xff0f6a70L, 0x66063bcaL, 0x11010b5cL,
+-        0x8f659effL, 0xf862ae69L, 0x616bffd3L, 0x166ccf45L, 0xa00ae278L,
+-        0xd70dd2eeL, 0x4e048354L, 0x3903b3c2L, 0xa7672661L, 0xd06016f7L,
+-        0x4969474dL, 0x3e6e77dbL, 0xaed16a4aL, 0xd9d65adcL, 0x40df0b66L,
+-        0x37d83bf0L, 0xa9bcae53L, 0xdebb9ec5L, 0x47b2cf7fL, 0x30b5ffe9L,
+-        0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L,
+-        0xcdd70693L, 0x54de5729L, 0x23d967bfL, 0xb3667a2eL, 0xc4614ab8L,
+-        0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL,
+-        0x2d02ef8dL
+-};
+-
+-static inline UINT32 crc32_add_char(UINT32 crc, UINT8 c) {
+-        return crc32_tab[(crc ^ c) & 0xff] ^ (crc >> 8);
+-}
+-
+-/*
+- * This a generic crc32() function, it takes seed as an argument,
+- * and does __not__ xor at the end. Then individual users can do
+- * whatever they need.
+- */
+-UINT32 crc32(UINT32 seed, const VOID *buf, UINTN len) {
+-        const UINT8 *p = buf;
+-        UINT32 crc = seed;
+-
+-        assert(buf);
+-
+-        while (len > 0) {
+-                crc = crc32_add_char(crc, *p++);
+-                len--;
+-        }
+-
+-        return crc;
+-}
+-
+-UINT32 crc32_exclude_offset(
+-                UINT32 seed,
+-                const VOID *buf,
+-                UINTN len,
+-                UINTN exclude_off,
+-                UINTN exclude_len) {
+-
+-        const UINT8 *p = buf;
+-        UINT32 crc = seed;
+-
+-        assert(buf);
+-
+-        for (UINTN i = 0; i < len; i++) {
+-                UINT8 x = *p++;
+-
+-                if (i >= exclude_off && i < exclude_off + exclude_len)
+-                        x = 0;
+-
+-                crc = crc32_add_char(crc, x);
+-        }
+-
+-        return crc;
+-}
+diff --git a/src/boot/efi/crc32.h b/src/boot/efi/crc32.h
+deleted file mode 100644
+index 3af543b84..000000000
+--- a/src/boot/efi/crc32.h
++++ /dev/null
+@@ -1,8 +0,0 @@
+-/* SPDX-License-Identifier: LicenseRef-crc32-no-restriction */
+-#pragma once
+-
+-#include <efi.h>
+-#include <efilib.h>
+-
+-UINT32 crc32(UINT32 seed, const VOID *buf, UINTN len);
+-UINT32 crc32_exclude_offset(UINT32 seed, const VOID *buf, UINTN len, UINTN exclude_off, UINTN exclude_len);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index e632006e0..e6e6f35ae 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -2,7 +2,6 @@
+ 
+ efi_headers = files('''
+         console.h
+-        crc32.h
+         disk.h
+         graphics.h
+         linux.h
+@@ -29,7 +28,6 @@ common_sources = '''
+ systemd_boot_sources = '''
+         boot.c
+         console.c
+-        crc32.c
+         random-seed.c
+         sha256.c
+         shim.c
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0024-efi-make-EFI_GUID-generally-constant.patch
+++ b/vendor/systemd-patches/0024-efi-make-EFI_GUID-generally-constant.patch
@@ -1,0 +1,278 @@
+From 812f0757c97ca118e6db91538f5b53d1b0488b25 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Wed, 1 Sep 2021 11:33:06 +0200
+Subject: [PATCH 24/73] efi: make EFI_GUID generally constant
+
+The GUIDs we usually deal with should be considered constant. Hence make
+them so. Unfortunately the prototypes for various functions doesn't mark
+them as const (but still decorates them with "IN", clarifying they are
+input-only), hence we need to cast things at various places. We already
+cast in similar fashion in many other cases, hence unify things here in
+one style.
+
+Making the EFI_GUID constant (and in particular so when specified in C99
+compound literal style) allows compilers to merge multiple instances of
+them.
+---
+ src/boot/efi/boot.c        |  6 +++---
+ src/boot/efi/console.c     |  9 +++++----
+ src/boot/efi/graphics.c    |  4 ++--
+ src/boot/efi/measure.c     |  8 ++++----
+ src/boot/efi/random-seed.c |  4 ++--
+ src/boot/efi/shim.c        | 18 +++++++++---------
+ src/boot/efi/splash.c      |  4 ++--
+ src/boot/efi/util.c        |  2 +-
+ 8 files changed, 28 insertions(+), 27 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index ecd18f592..bf27309d6 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1185,7 +1185,7 @@ static VOID config_entry_bump_counters(
+ 
+         _cleanup_freepool_ CHAR16* old_path = NULL, *new_path = NULL;
+         _cleanup_(FileHandleClosep) EFI_FILE_HANDLE handle = NULL;
+-        static EFI_GUID EfiFileInfoGuid = EFI_FILE_INFO_ID;
++        static const EFI_GUID EfiFileInfoGuid = EFI_FILE_INFO_ID;
+         _cleanup_freepool_ EFI_FILE_INFO *file_info = NULL;
+         UINTN file_info_size, a, b;
+         EFI_STATUS r;
+@@ -1213,7 +1213,7 @@ static VOID config_entry_bump_counters(
+         for (;;) {
+                 file_info = AllocatePool(file_info_size);
+ 
+-                r = uefi_call_wrapper(handle->GetInfo, 4, handle, &EfiFileInfoGuid, &file_info_size, file_info);
++                r = uefi_call_wrapper(handle->GetInfo, 4, handle, (EFI_GUID*) &EfiFileInfoGuid, &file_info_size, file_info);
+                 if (!EFI_ERROR(r))
+                         break;
+ 
+@@ -1228,7 +1228,7 @@ static VOID config_entry_bump_counters(
+ 
+         /* And rename the file */
+         StrCpy(file_info->FileName, entry->next_name);
+-        r = uefi_call_wrapper(handle->SetInfo, 4, handle, &EfiFileInfoGuid, file_info_size, file_info);
++        r = uefi_call_wrapper(handle->SetInfo, 4, handle, (EFI_GUID*) &EfiFileInfoGuid, file_info_size, file_info);
+         if (EFI_ERROR(r)) {
+                 log_error_stall(L"Failed to rename '%s' to '%s', ignoring: %r", old_path, entry->next_name, r);
+                 return;
+diff --git a/src/boot/efi/console.c b/src/boot/efi/console.c
+index 3f405113b..12d3047ac 100644
+--- a/src/boot/efi/console.c
++++ b/src/boot/efi/console.c
+@@ -9,7 +9,8 @@
+ #define SYSTEM_FONT_WIDTH 8
+ #define SYSTEM_FONT_HEIGHT 19
+ 
+-#define EFI_SIMPLE_TEXT_INPUT_EX_GUID &(EFI_GUID) EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID
++#define EFI_SIMPLE_TEXT_INPUT_EX_GUID                           \
++        &(const EFI_GUID) EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID
+ 
+ static inline void EventClosep(EFI_EVENT *event) {
+         if (!*event)
+@@ -46,7 +47,7 @@ EFI_STATUS console_key_read(UINT64 *key, UINT64 timeout_usec) {
+         assert(key);
+ 
+         if (!checked) {
+-                err = LibLocateProtocol(EFI_SIMPLE_TEXT_INPUT_EX_GUID, (VOID **)&TextInputEx);
++                err = LibLocateProtocol((EFI_GUID*) EFI_SIMPLE_TEXT_INPUT_EX_GUID, (VOID **)&TextInputEx);
+                 if (EFI_ERROR(err) ||
+                     uefi_call_wrapper(BS->CheckEvent, 1, TextInputEx->WaitForKeyEx) == EFI_INVALID_PARAMETER)
+                         /* If WaitForKeyEx fails here, the firmware pretends it talks this
+@@ -148,7 +149,7 @@ static EFI_STATUS mode_auto(UINTN *mode) {
+         const UINT32 VERTICAL_MAX_OK = 1080;
+         const UINT64 VIEWPORT_RATIO = 10;
+         UINT64 screen_area, text_area;
+-        EFI_GUID GraphicsOutputProtocolGuid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
++        static const EFI_GUID GraphicsOutputProtocolGuid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
+         EFI_GRAPHICS_OUTPUT_PROTOCOL *GraphicsOutput;
+         EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *Info;
+         EFI_STATUS err;
+@@ -156,7 +157,7 @@ static EFI_STATUS mode_auto(UINTN *mode) {
+ 
+         assert(mode);
+ 
+-        err = LibLocateProtocol(&GraphicsOutputProtocolGuid, (VOID **)&GraphicsOutput);
++        err = LibLocateProtocol((EFI_GUID*) &GraphicsOutputProtocolGuid, (VOID **)&GraphicsOutput);
+         if (!EFI_ERROR(err) && GraphicsOutput->Mode && GraphicsOutput->Mode->Info) {
+                 Info = GraphicsOutput->Mode->Info;
+ 
+diff --git a/src/boot/efi/graphics.c b/src/boot/efi/graphics.c
+index ddfe68cc7..3f6f3f75c 100644
+--- a/src/boot/efi/graphics.c
++++ b/src/boot/efi/graphics.c
+@@ -11,7 +11,7 @@
+ #include "util.h"
+ 
+ #define EFI_CONSOLE_CONTROL_GUID \
+-        &(EFI_GUID) { 0xf42f7782, 0x12e, 0x4c12, { 0x99, 0x56, 0x49, 0xf9, 0x43, 0x4, 0xf7, 0x21 } }
++        &(const EFI_GUID) { 0xf42f7782, 0x12e, 0x4c12, { 0x99, 0x56, 0x49, 0xf9, 0x43, 0x4, 0xf7, 0x21 } }
+ 
+ EFI_STATUS graphics_mode(BOOLEAN on) {
+ 
+@@ -53,7 +53,7 @@ EFI_STATUS graphics_mode(BOOLEAN on) {
+         BOOLEAN stdin_locked;
+         EFI_STATUS err;
+ 
+-        err = LibLocateProtocol(EFI_CONSOLE_CONTROL_GUID, (VOID **)&ConsoleControl);
++        err = LibLocateProtocol((EFI_GUID*) EFI_CONSOLE_CONTROL_GUID, (VOID **)&ConsoleControl);
+         if (EFI_ERROR(err))
+                 /* console control protocol is nonstandard and might not exist. */
+                 return err == EFI_NOT_FOUND ? EFI_SUCCESS : err;
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index 1d19366f7..3e64ab6be 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -9,7 +9,7 @@
+ #include "measure.h"
+ 
+ #define EFI_TCG_GUID \
+-        &(EFI_GUID) { 0xf541796d, 0xa62e, 0x4954, { 0xa7, 0x75, 0x95, 0x84, 0xf6, 0x1b, 0x9c, 0xdd } }
++        &(const EFI_GUID) { 0xf541796d, 0xa62e, 0x4954, { 0xa7, 0x75, 0x95, 0x84, 0xf6, 0x1b, 0x9c, 0xdd } }
+ 
+ typedef struct _TCG_VERSION {
+         UINT8 Major;
+@@ -104,7 +104,7 @@ typedef struct _EFI_TCG {
+ } EFI_TCG;
+ 
+ #define EFI_TCG2_GUID \
+-        &(EFI_GUID) { 0x607f766c, 0x7455, 0x42be, { 0x93, 0x0b, 0xe4, 0xd7, 0x6d, 0xb2, 0x72, 0x0f } }
++        &(const EFI_GUID) { 0x607f766c, 0x7455, 0x42be, { 0x93, 0x0b, 0xe4, 0xd7, 0x6d, 0xb2, 0x72, 0x0f } }
+ 
+ typedef struct tdEFI_TCG2_PROTOCOL EFI_TCG2_PROTOCOL;
+ 
+@@ -253,7 +253,7 @@ static EFI_TCG * tcg1_interface_check(void) {
+         EFI_PHYSICAL_ADDRESS event_log_location;
+         EFI_PHYSICAL_ADDRESS event_log_last_entry;
+ 
+-        status = LibLocateProtocol(EFI_TCG_GUID, (void **) &tcg);
++        status = LibLocateProtocol((EFI_GUID*) EFI_TCG_GUID, (void **) &tcg);
+ 
+         if (EFI_ERROR(status))
+                 return NULL;
+@@ -278,7 +278,7 @@ static EFI_TCG2 * tcg2_interface_check(void) {
+         EFI_TCG2 *tcg;
+         EFI_TCG2_BOOT_SERVICE_CAPABILITY capability;
+ 
+-        status = LibLocateProtocol(EFI_TCG2_GUID, (void **) &tcg);
++        status = LibLocateProtocol((EFI_GUID*) EFI_TCG2_GUID, (void **) &tcg);
+ 
+         if (EFI_ERROR(status))
+                 return NULL;
+diff --git a/src/boot/efi/random-seed.c b/src/boot/efi/random-seed.c
+index 55348a64e..d20923eac 100644
+--- a/src/boot/efi/random-seed.c
++++ b/src/boot/efi/random-seed.c
+@@ -12,7 +12,7 @@
+ #define RANDOM_MAX_SIZE_MIN (32U)
+ #define RANDOM_MAX_SIZE_MAX (32U*1024U)
+ 
+-#define EFI_RNG_GUID &(EFI_GUID) EFI_RNG_PROTOCOL_GUID
++#define EFI_RNG_GUID &(const EFI_GUID) EFI_RNG_PROTOCOL_GUID
+ 
+ /* SHA256 gives us 256/8=32 bytes */
+ #define HASH_VALUE_SIZE 32
+@@ -26,7 +26,7 @@ static EFI_STATUS acquire_rng(UINTN size, VOID **ret) {
+ 
+         /* Try to acquire the specified number of bytes from the UEFI RNG */
+ 
+-        err = LibLocateProtocol(EFI_RNG_GUID, (VOID**) &rng);
++        err = LibLocateProtocol((EFI_GUID*) EFI_RNG_GUID, (VOID**) &rng);
+         if (EFI_ERROR(err))
+                 return err;
+         if (!rng)
+diff --git a/src/boot/efi/shim.c b/src/boot/efi/shim.c
+index 9bcbb3476..849598f1c 100644
+--- a/src/boot/efi/shim.c
++++ b/src/boot/efi/shim.c
+@@ -30,18 +30,18 @@ struct ShimLock {
+         EFI_STATUS __sysv_abi__ (*read_header) (VOID *data, UINT32 datasize, VOID *context);
+ };
+ 
+-#define SIMPLE_FS_GUID &(EFI_GUID) SIMPLE_FILE_SYSTEM_PROTOCOL
++#define SIMPLE_FS_GUID &(const EFI_GUID) SIMPLE_FILE_SYSTEM_PROTOCOL
+ #define SECURITY_PROTOCOL_GUID \
+-        &(EFI_GUID) { 0xa46423e3, 0x4617, 0x49f1, { 0xb9, 0xff, 0xd1, 0xbf, 0xa9, 0x11, 0x58, 0x39 } }
++        &(const EFI_GUID) { 0xa46423e3, 0x4617, 0x49f1, { 0xb9, 0xff, 0xd1, 0xbf, 0xa9, 0x11, 0x58, 0x39 } }
+ #define SECURITY_PROTOCOL2_GUID \
+-        &(EFI_GUID) { 0x94ab2f58, 0x1438, 0x4ef1, { 0x91, 0x52, 0x18, 0x94, 0x1a, 0x3a, 0x0e, 0x68 } }
++        &(const EFI_GUID) { 0x94ab2f58, 0x1438, 0x4ef1, { 0x91, 0x52, 0x18, 0x94, 0x1a, 0x3a, 0x0e, 0x68 } }
+ #define SHIM_LOCK_GUID \
+-        &(EFI_GUID) { 0x605dab50, 0xe046, 0x4300, { 0xab, 0xb6, 0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23 } }
++        &(const EFI_GUID) { 0x605dab50, 0xe046, 0x4300, { 0xab, 0xb6, 0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23 } }
+ 
+ BOOLEAN shim_loaded(void) {
+         struct ShimLock *shim_lock;
+ 
+-        return uefi_call_wrapper(BS->LocateProtocol, 3, SHIM_LOCK_GUID, NULL, (VOID**) &shim_lock) == EFI_SUCCESS;
++        return uefi_call_wrapper(BS->LocateProtocol, 3, (EFI_GUID*) SHIM_LOCK_GUID, NULL, (VOID**) &shim_lock) == EFI_SUCCESS;
+ }
+ 
+ static BOOLEAN shim_validate(VOID *data, UINT32 size) {
+@@ -50,7 +50,7 @@ static BOOLEAN shim_validate(VOID *data, UINT32 size) {
+         if (!data)
+                 return FALSE;
+ 
+-        if (uefi_call_wrapper(BS->LocateProtocol, 3, SHIM_LOCK_GUID, NULL, (VOID**) &shim_lock) != EFI_SUCCESS)
++        if (uefi_call_wrapper(BS->LocateProtocol, 3, (EFI_GUID*) SHIM_LOCK_GUID, NULL, (VOID**) &shim_lock) != EFI_SUCCESS)
+                 return FALSE;
+ 
+         if (!shim_lock)
+@@ -155,7 +155,7 @@ static EFIAPI EFI_STATUS security_policy_authentication (const EFI_SECURITY_PROT
+ 
+         dev_path = DuplicateDevicePath((EFI_DEVICE_PATH*) device_path_const);
+ 
+-        status = uefi_call_wrapper(BS->LocateDevicePath, 3, SIMPLE_FS_GUID, &dev_path, &h);
++        status = uefi_call_wrapper(BS->LocateDevicePath, 3, (EFI_GUID*) SIMPLE_FS_GUID, &dev_path, &h);
+         if (status != EFI_SUCCESS)
+                 return status;
+ 
+@@ -189,9 +189,9 @@ EFI_STATUS security_policy_install(void) {
+          * to fail, since SECURITY2 was introduced in PI 1.2.1.
+          * Use security2_protocol == NULL as indicator.
+          */
+-        uefi_call_wrapper(BS->LocateProtocol, 3, SECURITY_PROTOCOL2_GUID, NULL, (VOID**) &security2_protocol);
++        uefi_call_wrapper(BS->LocateProtocol, 3, (EFI_GUID*) SECURITY_PROTOCOL2_GUID, NULL, (VOID**) &security2_protocol);
+ 
+-        status = uefi_call_wrapper(BS->LocateProtocol, 3, SECURITY_PROTOCOL_GUID, NULL, (VOID**) &security_protocol);
++        status = uefi_call_wrapper(BS->LocateProtocol, 3, (EFI_GUID*) SECURITY_PROTOCOL_GUID, NULL, (VOID**) &security_protocol);
+          /* This one is mandatory, so there's a serious problem */
+         if (status != EFI_SUCCESS)
+                 return status;
+diff --git a/src/boot/efi/splash.c b/src/boot/efi/splash.c
+index 23627a794..0286a5a90 100644
+--- a/src/boot/efi/splash.c
++++ b/src/boot/efi/splash.c
+@@ -248,7 +248,7 @@ static EFI_STATUS bmp_to_blt(EFI_GRAPHICS_OUTPUT_BLT_PIXEL *buf,
+ 
+ EFI_STATUS graphics_splash(UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_BLT_PIXEL *background) {
+         EFI_GRAPHICS_OUTPUT_BLT_PIXEL pixel = {};
+-        EFI_GUID GraphicsOutputProtocolGuid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
++        static const EFI_GUID GraphicsOutputProtocolGuid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
+         EFI_GRAPHICS_OUTPUT_PROTOCOL *GraphicsOutput = NULL;
+         struct bmp_dib *dib;
+         struct bmp_map *map;
+@@ -270,7 +270,7 @@ EFI_STATUS graphics_splash(UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_
+                 background = &pixel;
+         }
+ 
+-        err = LibLocateProtocol(&GraphicsOutputProtocolGuid, (VOID **)&GraphicsOutput);
++        err = LibLocateProtocol((EFI_GUID*) &GraphicsOutputProtocolGuid, (VOID **)&GraphicsOutput);
+         if (EFI_ERROR(err))
+                 return err;
+ 
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index c0d1d6dad..b78408e1a 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -101,7 +101,7 @@ EFI_STATUS efivar_set_raw(const EFI_GUID *vendor, const CHAR16 *name, const VOID
+         assert(buf || size == 0);
+ 
+         flags |= EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS;
+-        return uefi_call_wrapper(RT->SetVariable, 5, (CHAR16*) name, (EFI_GUID *)vendor, flags, size, (VOID*) buf);
++        return uefi_call_wrapper(RT->SetVariable, 5, (CHAR16*) name, (EFI_GUID *) vendor, flags, size, (VOID*) buf);
+ }
+ 
+ EFI_STATUS efivar_set(const EFI_GUID *vendor, const CHAR16 *name, const CHAR16 *value, UINT32 flags) {
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0025-efi-drop-spaces-between-function-name-and.patch
+++ b/vendor/systemd-patches/0025-efi-drop-spaces-between-function-name-and.patch
@@ -1,0 +1,117 @@
+From 31e4e3c58b8342f416e86d0e777df1bc6fcc7977 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Wed, 1 Sep 2021 14:40:33 +0200
+Subject: [PATCH 25/73] efi: drop spaces between function name and "("
+
+When pulling in the SHA256 implementation from glibc, only some of the
+coding style was adjusted to ours, other was not. Let's make things a
+bit more consistent.
+---
+ src/boot/efi/sha256.c | 38 +++++++++++++++++++-------------------
+ 1 file changed, 19 insertions(+), 19 deletions(-)
+
+diff --git a/src/boot/efi/sha256.c b/src/boot/efi/sha256.c
+index 5df7e5316..d2e267eef 100644
+--- a/src/boot/efi/sha256.c
++++ b/src/boot/efi/sha256.c
+@@ -106,19 +106,19 @@ void *sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf) {
+         ctx->total64 += bytes;
+ 
+         pad = bytes >= 56 ? 64 + 56 - bytes : 56 - bytes;
+-        CopyMem (&ctx->buffer[bytes], fillbuf, pad);
++        CopyMem(&ctx->buffer[bytes], fillbuf, pad);
+ 
+         /* Put the 64-bit file length in *bits* at the end of the buffer.  */
+-        ctx->buffer32[(bytes + pad + 4) / 4] = SWAP (ctx->total[TOTAL64_low] << 3);
+-        ctx->buffer32[(bytes + pad) / 4] = SWAP ((ctx->total[TOTAL64_high] << 3)
+-                                                 | (ctx->total[TOTAL64_low] >> 29));
++        ctx->buffer32[(bytes + pad + 4) / 4] = SWAP(ctx->total[TOTAL64_low] << 3);
++        ctx->buffer32[(bytes + pad) / 4] = SWAP((ctx->total[TOTAL64_high] << 3)
++                                                | (ctx->total[TOTAL64_low] >> 29));
+ 
+         /* Process last bytes.  */
+-        sha256_process_block (ctx->buffer, bytes + pad + 8, ctx);
++        sha256_process_block(ctx->buffer, bytes + pad + 8, ctx);
+ 
+         /* Put result from CTX in first 32 bytes following RESBUF.  */
+         for (UINTN i = 0; i < 8; ++i)
+-                ((UINT32 *) resbuf)[i] = SWAP (ctx->H[i]);
++                ((UINT32 *) resbuf)[i] = SWAP(ctx->H[i]);
+ 
+         return resbuf;
+ }
+@@ -134,15 +134,15 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+                 UINTN left_over = ctx->buflen;
+                 UINTN add = 128 - left_over > len ? len : 128 - left_over;
+ 
+-                CopyMem (&ctx->buffer[left_over], buffer, add);
++                CopyMem(&ctx->buffer[left_over], buffer, add);
+                 ctx->buflen += add;
+ 
+                 if (ctx->buflen > 64) {
+-                        sha256_process_block (ctx->buffer, ctx->buflen & ~63, ctx);
++                        sha256_process_block(ctx->buffer, ctx->buflen & ~63, ctx);
+ 
+                         ctx->buflen &= 63;
+                         /* The regions in the following copy operation cannot overlap.  */
+-                        CopyMem (ctx->buffer, &ctx->buffer[(left_over + add) & ~63],
++                        CopyMem(ctx->buffer, &ctx->buffer[(left_over + add) & ~63],
+                                 ctx->buflen);
+                 }
+ 
+@@ -159,21 +159,21 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+ 
+ /* To check alignment gcc has an appropriate operator. Other compilers don't.  */
+ # if __GNUC__ >= 2
+-#  define UNALIGNED_P(p) (((UINTN) p) % __alignof__ (UINT32) != 0)
++#  define UNALIGNED_P(p) (((UINTN) p) % __alignof__(UINT32) != 0)
+ # else
+-#  define UNALIGNED_P(p) (((UINTN) p) % sizeof (UINT32) != 0)
++#  define UNALIGNED_P(p) (((UINTN) p) % sizeof(UINT32) != 0)
+ # endif
+-                if (UNALIGNED_P (buffer))
++                if (UNALIGNED_P(buffer))
+                         while (len > 64) {
+-                                CopyMem (ctx->buffer, buffer, 64);
+-                                sha256_process_block (ctx->buffer, 64, ctx);
++                                CopyMem(ctx->buffer, buffer, 64);
++                                sha256_process_block(ctx->buffer, 64, ctx);
+                                 buffer = (const char *) buffer + 64;
+                                 len -= 64;
+                         }
+                 else
+ #endif
+                 {
+-                        sha256_process_block (buffer, len & ~63, ctx);
++                        sha256_process_block(buffer, len & ~63, ctx);
+                         buffer = (const char *) buffer + (len & ~63);
+                         len &= 63;
+                 }
+@@ -183,12 +183,12 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+         if (len > 0) {
+                 UINTN left_over = ctx->buflen;
+ 
+-                CopyMem (&ctx->buffer[left_over], buffer, len);
++                CopyMem(&ctx->buffer[left_over], buffer, len);
+                 left_over += len;
+                 if (left_over >= 64) {
+-                        sha256_process_block (ctx->buffer, 64, ctx);
++                        sha256_process_block(ctx->buffer, 64, ctx);
+                         left_over -= 64;
+-                        CopyMem (ctx->buffer, &ctx->buffer[64], left_over);
++                        CopyMem(ctx->buffer, &ctx->buffer[64], left_over);
+                 }
+                 ctx->buflen = left_over;
+         }
+@@ -199,7 +199,7 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+    It is assumed that LEN % 64 == 0.  */
+ static void sha256_process_block(const void *buffer, UINTN len, struct sha256_ctx *ctx) {
+         const UINT32 *words = buffer;
+-        UINTN nwords = len / sizeof (UINT32);
++        UINTN nwords = len / sizeof(UINT32);
+ 
+         assert(buffer);
+         assert(ctx);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0026-sd-boot-Support-installing-new-devicetree.patch
+++ b/vendor/systemd-patches/0026-sd-boot-Support-installing-new-devicetree.patch
@@ -1,0 +1,327 @@
+From abc7f7f8d6bb6a0857016cb26261ccd29bd6b212 Mon Sep 17 00:00:00 2001
+From: Emil Renner Berthing <systemd@esmil.dk>
+Date: Sat, 24 Apr 2021 23:38:28 +0000
+Subject: [PATCH 26/73] sd-boot: Support installing new devicetree
+
+The Bootloader Specification says "devicetree refers to the binary
+device tree to use when executing the kernel..", but systemd-boot
+didn't actually do anything when encountering this stanza until now.
+
+Add support for loading, applying fixups if relevant, and installing the
+new device tree before executing the kernel.
+---
+ src/boot/efi/boot.c        |  21 +++++-
+ src/boot/efi/devicetree.c  | 131 +++++++++++++++++++++++++++++++++++++
+ src/boot/efi/devicetree.h  |  11 ++++
+ src/boot/efi/meson.build   |   2 +
+ src/boot/efi/missing_efi.h |  36 ++++++++++
+ 5 files changed, 200 insertions(+), 1 deletion(-)
+ create mode 100644 src/boot/efi/devicetree.c
+ create mode 100644 src/boot/efi/devicetree.h
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index bf27309d6..50a17e0a7 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -5,6 +5,7 @@
+ #include <efilib.h>
+ 
+ #include "console.h"
++#include "devicetree.h"
+ #include "disk.h"
+ #include "efi-loader-features.h"
+ #include "graphics.h"
+@@ -40,6 +41,7 @@ typedef struct {
+         EFI_HANDLE *device;
+         enum loader_type type;
+         CHAR16 *loader;
++        CHAR16 *devicetree;
+         CHAR16 *options;
+         CHAR16 key;
+         EFI_STATUS (*call)(VOID);
+@@ -475,6 +477,8 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+                 }
+                 if (entry->loader)
+                         Print(L"loader                  '%s'\n", entry->loader);
++                if (entry->devicetree)
++                        Print(L"devicetree              '%s'\n", entry->devicetree);
+                 if (entry->options)
+                         Print(L"options                 '%s'\n", entry->options);
+                 Print(L"auto-select             %s\n", yes_no(!entry->no_autoselect));
+@@ -893,6 +897,7 @@ static VOID config_entry_free(ConfigEntry *entry) {
+         FreePool(entry->version);
+         FreePool(entry->machine_id);
+         FreePool(entry->loader);
++        FreePool(entry->devicetree);
+         FreePool(entry->options);
+         FreePool(entry->path);
+         FreePool(entry->current_name);
+@@ -1330,6 +1335,12 @@ static VOID config_entry_add_from_file(
+                         continue;
+                 }
+ 
++                if (strcmpa((CHAR8 *)"devicetree", key) == 0) {
++                        FreePool(entry->devicetree);
++                        entry->devicetree = stra_to_path(value);
++                        continue;
++                }
++
+                 if (strcmpa((CHAR8 *)"initrd", key) == 0) {
+                         _cleanup_freepool_ CHAR16 *new = NULL;
+ 
+@@ -2270,10 +2281,12 @@ found:
+ }
+ 
+ static EFI_STATUS image_start(
++                EFI_FILE_HANDLE root_dir,
+                 EFI_HANDLE parent_image,
+                 const Config *config,
+                 const ConfigEntry *entry) {
+ 
++        _cleanup_(devicetree_cleanup) struct devicetree_state dtstate = {};
+         EFI_HANDLE image;
+         _cleanup_freepool_ EFI_DEVICE_PATH *path = NULL;
+         CHAR16 *options;
+@@ -2290,6 +2303,12 @@ static EFI_STATUS image_start(
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Error loading %s: %r", entry->loader, err);
+ 
++        if (entry->devicetree) {
++                err = devicetree_install(&dtstate, root_dir, entry->devicetree);
++                if (EFI_ERROR(err))
++                        return log_error_status_stall(err, L"Error loading %s: %r", entry->devicetree, err);
++        }
++
+         if (config->options_edit)
+                 options = config->options_edit;
+         else if (entry->options)
+@@ -2533,7 +2552,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 (VOID) process_random_seed(root_dir, config.random_seed_mode);
+ 
+                 uefi_call_wrapper(BS->SetWatchdogTimer, 4, 5 * 60, 0x10000, 0, NULL);
+-                err = image_start(image, &config, entry);
++                err = image_start(root_dir, image, &config, entry);
+                 if (EFI_ERROR(err)) {
+                         graphics_mode(FALSE);
+                         log_error_stall(L"Failed to execute %s (%s): %r", entry->title, entry->loader, err);
+diff --git a/src/boot/efi/devicetree.c b/src/boot/efi/devicetree.c
+new file mode 100644
+index 000000000..c65936bdb
+--- /dev/null
++++ b/src/boot/efi/devicetree.c
+@@ -0,0 +1,131 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include <efi.h>
++
++#include "devicetree.h"
++#include "missing_efi.h"
++#include "util.h"
++
++#define FDT_V1_SIZE (7*4)
++
++static EFI_STATUS devicetree_allocate(struct devicetree_state *state, UINTN size) {
++        UINTN pages = DIV_ROUND_UP(size, EFI_PAGE_SIZE);
++        EFI_STATUS err;
++
++        assert(state);
++
++        err = uefi_call_wrapper(BS->AllocatePages, 4, AllocateAnyPages, EfiACPIReclaimMemory, pages,
++                                &state->addr);
++        if (EFI_ERROR(err))
++                return err;
++
++        state->pages = pages;
++        return err;
++}
++
++static UINTN devicetree_allocated(const struct devicetree_state *state) {
++        assert(state);
++        return state->pages * EFI_PAGE_SIZE;
++}
++
++static VOID *devicetree_ptr(const struct devicetree_state *state) {
++        assert(state);
++        assert(state->addr <= UINTN_MAX);
++        return (VOID *)(UINTN)state->addr;
++}
++
++static EFI_STATUS devicetree_fixup(struct devicetree_state *state, UINTN len) {
++        EFI_DT_FIXUP_PROTOCOL *fixup;
++        UINTN size;
++        EFI_STATUS err;
++
++        assert(state);
++
++        err = LibLocateProtocol(&EfiDtFixupProtocol, (VOID **)&fixup);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(EFI_SUCCESS,
++                                              L"Could not locate device tree fixup protocol, skipping.");
++
++        size = devicetree_allocated(state);
++        err = uefi_call_wrapper(fixup->Fixup, 4, fixup, devicetree_ptr(state), &size,
++                                EFI_DT_APPLY_FIXUPS | EFI_DT_RESERVE_MEMORY);
++        if (err == EFI_BUFFER_TOO_SMALL) {
++                EFI_PHYSICAL_ADDRESS oldaddr = state->addr;
++                UINTN oldpages = state->pages;
++                VOID *oldptr = devicetree_ptr(state);
++
++                err = devicetree_allocate(state, size);
++                if (EFI_ERROR(err))
++                        return err;
++
++                CopyMem(devicetree_ptr(state), oldptr, len);
++                err = uefi_call_wrapper(BS->FreePages, 2, oldaddr, oldpages);
++                if (EFI_ERROR(err))
++                        return err;
++
++                size = devicetree_allocated(state);
++                err = uefi_call_wrapper(fixup->Fixup, 4, fixup, devicetree_ptr(state), &size,
++                                        EFI_DT_APPLY_FIXUPS | EFI_DT_RESERVE_MEMORY);
++        }
++
++        return err;
++}
++
++EFI_STATUS devicetree_install(struct devicetree_state *state,
++                EFI_FILE_HANDLE root_dir, CHAR16 *name) {
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE handle = NULL;
++        _cleanup_freepool_ EFI_FILE_INFO *info = NULL;
++        UINTN len;
++        EFI_STATUS err;
++
++        assert(state);
++        assert(root_dir);
++        assert(name);
++
++        err = LibGetSystemConfigurationTable(&EfiDtbTableGuid, &state->orig);
++        if (EFI_ERROR(err))
++                return EFI_UNSUPPORTED;
++
++        err = uefi_call_wrapper(root_dir->Open, 5, root_dir, &handle, name, EFI_FILE_MODE_READ,
++                                EFI_FILE_READ_ONLY);
++        if (EFI_ERROR(err))
++                return err;
++
++        info = LibFileInfo(handle);
++        if (!info)
++                return EFI_OUT_OF_RESOURCES;
++        if (info->FileSize < FDT_V1_SIZE || info->FileSize > 32 * 1024 * 1024)
++                /* 32MB device tree blob doesn't seem right */
++                return EFI_INVALID_PARAMETER;
++
++        len = info->FileSize;
++
++        err = devicetree_allocate(state, len);
++        if (EFI_ERROR(err))
++                return err;
++
++        err = uefi_call_wrapper(handle->Read, 3, handle, &len, devicetree_ptr(state));
++        if (EFI_ERROR(err))
++                return err;
++
++        err = devicetree_fixup(state, len);
++        if (EFI_ERROR(err))
++                return err;
++
++        return uefi_call_wrapper(BS->InstallConfigurationTable, 2, &EfiDtbTableGuid, devicetree_ptr(state));
++}
++
++void devicetree_cleanup(struct devicetree_state *state) {
++        EFI_STATUS err;
++
++        if (!state->pages)
++                return;
++
++        err = uefi_call_wrapper(BS->InstallConfigurationTable, 2, &EfiDtbTableGuid, state->orig);
++        /* don't free the current device tree if we can't reinstate the old one */
++        if (EFI_ERROR(err))
++                return;
++
++        uefi_call_wrapper(BS->FreePages, 2, state->addr, state->pages);
++        state->pages = 0;
++}
+diff --git a/src/boot/efi/devicetree.h b/src/boot/efi/devicetree.h
+new file mode 100644
+index 000000000..2839cb681
+--- /dev/null
++++ b/src/boot/efi/devicetree.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++#pragma once
++
++struct devicetree_state {
++        EFI_PHYSICAL_ADDRESS addr;
++        UINTN pages;
++        VOID *orig;
++};
++
++EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE_HANDLE root_dir, CHAR16 *name);
++void devicetree_cleanup(struct devicetree_state *state);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index e6e6f35ae..e5925dd42 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -2,6 +2,7 @@
+ 
+ efi_headers = files('''
+         console.h
++        devicetree.h
+         disk.h
+         graphics.h
+         linux.h
+@@ -28,6 +29,7 @@ common_sources = '''
+ systemd_boot_sources = '''
+         boot.c
+         console.c
++        devicetree.c
+         random-seed.c
+         sha256.c
+         shim.c
+diff --git a/src/boot/efi/missing_efi.h b/src/boot/efi/missing_efi.h
+index 37c468f2a..91bf3e65d 100644
+--- a/src/boot/efi/missing_efi.h
++++ b/src/boot/efi/missing_efi.h
+@@ -124,3 +124,39 @@ typedef struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL {
+ #ifndef EFI_IMAGE_MACHINE_RISCV64
+         #define EFI_IMAGE_MACHINE_RISCV64 0x5064
+ #endif
++
++#ifndef EFI_DTB_TABLE_GUID
++#define EFI_DTB_TABLE_GUID \
++        { 0xb1b621d5, 0xf19c, 0x41a5, {0x83, 0x0b, 0xd9, 0x15, 0x2c, 0x69, 0xaa, 0xe0} }
++#define EfiDtbTableGuid ((EFI_GUID)EFI_DTB_TABLE_GUID)
++#endif
++
++#ifndef EFI_DT_FIXUP_PROTOCOL_GUID
++#define EFI_DT_FIXUP_PROTOCOL_GUID \
++        { 0xe617d64c, 0xfe08, 0x46da, {0xf4, 0xdc, 0xbb, 0xd5, 0x87, 0x0c, 0x73, 0x00} }
++#define EfiDtFixupProtocol ((EFI_GUID)EFI_DT_FIXUP_PROTOCOL_GUID)
++
++#define EFI_DT_FIXUP_PROTOCOL_REVISION 0x00010000
++
++/* Add nodes and update properties */
++#define EFI_DT_APPLY_FIXUPS    0x00000001
++/*
++ * Reserve memory according to the /reserved-memory node
++ * and the memory reservation block
++ */
++#define EFI_DT_RESERVE_MEMORY  0x00000002
++
++typedef struct _EFI_DT_FIXUP_PROTOCOL EFI_DT_FIXUP_PROTOCOL;
++
++typedef EFI_STATUS (EFIAPI *EFI_DT_FIXUP) (
++        IN EFI_DT_FIXUP_PROTOCOL *This,
++        IN VOID                  *Fdt,
++        IN OUT UINTN             *BufferSize,
++        IN UINT32                Flags);
++
++struct _EFI_DT_FIXUP_PROTOCOL {
++        UINT64         Revision;
++        EFI_DT_FIXUP   Fixup;
++};
++
++#endif
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0027-sd-boot-Fix-assertion-fail.patch
+++ b/vendor/systemd-patches/0027-sd-boot-Fix-assertion-fail.patch
@@ -1,0 +1,35 @@
+From 7fcbff10222b47db805f6f176385f875932bb551 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sat, 11 Sep 2021 11:14:06 +0200
+Subject: [PATCH 27/73] sd-boot: Fix assertion fail
+
+The UEFI Platform Initialization Specification says that both
+parameters may be NULL.
+---
+ src/boot/efi/shim.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/boot/efi/shim.c b/src/boot/efi/shim.c
+index 849598f1c..e3fb073fd 100644
+--- a/src/boot/efi/shim.c
++++ b/src/boot/efi/shim.c
+@@ -112,14 +112,13 @@ static EFIAPI EFI_STATUS security2_policy_authentication (const EFI_SECURITY2_PR
+         EFI_STATUS status;
+ 
+         assert(this);
+-        assert(device_path);
+-        assert(file_buffer);
++        /* device_path and file_buffer may be NULL */
+ 
+         /* Chain original security policy */
+         status = uefi_call_wrapper(es2fa, 5, this, device_path, file_buffer, file_size, boot_policy);
+ 
+         /* if OK, don't bother with MOK check */
+-        if (status == EFI_SUCCESS)
++        if (!EFI_ERROR(status))
+                 return status;
+ 
+         if (shim_validate(file_buffer, file_size))
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0028-sd-boot-Simplify-setting-console-mode.patch
+++ b/vendor/systemd-patches/0028-sd-boot-Simplify-setting-console-mode.patch
@@ -1,0 +1,333 @@
+From 0cd12c9883cb39fd82a04d78bb7d6d52045038e9 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sun, 15 Aug 2021 13:44:42 +0200
+Subject: [PATCH 28/73] sd-boot: Simplify setting console mode
+
+---
+ src/boot/efi/boot.c    |  41 +++++--------
+ src/boot/efi/console.c | 131 ++++++++++++++++++++++-------------------
+ src/boot/efi/console.h |  20 +++++--
+ 3 files changed, 102 insertions(+), 90 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 50a17e0a7..df369b426 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -69,8 +69,7 @@ typedef struct {
+         BOOLEAN auto_entries;
+         BOOLEAN auto_firmware;
+         BOOLEAN force_menu;
+-        UINTN console_mode;
+-        enum console_mode_change_type console_mode_change;
++        INT64 console_mode;
+         RandomSeedMode random_seed_mode;
+ } Config;
+ 
+@@ -370,7 +369,7 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         UINTN timeout;
+         BOOLEAN modevar;
+         _cleanup_freepool_ CHAR16 *partstr = NULL, *defaultstr = NULL;
+-        UINTN x, y;
++        UINTN x_max, y_max;
+ 
+         assert(config);
+         assert(loaded_image_path);
+@@ -378,16 +377,15 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, COLOR_NORMAL);
+         uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+ 
++        console_query_mode(&x_max, &y_max);
++
+         Print(L"systemd-boot version:   " GIT_VERSION "\n");
+         Print(L"architecture:           " EFI_MACHINE_TYPE_NAME "\n");
+         Print(L"loaded image:           %s\n", loaded_image_path);
+         Print(L"UEFI specification:     %d.%02d\n", ST->Hdr.Revision >> 16, ST->Hdr.Revision & 0xffff);
+         Print(L"firmware vendor:        %s\n", ST->FirmwareVendor);
+         Print(L"firmware version:       %d.%02d\n", ST->FirmwareRevision >> 16, ST->FirmwareRevision & 0xffff);
+-
+-        if (uefi_call_wrapper(ST->ConOut->QueryMode, 4, ST->ConOut, ST->ConOut->Mode->Mode, &x, &y) == EFI_SUCCESS)
+-                Print(L"console size:           %d x %d\n", x, y);
+-
++        Print(L"console size:           %d x %d\n", x_max, y_max);
+         Print(L"SecureBoot:             %s\n", yes_no(secure_boot_enabled()));
+ 
+         if (efivar_get_boolean_u8(EFI_GLOBAL_GUID, L"SetupMode", &modevar) == EFI_SUCCESS)
+@@ -542,20 +540,11 @@ static BOOLEAN menu_run(
+         /* draw a single character to make ClearScreen work on some firmware */
+         Print(L" ");
+ 
+-        if (config->console_mode_change != CONSOLE_MODE_KEEP) {
+-                err = console_set_mode(&config->console_mode, config->console_mode_change);
+-                if (EFI_ERROR(err)) {
+-                        uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+-                        log_error_stall(L"Error switching console mode to %lu: %r", (UINT64)config->console_mode, err);
+-                }
+-        } else
+-                uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+-
+-        err = uefi_call_wrapper(ST->ConOut->QueryMode, 4, ST->ConOut, ST->ConOut->Mode->Mode, &x_max, &y_max);
+-        if (EFI_ERROR(err)) {
+-                x_max = 80;
+-                y_max = 25;
+-        }
++        err = console_set_mode(config->console_mode);
++        uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
++        if (EFI_ERROR(err))
++                log_error_stall(L"Error switching console mode: %r", err);
++        console_query_mode(&x_max, &y_max);
+ 
+         visible_max = y_max - 2;
+ 
+@@ -1027,17 +1016,16 @@ static VOID config_defaults_load_from_file(Config *config, CHAR8 *content) {
+ 
+                 if (strcmpa((CHAR8 *)"console-mode", key) == 0) {
+                         if (strcmpa((CHAR8 *)"auto", value) == 0)
+-                                config->console_mode_change = CONSOLE_MODE_AUTO;
++                                config->console_mode = CONSOLE_MODE_AUTO;
+                         else if (strcmpa((CHAR8 *)"max", value) == 0)
+-                                config->console_mode_change = CONSOLE_MODE_MAX;
++                                config->console_mode = CONSOLE_MODE_FIRMWARE_MAX;
+                         else if (strcmpa((CHAR8 *)"keep", value)  == 0)
+-                                config->console_mode_change = CONSOLE_MODE_KEEP;
++                                config->console_mode = CONSOLE_MODE_KEEP;
+                         else {
+                                 _cleanup_freepool_ CHAR16 *s = NULL;
+ 
+                                 s = stra_to_str(value);
+-                                config->console_mode = Atoi(s);
+-                                config->console_mode_change = CONSOLE_MODE_SET;
++                                config->console_mode = MIN(Atoi(s), (UINTN)CONSOLE_MODE_RANGE_MAX);
+                         }
+ 
+                         continue;
+@@ -1421,6 +1409,7 @@ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+                 .auto_firmware = TRUE,
+                 .random_seed_mode = RANDOM_SEED_WITH_SYSTEM_TOKEN,
+                 .idx_default_efivar = -1,
++                .console_mode = CONSOLE_MODE_KEEP,
+         };
+ 
+         err = file_read(root_dir, L"\\loader\\loader.conf", 0, 0, &content, NULL);
+diff --git a/src/boot/efi/console.c b/src/boot/efi/console.c
+index 12d3047ac..5f1b3500d 100644
+--- a/src/boot/efi/console.c
++++ b/src/boot/efi/console.c
+@@ -8,6 +8,9 @@
+ 
+ #define SYSTEM_FONT_WIDTH 8
+ #define SYSTEM_FONT_HEIGHT 19
++#define HORIZONTAL_MAX_OK 1920
++#define VERTICAL_MAX_OK 1080
++#define VIEWPORT_RATIO 10
+ 
+ #define EFI_SIMPLE_TEXT_INPUT_EX_GUID                           \
+         &(const EFI_GUID) EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID
+@@ -115,51 +118,36 @@ EFI_STATUS console_key_read(UINT64 *key, UINT64 timeout_usec) {
+         return EFI_SUCCESS;
+ }
+ 
+-static EFI_STATUS change_mode(UINTN mode) {
++static EFI_STATUS change_mode(INT64 mode) {
+         EFI_STATUS err;
++        INT32 old_mode;
++
++        /* SetMode expects a UINTN, so make sure these values are sane. */
++        mode = CLAMP(mode, CONSOLE_MODE_RANGE_MIN, CONSOLE_MODE_RANGE_MAX);
++        old_mode = MAX(CONSOLE_MODE_RANGE_MIN, ST->ConOut->Mode->Mode);
+ 
+         err = uefi_call_wrapper(ST->ConOut->SetMode, 2, ST->ConOut, mode);
++        if (!EFI_ERROR(err))
++                return EFI_SUCCESS;
+ 
+-        /* Special case mode 1: when using OVMF and qemu, setting it returns error
+-         * and breaks console output. */
+-        if (EFI_ERROR(err) && mode == 1)
+-                uefi_call_wrapper(ST->ConOut->SetMode, 2, ST->ConOut, (UINTN)0);
++        /* Something went wrong. Output is probably borked, so try to revert to previous mode. */
++        if (!EFI_ERROR(uefi_call_wrapper(ST->ConOut->SetMode, 2, ST->ConOut, old_mode)))
++                return err;
+ 
++        /* Maybe the device is on fire? */
++        uefi_call_wrapper(ST->ConOut->Reset, 2, ST->ConOut, TRUE);
++        uefi_call_wrapper(ST->ConOut->SetMode, 2, ST->ConOut, CONSOLE_MODE_RANGE_MIN);
+         return err;
+ }
+ 
+-static UINT64 text_area_from_font_size(void) {
+-        EFI_STATUS err;
+-        UINT64 text_area;
+-        UINTN rows, columns;
+-
+-        err = uefi_call_wrapper(ST->ConOut->QueryMode, 4, ST->ConOut, ST->ConOut->Mode->Mode, &columns, &rows);
+-        if (EFI_ERROR(err)) {
+-                columns = 80;
+-                rows = 25;
+-        }
+-
+-        text_area = SYSTEM_FONT_WIDTH * SYSTEM_FONT_HEIGHT * (UINT64)rows * (UINT64)columns;
+-
+-        return text_area;
+-}
+-
+-static EFI_STATUS mode_auto(UINTN *mode) {
+-        const UINT32 HORIZONTAL_MAX_OK = 1920;
+-        const UINT32 VERTICAL_MAX_OK = 1080;
+-        const UINT64 VIEWPORT_RATIO = 10;
+-        UINT64 screen_area, text_area;
+-        static const EFI_GUID GraphicsOutputProtocolGuid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
++static INT64 get_auto_mode(void) {
+         EFI_GRAPHICS_OUTPUT_PROTOCOL *GraphicsOutput;
+-        EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *Info;
+         EFI_STATUS err;
+-        BOOLEAN keep = FALSE;
+ 
+-        assert(mode);
+-
+-        err = LibLocateProtocol((EFI_GUID*) &GraphicsOutputProtocolGuid, (VOID **)&GraphicsOutput);
++        err = LibLocateProtocol(&GraphicsOutputProtocol, (VOID **)&GraphicsOutput);
+         if (!EFI_ERROR(err) && GraphicsOutput->Mode && GraphicsOutput->Mode->Info) {
+-                Info = GraphicsOutput->Mode->Info;
++                EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *Info = GraphicsOutput->Mode->Info;
++                BOOLEAN keep = FALSE;
+ 
+                 /* Start verifying if we are in a resolution larger than Full HD
+                  * (1920x1080). If we're not, assume we're in a good mode and do not
+@@ -170,19 +158,19 @@ static EFI_STATUS mode_auto(UINTN *mode) {
+                  * area to the text viewport area. If it's less than 10 times bigger,
+                  * then assume the text is readable and keep the text mode. */
+                 else {
+-                        screen_area = (UINT64)Info->HorizontalResolution * (UINT64)Info->VerticalResolution;
+-                        text_area = text_area_from_font_size();
++                        UINT64 text_area;
++                        UINTN x_max, y_max;
++                        UINT64 screen_area = (UINT64)Info->HorizontalResolution * (UINT64)Info->VerticalResolution;
++
++                        console_query_mode(&x_max, &y_max);
++                        text_area = SYSTEM_FONT_WIDTH * SYSTEM_FONT_HEIGHT * (UINT64)x_max * (UINT64)y_max;
+ 
+                         if (text_area != 0 && screen_area/text_area < VIEWPORT_RATIO)
+                                 keep = TRUE;
+                 }
+-        }
+ 
+-        if (keep) {
+-                /* Just clear the screen instead of changing the mode and return. */
+-                *mode = ST->ConOut->Mode->Mode;
+-                uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+-                return EFI_SUCCESS;
++                if (keep)
++                        return ST->ConOut->Mode->Mode;
+         }
+ 
+         /* If we reached here, then we have a high resolution screen and the text
+@@ -191,32 +179,57 @@ static EFI_STATUS mode_auto(UINTN *mode) {
+          * standard mode, which is provided by the device manufacturer, so it should
+          * be a good mode.
+          * Note: MaxMode is the number of modes, not the last mode. */
+-        if (ST->ConOut->Mode->MaxMode > 2)
+-                *mode = 2;
++        if (ST->ConOut->Mode->MaxMode > CONSOLE_MODE_FIRMWARE_FIRST)
++                return CONSOLE_MODE_FIRMWARE_FIRST;
++
+         /* Try again with mode different than zero (assume user requests
+          * auto mode due to some problem with mode zero). */
+-        else if (ST->ConOut->Mode->MaxMode == 2)
+-                *mode = 1;
+-        /* Else force mode change to zero. */
+-        else
+-                *mode = 0;
++        if (ST->ConOut->Mode->MaxMode > CONSOLE_MODE_80_50)
++                return CONSOLE_MODE_80_50;
+ 
+-        return change_mode(*mode);
++        return CONSOLE_MODE_80_25;
+ }
+ 
+-EFI_STATUS console_set_mode(UINTN *mode, enum console_mode_change_type how) {
+-        assert(mode);
++EFI_STATUS console_set_mode(INT64 mode) {
++        switch (mode) {
++        case CONSOLE_MODE_KEEP:
++                /* If the firmware indicates the current mode is invalid, change it anyway. */
++                if (ST->ConOut->Mode->Mode < CONSOLE_MODE_RANGE_MIN)
++                        return change_mode(CONSOLE_MODE_RANGE_MIN);
++                return EFI_SUCCESS;
+ 
+-        if (how == CONSOLE_MODE_AUTO)
+-                return mode_auto(mode);
++        case CONSOLE_MODE_AUTO:
++                return change_mode(get_auto_mode());
+ 
+-        if (how == CONSOLE_MODE_MAX) {
++        case CONSOLE_MODE_FIRMWARE_MAX:
+                 /* Note: MaxMode is the number of modes, not the last mode. */
+-                if (ST->ConOut->Mode->MaxMode > 0)
+-                        *mode = ST->ConOut->Mode->MaxMode-1;
+-                else
+-                        *mode = 0;
++                return change_mode(ST->ConOut->Mode->MaxMode - 1LL);
++
++        default:
++                return change_mode(mode);
++        }
++}
++
++EFI_STATUS console_query_mode(UINTN *x_max, UINTN *y_max) {
++        EFI_STATUS err;
++
++        assert(x_max);
++        assert(y_max);
++
++        err = uefi_call_wrapper(ST->ConOut->QueryMode, 4, ST->ConOut, ST->ConOut->Mode->Mode, x_max, y_max);
++        if (EFI_ERROR(err)) {
++                /* Fallback values mandated by UEFI spec. */
++                switch (ST->ConOut->Mode->Mode) {
++                case CONSOLE_MODE_80_50:
++                        *x_max = 80;
++                        *y_max = 50;
++                        break;
++                case CONSOLE_MODE_80_25:
++                default:
++                        *x_max = 80;
++                        *y_max = 25;
++                }
+         }
+ 
+-        return change_mode(*mode);
++        return err;
+ }
+diff --git a/src/boot/efi/console.h b/src/boot/efi/console.h
+index 23848a9c5..ec1a96871 100644
+--- a/src/boot/efi/console.h
++++ b/src/boot/efi/console.h
+@@ -9,12 +9,22 @@
+ #define KEYCHAR(k) ((k) & 0xffff)
+ #define CHAR_CTRL(c) ((c) - 'a' + 1)
+ 
+-enum console_mode_change_type {
+-        CONSOLE_MODE_KEEP = 0,
+-        CONSOLE_MODE_SET,
++enum {
++        /* Console mode is a INT32 in EFI. We use INT64 to make room for our special values. */
++        CONSOLE_MODE_RANGE_MIN = 0,
++        CONSOLE_MODE_RANGE_MAX = INT32_MAX, /* This is just the theoretical limit. */
++        CONSOLE_MODE_INVALID = -1,          /* UEFI uses -1 if the device is not in a valid text mode. */
++
++        CONSOLE_MODE_80_25 = 0,             /* 80x25 is required by UEFI spec. */
++        CONSOLE_MODE_80_50 = 1,             /* 80x50 may be supported. */
++        CONSOLE_MODE_FIRMWARE_FIRST = 2,    /* First custom mode, if supported. */
++
++        /* These are our own mode values that map to concrete values at runtime. */
++        CONSOLE_MODE_KEEP = CONSOLE_MODE_RANGE_MAX + 1LL,
+         CONSOLE_MODE_AUTO,
+-        CONSOLE_MODE_MAX,
++        CONSOLE_MODE_FIRMWARE_MAX, /* 'max' in config. */
+ };
+ 
+ EFI_STATUS console_key_read(UINT64 *key, UINT64 timeout_usec);
+-EFI_STATUS console_set_mode(UINTN *mode, enum console_mode_change_type how);
++EFI_STATUS console_set_mode(INT64 mode);
++EFI_STATUS console_query_mode(UINTN *x_max, UINTN *y_max);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0029-sd-boot-Add-support-for-changing-console-mode-at-run.patch
+++ b/vendor/systemd-patches/0029-sd-boot-Add-support-for-changing-console-mode-at-run.patch
@@ -1,0 +1,472 @@
+From d866fdf4280bac5da0e296a3c1f1793ad0242c14 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Sun, 15 Aug 2021 13:44:47 +0200
+Subject: [PATCH 29/73] sd-boot: Add support for changing console mode at
+ runtime
+
+---
+ man/systemd-boot.xml   |  10 ++
+ src/boot/efi/boot.c    | 227 +++++++++++++++++++++++++----------------
+ src/boot/efi/console.c |  15 +++
+ src/boot/efi/console.h |   1 +
+ src/boot/efi/util.c    |   5 +
+ src/boot/efi/util.h    |   1 +
+ 6 files changed, 172 insertions(+), 87 deletions(-)
+
+diff --git a/man/systemd-boot.xml b/man/systemd-boot.xml
+index d3306593e..8685ed50f 100644
+--- a/man/systemd-boot.xml
++++ b/man/systemd-boot.xml
+@@ -151,6 +151,16 @@
+         <listitem><para>Decrease the timeout</para></listitem>
+       </varlistentry>
+ 
++      <varlistentry>
++        <term><keycap>r</keycap></term>
++        <listitem><para>Change screen resolution, skipping any unsupported modes.</para></listitem>
++      </varlistentry>
++
++      <varlistentry>
++        <term><keycap>R</keycap></term>
++        <listitem><para>Reset screen resolution to firmware or configuration file default.</para></listitem>
++      </varlistentry>
++
+       <varlistentry>
+         <term><keycap>p</keycap></term>
+         <listitem><para>Print status</para></listitem>
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index df369b426..af02cfb7e 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -70,6 +70,7 @@ typedef struct {
+         BOOLEAN auto_firmware;
+         BOOLEAN force_menu;
+         INT64 console_mode;
++        INT64 console_mode_efivar;
+         RandomSeedMode random_seed_mode;
+ } Config;
+ 
+@@ -374,9 +375,7 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         assert(config);
+         assert(loaded_image_path);
+ 
+-        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, COLOR_NORMAL);
+-        uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+-
++        clear_screen(COLOR_NORMAL);
+         console_query_mode(&x_max, &y_max);
+ 
+         Print(L"systemd-boot version:   " GIT_VERSION "\n");
+@@ -385,6 +384,7 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         Print(L"UEFI specification:     %d.%02d\n", ST->Hdr.Revision >> 16, ST->Hdr.Revision & 0xffff);
+         Print(L"firmware vendor:        %s\n", ST->FirmwareVendor);
+         Print(L"firmware version:       %d.%02d\n", ST->FirmwareRevision >> 16, ST->FirmwareRevision & 0xffff);
++        Print(L"console mode:           %d/%ld\n", ST->ConOut->Mode->Mode, ST->ConOut->Mode->MaxMode - 1LL);
+         Print(L"console size:           %d x %d\n", x_max, y_max);
+         Print(L"SecureBoot:             %s\n", yes_no(secure_boot_enabled()));
+ 
+@@ -497,8 +497,6 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+                 Print(L"\n--- press key ---\n\n");
+                 console_key_read(&key, 0);
+         }
+-
+-        uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+ }
+ 
+ static BOOLEAN menu_run(
+@@ -511,98 +509,115 @@ static BOOLEAN menu_run(
+         assert(loaded_image_path);
+ 
+         EFI_STATUS err;
+-        UINTN visible_max;
++        UINTN visible_max = 0;
+         UINTN idx_highlight = config->idx_default;
+         UINTN idx_highlight_prev = 0;
+-        UINTN idx_first;
+-        UINTN idx_last;
+-        BOOLEAN refresh = TRUE;
+-        BOOLEAN highlight = FALSE;
+-        UINTN line_width = 0;
+-        UINTN entry_padding = 3;
+-        CHAR16 **lines;
+-        UINTN x_start;
+-        UINTN y_start;
+-        UINTN x_max;
+-        UINTN y_max;
+-        CHAR16 *status = NULL;
+-        CHAR16 *clearline;
++        UINTN idx_first = 0, idx_last = 0;
++        BOOLEAN new_mode = TRUE, clear = TRUE;
++        BOOLEAN refresh = TRUE, highlight = FALSE;
++        UINTN x_start = 0, y_start = 0, y_status = 0;
++        UINTN x_max, y_max;
++        CHAR16 **lines = NULL, *status = NULL, *clearline = NULL;
+         UINTN timeout_remain = config->timeout_sec;
+         INT16 idx;
+-        BOOLEAN exit = FALSE;
+-        BOOLEAN run = TRUE;
++        BOOLEAN exit = FALSE, run = TRUE;
++        INT64 console_mode_initial = ST->ConOut->Mode->Mode, console_mode_efivar_saved = config->console_mode_efivar;
+ 
+         graphics_mode(FALSE);
+         uefi_call_wrapper(ST->ConIn->Reset, 2, ST->ConIn, FALSE);
+         uefi_call_wrapper(ST->ConOut->EnableCursor, 2, ST->ConOut, FALSE);
+-        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, COLOR_NORMAL);
+ 
+         /* draw a single character to make ClearScreen work on some firmware */
+         Print(L" ");
+ 
+-        err = console_set_mode(config->console_mode);
+-        uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+-        if (EFI_ERROR(err))
++        err = console_set_mode(config->console_mode_efivar != CONSOLE_MODE_KEEP ?
++                               config->console_mode_efivar : config->console_mode);
++        if (EFI_ERROR(err)) {
++                clear_screen(COLOR_NORMAL);
+                 log_error_stall(L"Error switching console mode: %r", err);
+-        console_query_mode(&x_max, &y_max);
++        }
+ 
+-        visible_max = y_max - 2;
++        while (!exit) {
++                UINT64 key;
+ 
+-        /* Drawing entries starts at idx_first until idx_last. We want to make
+-         * sure that idx_highlight is centered, but not if we are close to the
+-         * beginning/end of the entry list. Otherwise we would have a half-empty
+-         * screen. */
+-        if (config->entry_count <= visible_max || idx_highlight <= visible_max / 2)
+-                idx_first = 0;
+-        else if (idx_highlight >= config->entry_count - (visible_max / 2))
+-                idx_first = config->entry_count - visible_max;
+-        else
+-                idx_first = idx_highlight - (visible_max / 2);
+-        idx_last = idx_first + visible_max - 1;
++                if (new_mode) {
++                        UINTN line_width = 0, entry_padding = 3;
+ 
+-        /* length of the longest entry */
+-        for (UINTN i = 0; i < config->entry_count; i++)
+-                line_width = MAX(line_width, StrLen(config->entries[i]->title_show));
+-        line_width = MIN(line_width + 2 * entry_padding, x_max);
++                        console_query_mode(&x_max, &y_max);
+ 
+-        /* offsets to center the entries on the screen */
+-        x_start = (x_max - (line_width)) / 2;
+-        if (config->entry_count < visible_max)
+-                y_start = ((visible_max - config->entry_count) / 2) + 1;
+-        else
+-                y_start = 0;
++                        /* account for padding+status */
++                        visible_max = y_max - 2;
+ 
+-        /* menu entries title lines */
+-        lines = AllocatePool(sizeof(CHAR16 *) * config->entry_count);
+-        for (UINTN i = 0; i < config->entry_count; i++) {
+-                UINTN j;
++                        /* Drawing entries starts at idx_first until idx_last. We want to make
++                        * sure that idx_highlight is centered, but not if we are close to the
++                        * beginning/end of the entry list. Otherwise we would have a half-empty
++                        * screen. */
++                        if (config->entry_count <= visible_max || idx_highlight <= visible_max / 2)
++                                idx_first = 0;
++                        else if (idx_highlight >= config->entry_count - (visible_max / 2))
++                                idx_first = config->entry_count - visible_max;
++                        else
++                                idx_first = idx_highlight - (visible_max / 2);
++                        idx_last = idx_first + visible_max - 1;
++
++                        /* length of the longest entry */
++                        for (UINTN i = 0; i < config->entry_count; i++)
++                                line_width = MAX(line_width, StrLen(config->entries[i]->title_show));
++                        line_width = MIN(line_width + 2 * entry_padding, x_max);
++
++                        /* offsets to center the entries on the screen */
++                        x_start = (x_max - (line_width)) / 2;
++                        if (config->entry_count < visible_max)
++                                y_start = ((visible_max - config->entry_count) / 2) + 1;
++                        else
++                                y_start = 0;
++
++                        /* Put status line after the entry list, but give it some breathing room. */
++                        y_status = MIN(y_start + MIN(visible_max, config->entry_count) + 4, y_max - 1);
++
++                        if (lines) {
++                                for (UINTN i = 0; i < config->entry_count; i++)
++                                        FreePool(lines[i]);
++                                FreePool(lines);
++                                FreePool(clearline);
++                        }
+ 
+-                lines[i] = AllocatePool(((line_width + 1) * sizeof(CHAR16)));
+-                UINTN padding = (line_width - MIN(StrLen(config->entries[i]->title_show), line_width)) / 2;
++                        /* menu entries title lines */
++                        lines = AllocatePool(sizeof(CHAR16 *) * config->entry_count);
++                        for (UINTN i = 0; i < config->entry_count; i++) {
++                                UINTN j, padding;
+ 
+-                for (j = 0; j < padding; j++)
+-                        lines[i][j] = ' ';
++                                lines[i] = AllocatePool(((line_width + 1) * sizeof(CHAR16)));
++                                padding = (line_width - MIN(StrLen(config->entries[i]->title_show), line_width)) / 2;
+ 
+-                for (UINTN k = 0; config->entries[i]->title_show[k] != '\0' && j < line_width; j++, k++)
+-                        lines[i][j] = config->entries[i]->title_show[k];
++                                for (j = 0; j < padding; j++)
++                                        lines[i][j] = ' ';
+ 
+-                for (; j < line_width; j++)
+-                        lines[i][j] = ' ';
+-                lines[i][line_width] = '\0';
+-        }
++                                for (UINTN k = 0; config->entries[i]->title_show[k] != '\0' && j < line_width; j++, k++)
++                                        lines[i][j] = config->entries[i]->title_show[k];
+ 
+-        clearline = AllocatePool((x_max+1) * sizeof(CHAR16));
+-        for (UINTN i = 0; i < x_max; i++)
+-                clearline[i] = ' ';
+-        clearline[x_max] = 0;
++                                for (; j < line_width; j++)
++                                        lines[i][j] = ' ';
++                                lines[i][line_width] = '\0';
++                        }
+ 
+-        while (!exit) {
+-                UINT64 key;
++                        clearline = AllocatePool((x_max+1) * sizeof(CHAR16));
++                        for (UINTN i = 0; i < x_max; i++)
++                                clearline[i] = ' ';
++                        clearline[x_max] = 0;
++
++                        new_mode = FALSE;
++                        clear = TRUE;
++                }
++
++                if (clear) {
++                        clear_screen(COLOR_NORMAL);
++                        clear = FALSE;
++                        refresh = TRUE;
++                }
+ 
+                 if (refresh) {
+-                        for (UINTN i = 0; i < config->entry_count; i++) {
+-                                if (i < idx_first || i > idx_last)
+-                                        continue;
++                        for (UINTN i = idx_first; i <= idx_last && i < config->entry_count; i++) {
+                                 print_at(x_start, y_start + i - idx_first,
+                                          (i == idx_highlight) ? COLOR_HIGHLIGHT : COLOR_ENTRY,
+                                          lines[i]);
+@@ -638,7 +653,7 @@ static BOOLEAN menu_run(
+                                 x = (x_max - len) / 2;
+                         else
+                                 x = 0;
+-                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + (x_max - x));
++                        print_at(0, y_status, COLOR_NORMAL, clearline + (x_max - x));
+                         uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, status);
+                         uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, clearline+1 + x + len);
+                 }
+@@ -660,7 +675,7 @@ static BOOLEAN menu_run(
+                 if (status) {
+                         FreePool(status);
+                         status = NULL;
+-                        print_at(0, y_max - 1, COLOR_NORMAL, clearline + 1);
++                        print_at(0, y_status, COLOR_NORMAL, clearline + 1);
+                 }
+ 
+                 idx_highlight_prev = idx_highlight;
+@@ -722,7 +737,7 @@ static BOOLEAN menu_run(
+                 case KEYPRESS(0, 0, 'H'):
+                 case KEYPRESS(0, 0, '?'):
+                         /* This must stay below 80 characters! Q/v/Ctrl+l deliberately not advertised. */
+-                        status = StrDuplicate(L"(d)efault (t/T)timeout (e)dit (p)rint (h)elp");
++                        status = StrDuplicate(L"(d)efault (t/T)timeout (e)dit (r/R)resolution (p)rint (h)elp");
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'Q'):
+@@ -802,9 +817,9 @@ static BOOLEAN menu_run(
+                          * causing a scroll to happen that screws with our beautiful boot loader output.
+                          * Since we cannot paint the last character of the edit line, we simply start
+                          * at x-offset 1 for symmetry. */
+-                        print_at(1, y_max - 1, COLOR_EDIT, clearline + 2);
+-                        exit = line_edit(config->entries[idx_highlight]->options, &config->options_edit, x_max-2, y_max-1);
+-                        print_at(1, y_max - 1, COLOR_NORMAL, clearline + 2);
++                        print_at(1, y_status, COLOR_EDIT, clearline + 2);
++                        exit = line_edit(config->entries[idx_highlight]->options, &config->options_edit, x_max - 2, y_status);
++                        print_at(1, y_status, COLOR_NORMAL, clearline + 2);
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'v'):
+@@ -816,12 +831,35 @@ static BOOLEAN menu_run(
+                 case KEYPRESS(0, 0, 'p'):
+                 case KEYPRESS(0, 0, 'P'):
+                         print_status(config, loaded_image_path);
+-                        refresh = TRUE;
++                        clear = TRUE;
+                         break;
+ 
+                 case KEYPRESS(EFI_CONTROL_PRESSED, 0, 'l'):
+                 case KEYPRESS(EFI_CONTROL_PRESSED, 0, CHAR_CTRL('l')):
+-                        refresh = TRUE;
++                        clear = TRUE;
++                        break;
++
++                case KEYPRESS(0, 0, 'r'):
++                        err = console_set_mode(CONSOLE_MODE_NEXT);
++                        if (EFI_ERROR(err))
++                                status = PoolPrint(L"Error changing console mode: %r", err);
++                        else {
++                                config->console_mode_efivar = ST->ConOut->Mode->Mode;
++                                status = PoolPrint(L"Console mode changed to %ld.", config->console_mode_efivar);
++                        }
++                        new_mode = TRUE;
++                        break;
++
++                case KEYPRESS(0, 0, 'R'):
++                        config->console_mode_efivar = CONSOLE_MODE_KEEP;
++                        err = console_set_mode(config->console_mode == CONSOLE_MODE_KEEP ?
++                                               console_mode_initial : config->console_mode);
++                        if (EFI_ERROR(err))
++                                status = PoolPrint(L"Error resetting console mode: %r", err);
++                        else
++                                status = PoolPrint(L"Console mode reset to %s default.",
++                                                   config->console_mode == CONSOLE_MODE_KEEP ? L"firmware" : L"configuration file");
++                        new_mode = TRUE;
+                         break;
+ 
+                 default:
+@@ -849,13 +887,23 @@ static BOOLEAN menu_run(
+ 
+         *chosen_entry = config->entries[idx_highlight];
+ 
++        /* The user is likely to cycle through several modes before
++         * deciding to keep one. Therefore, we update the EFI var after
++         * we left the menu to reduce nvram writes. */
++        if (console_mode_efivar_saved != config->console_mode_efivar) {
++                if (config->console_mode_efivar == CONSOLE_MODE_KEEP)
++                        efivar_set(LOADER_GUID, L"LoaderConfigConsoleMode", NULL, EFI_VARIABLE_NON_VOLATILE);
++                else
++                        efivar_set_uint_string(LOADER_GUID, L"LoaderConfigConsoleMode",
++                                               config->console_mode_efivar, EFI_VARIABLE_NON_VOLATILE);
++        }
++
+         for (UINTN i = 0; i < config->entry_count; i++)
+                 FreePool(lines[i]);
+         FreePool(lines);
+         FreePool(clearline);
+ 
+-        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, COLOR_NORMAL);
+-        uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
++        clear_screen(COLOR_NORMAL);
+         return run;
+ }
+ 
+@@ -1398,7 +1446,7 @@ static VOID config_entry_add_from_file(
+ 
+ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+         _cleanup_freepool_ CHAR8 *content = NULL;
+-        UINTN sec;
++        UINTN value;
+         EFI_STATUS err;
+ 
+         assert(root_dir);
+@@ -1410,27 +1458,32 @@ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+                 .random_seed_mode = RANDOM_SEED_WITH_SYSTEM_TOKEN,
+                 .idx_default_efivar = -1,
+                 .console_mode = CONSOLE_MODE_KEEP,
++                .console_mode_efivar = CONSOLE_MODE_KEEP,
+         };
+ 
+         err = file_read(root_dir, L"\\loader\\loader.conf", 0, 0, &content, NULL);
+         if (!EFI_ERROR(err))
+                 config_defaults_load_from_file(config, content);
+ 
+-        err = efivar_get_uint_string(LOADER_GUID, L"LoaderConfigTimeout", &sec);
++        err = efivar_get_uint_string(LOADER_GUID, L"LoaderConfigTimeout", &value);
+         if (!EFI_ERROR(err)) {
+-                config->timeout_sec_efivar = sec > INTN_MAX ? INTN_MAX : sec;
+-                config->timeout_sec = sec;
++                config->timeout_sec_efivar = value > INTN_MAX ? INTN_MAX : value;
++                config->timeout_sec = value;
+         } else
+                 config->timeout_sec_efivar = -1;
+ 
+-        err = efivar_get_uint_string(LOADER_GUID, L"LoaderConfigTimeoutOneShot", &sec);
++        err = efivar_get_uint_string(LOADER_GUID, L"LoaderConfigTimeoutOneShot", &value);
+         if (!EFI_ERROR(err)) {
+                 /* Unset variable now, after all it's "one shot". */
+                 (void) efivar_set(LOADER_GUID, L"LoaderConfigTimeoutOneShot", NULL, EFI_VARIABLE_NON_VOLATILE);
+ 
+-                config->timeout_sec = sec;
++                config->timeout_sec = value;
+                 config->force_menu = TRUE; /* force the menu when this is set */
+         }
++
++        err = efivar_get_uint_string(LOADER_GUID, L"LoaderConfigConsoleMode", &value);
++        if (!EFI_ERROR(err))
++                config->console_mode_efivar = value;
+ }
+ 
+ static VOID config_load_entries(
+diff --git a/src/boot/efi/console.c b/src/boot/efi/console.c
+index 5f1b3500d..b581c21bd 100644
+--- a/src/boot/efi/console.c
++++ b/src/boot/efi/console.c
+@@ -198,6 +198,21 @@ EFI_STATUS console_set_mode(INT64 mode) {
+                         return change_mode(CONSOLE_MODE_RANGE_MIN);
+                 return EFI_SUCCESS;
+ 
++        case CONSOLE_MODE_NEXT:
++                if (ST->ConOut->Mode->MaxMode <= CONSOLE_MODE_RANGE_MIN)
++                        return EFI_UNSUPPORTED;
++
++                mode = MAX(CONSOLE_MODE_RANGE_MIN, ST->ConOut->Mode->Mode);
++                do {
++                        mode = (mode + 1) % ST->ConOut->Mode->MaxMode;
++                        if (!EFI_ERROR(change_mode(mode)))
++                                break;
++                        /* If this mode is broken/unsupported, try the next.
++                         * If mode is 0, we wrapped around and should stop. */
++                } while (mode > CONSOLE_MODE_RANGE_MIN);
++
++                return EFI_SUCCESS;
++
+         case CONSOLE_MODE_AUTO:
+                 return change_mode(get_auto_mode());
+ 
+diff --git a/src/boot/efi/console.h b/src/boot/efi/console.h
+index ec1a96871..90086028c 100644
+--- a/src/boot/efi/console.h
++++ b/src/boot/efi/console.h
+@@ -21,6 +21,7 @@ enum {
+ 
+         /* These are our own mode values that map to concrete values at runtime. */
+         CONSOLE_MODE_KEEP = CONSOLE_MODE_RANGE_MAX + 1LL,
++        CONSOLE_MODE_NEXT,
+         CONSOLE_MODE_AUTO,
+         CONSOLE_MODE_FIRMWARE_MAX, /* 'max' in config. */
+ };
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index b78408e1a..065e1ea39 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -522,3 +522,8 @@ VOID print_at(UINTN x, UINTN y, UINTN attr, const CHAR16 *str) {
+         uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, attr);
+         uefi_call_wrapper(ST->ConOut->OutputString, 2, ST->ConOut, (CHAR16*)str);
+ }
++
++VOID clear_screen(UINTN attr) {
++        uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, attr);
++        uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
++}
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index 9eef51cc7..a5b6435f1 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -93,3 +93,4 @@ static inline VOID *mempmem_safe(const VOID *haystack, UINTN haystack_len, const
+ }
+ 
+ VOID print_at(UINTN x, UINTN y, UINTN attr, const CHAR16 *str);
++VOID clear_screen(UINTN attr);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0030-boot-invert-if-check-to-reduce-indentation-level.patch
+++ b/vendor/systemd-patches/0030-boot-invert-if-check-to-reduce-indentation-level.patch
@@ -1,0 +1,79 @@
+From 5d58a758f5dc9379dcc33e870b88f51bd3dd99a6 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Thu, 16 Sep 2021 16:02:36 +0200
+Subject: [PATCH 30/73] boot: invert if check, to reduce indentation level
+
+---
+ src/boot/efi/boot.c | 52 +++++++++++++++++++++++----------------------
+ 1 file changed, 27 insertions(+), 25 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index af02cfb7e..cfe20c27f 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1501,35 +1501,37 @@ static VOID config_load_entries(
+         assert(loaded_image_path);
+ 
+         err = uefi_call_wrapper(root_dir->Open, 5, root_dir, &entries_dir, (CHAR16*) L"\\loader\\entries", EFI_FILE_MODE_READ, 0ULL);
+-        if (!EFI_ERROR(err)) {
+-                for (;;) {
+-                        CHAR16 buf[256];
+-                        UINTN bufsize;
+-                        EFI_FILE_INFO *f;
+-                        _cleanup_freepool_ CHAR8 *content = NULL;
+-
+-                        bufsize = sizeof(buf);
+-                        err = uefi_call_wrapper(entries_dir->Read, 3, entries_dir, &bufsize, buf);
+-                        if (bufsize == 0 || EFI_ERROR(err))
+-                                break;
++        if (EFI_ERROR(err))
++                return;
+ 
+-                        f = (EFI_FILE_INFO *) buf;
+-                        if (f->FileName[0] == '.')
+-                                continue;
+-                        if (f->Attribute & EFI_FILE_DIRECTORY)
+-                                continue;
++        for (;;) {
++                CHAR16 buf[256];
++                UINTN bufsize;
++                EFI_FILE_INFO *f;
++                _cleanup_freepool_ CHAR8 *content = NULL;
+ 
+-                        if (!endswith_no_case(f->FileName, L".conf"))
+-                                continue;
+-                        if (startswith(f->FileName, L"auto-"))
+-                                continue;
++                bufsize = sizeof(buf);
++                err = uefi_call_wrapper(entries_dir->Read, 3, entries_dir, &bufsize, buf);
++                if (bufsize == 0 || EFI_ERROR(err))
++                        break;
+ 
+-                        err = file_read(entries_dir, f->FileName, 0, 0, &content, NULL);
+-                        if (!EFI_ERROR(err))
+-                                config_entry_add_from_file(config, device, root_dir, L"\\loader\\entries", f->FileName, content, loaded_image_path);
+-                }
+-                uefi_call_wrapper(entries_dir->Close, 1, entries_dir);
++                f = (EFI_FILE_INFO *) buf;
++                if (f->FileName[0] == '.')
++                        continue;
++                if (f->Attribute & EFI_FILE_DIRECTORY)
++                        continue;
++
++                if (!endswith_no_case(f->FileName, L".conf"))
++                        continue;
++                if (startswith(f->FileName, L"auto-"))
++                        continue;
++
++                err = file_read(entries_dir, f->FileName, 0, 0, &content, NULL);
++                if (!EFI_ERROR(err))
++                        config_entry_add_from_file(config, device, root_dir, L"\\loader\\entries", f->FileName, content, loaded_image_path);
+         }
++
++        uefi_call_wrapper(entries_dir->Close, 1, entries_dir);
+ }
+ 
+ static INTN config_entry_compare(ConfigEntry *a, ConfigEntry *b) {
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0031-boot-use-cleanup-based-file-handle-closing-a-bit-mor.patch
+++ b/vendor/systemd-patches/0031-boot-use-cleanup-based-file-handle-closing-a-bit-mor.patch
@@ -1,0 +1,52 @@
+From d769766f2ee7604d339fee2eaade376da2299f48 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Fri, 17 Sep 2021 10:32:33 +0200
+Subject: [PATCH 31/73] boot: use cleanup-based file handle closing a bit more
+
+---
+ src/boot/efi/boot.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index cfe20c27f..106fda925 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1492,7 +1492,7 @@ static VOID config_load_entries(
+                 EFI_FILE *root_dir,
+                 CHAR16 *loaded_image_path) {
+ 
+-        EFI_FILE_HANDLE entries_dir;
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE entries_dir = NULL;
+         EFI_STATUS err;
+ 
+         assert(config);
+@@ -1530,8 +1530,6 @@ static VOID config_load_entries(
+                 if (!EFI_ERROR(err))
+                         config_entry_add_from_file(config, device, root_dir, L"\\loader\\entries", f->FileName, content, loaded_image_path);
+         }
+-
+-        uefi_call_wrapper(entries_dir->Close, 1, entries_dir);
+ }
+ 
+ static INTN config_entry_compare(ConfigEntry *a, ConfigEntry *b) {
+@@ -1982,7 +1980,7 @@ static VOID config_entry_add_linux(
+                 EFI_HANDLE *device,
+                 EFI_FILE *root_dir) {
+ 
+-        EFI_FILE_HANDLE linux_dir;
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE linux_dir = NULL;
+         EFI_STATUS err;
+         ConfigEntry *entry;
+ 
+@@ -2112,8 +2110,6 @@ static VOID config_entry_add_linux(
+                 FreePool(os_build_id);
+                 FreePool(content);
+         }
+-
+-        uefi_call_wrapper(linux_dir->Close, 1, linux_dir);
+ }
+ 
+ #define XBOOTLDR_GUID \
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0032-boot-move-TCG-TPM-protocol-definitions-into-missing_.patch
+++ b/vendor/systemd-patches/0032-boot-move-TCG-TPM-protocol-definitions-into-missing_.patch
@@ -1,0 +1,383 @@
+From dbfa9b6c480e294624a92d99fe12719e9ba62238 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 20 Sep 2021 13:32:12 +0200
+Subject: [PATCH 32/73] boot: move TCG/TPM protocol definitions into
+ missing_efi.h
+
+That's what it is for...
+---
+ src/boot/efi/measure.c     | 170 +-----------------------------------
+ src/boot/efi/missing_efi.h | 171 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 172 insertions(+), 169 deletions(-)
+
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index 3e64ab6be..112acd78c 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -7,175 +7,7 @@
+ 
+ #include "macro-fundamental.h"
+ #include "measure.h"
+-
+-#define EFI_TCG_GUID \
+-        &(const EFI_GUID) { 0xf541796d, 0xa62e, 0x4954, { 0xa7, 0x75, 0x95, 0x84, 0xf6, 0x1b, 0x9c, 0xdd } }
+-
+-typedef struct _TCG_VERSION {
+-        UINT8 Major;
+-        UINT8 Minor;
+-        UINT8 RevMajor;
+-        UINT8 RevMinor;
+-} TCG_VERSION;
+-
+-typedef struct tdEFI_TCG2_VERSION {
+-        UINT8 Major;
+-        UINT8 Minor;
+-} EFI_TCG2_VERSION;
+-
+-typedef struct _TCG_BOOT_SERVICE_CAPABILITY {
+-        UINT8 Size;
+-        struct _TCG_VERSION StructureVersion;
+-        struct _TCG_VERSION ProtocolSpecVersion;
+-        UINT8 HashAlgorithmBitmap;
+-        BOOLEAN TPMPresentFlag;
+-        BOOLEAN TPMDeactivatedFlag;
+-} TCG_BOOT_SERVICE_CAPABILITY;
+-
+-typedef struct tdTREE_BOOT_SERVICE_CAPABILITY {
+-        UINT8 Size;
+-        EFI_TCG2_VERSION StructureVersion;
+-        EFI_TCG2_VERSION ProtocolVersion;
+-        UINT32 HashAlgorithmBitmap;
+-        UINT32 SupportedEventLogs;
+-        BOOLEAN TrEEPresentFlag;
+-        UINT16 MaxCommandSize;
+-        UINT16 MaxResponseSize;
+-        UINT32 ManufacturerID;
+-} TREE_BOOT_SERVICE_CAPABILITY;
+-
+-typedef UINT32 TCG_ALGORITHM_ID;
+-#define TCG_ALG_SHA 0x00000004  // The SHA1 algorithm
+-
+-#define SHA1_DIGEST_SIZE 20
+-
+-typedef struct _TCG_DIGEST {
+-        UINT8 Digest[SHA1_DIGEST_SIZE];
+-} TCG_DIGEST;
+-
+-#define EV_IPL 13
+-
+-typedef struct _TCG_PCR_EVENT {
+-        UINT32 PCRIndex;
+-        UINT32 EventType;
+-        struct _TCG_DIGEST digest;
+-        UINT32 EventSize;
+-        UINT8 Event[1];
+-} TCG_PCR_EVENT;
+-
+-INTERFACE_DECL(_EFI_TCG);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG_STATUS_CHECK) (IN struct _EFI_TCG * This,
+-                                                   OUT struct _TCG_BOOT_SERVICE_CAPABILITY * ProtocolCapability,
+-                                                   OUT UINT32 * TCGFeatureFlags,
+-                                                   OUT EFI_PHYSICAL_ADDRESS * EventLogLocation,
+-                                                   OUT EFI_PHYSICAL_ADDRESS * EventLogLastEntry);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG_HASH_ALL) (IN struct _EFI_TCG * This,
+-                                               IN UINT8 * HashData,
+-                                               IN UINT64 HashDataLen,
+-                                               IN TCG_ALGORITHM_ID AlgorithmId,
+-                                               IN OUT UINT64 * HashedDataLen, IN OUT UINT8 ** HashedDataResult);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG_LOG_EVENT) (IN struct _EFI_TCG * This,
+-                                                IN struct _TCG_PCR_EVENT * TCGLogData,
+-                                                IN OUT UINT32 * EventNumber, IN UINT32 Flags);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG_PASS_THROUGH_TO_TPM) (IN struct _EFI_TCG * This,
+-                                                          IN UINT32 TpmInputParameterBlockSize,
+-                                                          IN UINT8 * TpmInputParameterBlock,
+-                                                          IN UINT32 TpmOutputParameterBlockSize,
+-                                                          IN UINT8 * TpmOutputParameterBlock);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG_HASH_LOG_EXTEND_EVENT) (IN struct _EFI_TCG * This,
+-                                                            IN EFI_PHYSICAL_ADDRESS HashData,
+-                                                            IN UINT64 HashDataLen,
+-                                                            IN TCG_ALGORITHM_ID AlgorithmId,
+-                                                            IN struct _TCG_PCR_EVENT * TCGLogData,
+-                                                            IN OUT UINT32 * EventNumber,
+-                                                            OUT EFI_PHYSICAL_ADDRESS * EventLogLastEntry);
+-
+-typedef struct _EFI_TCG {
+-        EFI_TCG_STATUS_CHECK StatusCheck;
+-        EFI_TCG_HASH_ALL HashAll;
+-        EFI_TCG_LOG_EVENT LogEvent;
+-        EFI_TCG_PASS_THROUGH_TO_TPM PassThroughToTPM;
+-        EFI_TCG_HASH_LOG_EXTEND_EVENT HashLogExtendEvent;
+-} EFI_TCG;
+-
+-#define EFI_TCG2_GUID \
+-        &(const EFI_GUID) { 0x607f766c, 0x7455, 0x42be, { 0x93, 0x0b, 0xe4, 0xd7, 0x6d, 0xb2, 0x72, 0x0f } }
+-
+-typedef struct tdEFI_TCG2_PROTOCOL EFI_TCG2_PROTOCOL;
+-
+-typedef UINT32 EFI_TCG2_EVENT_LOG_BITMAP;
+-typedef UINT32 EFI_TCG2_EVENT_LOG_FORMAT;
+-typedef UINT32 EFI_TCG2_EVENT_ALGORITHM_BITMAP;
+-
+-typedef struct tdEFI_TCG2_BOOT_SERVICE_CAPABILITY {
+-        UINT8 Size;
+-        EFI_TCG2_VERSION StructureVersion;
+-        EFI_TCG2_VERSION ProtocolVersion;
+-        EFI_TCG2_EVENT_ALGORITHM_BITMAP HashAlgorithmBitmap;
+-        EFI_TCG2_EVENT_LOG_BITMAP SupportedEventLogs;
+-        BOOLEAN TPMPresentFlag;
+-        UINT16 MaxCommandSize;
+-        UINT16 MaxResponseSize;
+-        UINT32 ManufacturerID;
+-        UINT32 NumberOfPCRBanks;
+-        EFI_TCG2_EVENT_ALGORITHM_BITMAP ActivePcrBanks;
+-} EFI_TCG2_BOOT_SERVICE_CAPABILITY;
+-
+-#define EFI_TCG2_EVENT_HEADER_VERSION  1
+-
+-typedef struct {
+-        UINT32 HeaderSize;
+-        UINT16 HeaderVersion;
+-        UINT32 PCRIndex;
+-        UINT32 EventType;
+-} _packed_ EFI_TCG2_EVENT_HEADER;
+-
+-typedef struct tdEFI_TCG2_EVENT {
+-        UINT32 Size;
+-        EFI_TCG2_EVENT_HEADER Header;
+-        UINT8 Event[1];
+-} _packed_ EFI_TCG2_EVENT;
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_CAPABILITY) (IN EFI_TCG2_PROTOCOL * This,
+-                                                      IN OUT EFI_TCG2_BOOT_SERVICE_CAPABILITY * ProtocolCapability);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_EVENT_LOG) (IN EFI_TCG2_PROTOCOL * This,
+-                                                     IN EFI_TCG2_EVENT_LOG_FORMAT EventLogFormat,
+-                                                     OUT EFI_PHYSICAL_ADDRESS * EventLogLocation,
+-                                                     OUT EFI_PHYSICAL_ADDRESS * EventLogLastEntry,
+-                                                     OUT BOOLEAN * EventLogTruncated);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG2_HASH_LOG_EXTEND_EVENT) (IN EFI_TCG2_PROTOCOL * This,
+-                                                             IN UINT64 Flags,
+-                                                             IN EFI_PHYSICAL_ADDRESS DataToHash,
+-                                                             IN UINT64 DataToHashLen, IN EFI_TCG2_EVENT * EfiTcgEvent);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG2_SUBMIT_COMMAND) (IN EFI_TCG2_PROTOCOL * This,
+-                                                      IN UINT32 InputParameterBlockSize,
+-                                                      IN UINT8 * InputParameterBlock,
+-                                                      IN UINT32 OutputParameterBlockSize, IN UINT8 * OutputParameterBlock);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_ACTIVE_PCR_BANKS) (IN EFI_TCG2_PROTOCOL * This, OUT UINT32 * ActivePcrBanks);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG2_SET_ACTIVE_PCR_BANKS) (IN EFI_TCG2_PROTOCOL * This, IN UINT32 ActivePcrBanks);
+-
+-typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_RESULT_OF_SET_ACTIVE_PCR_BANKS) (IN EFI_TCG2_PROTOCOL * This,
+-                                                                          OUT UINT32 * OperationPresent, OUT UINT32 * Response);
+-
+-typedef struct tdEFI_TCG2_PROTOCOL {
+-        EFI_TCG2_GET_CAPABILITY GetCapability;
+-        EFI_TCG2_GET_EVENT_LOG GetEventLog;
+-        EFI_TCG2_HASH_LOG_EXTEND_EVENT HashLogExtendEvent;
+-        EFI_TCG2_SUBMIT_COMMAND SubmitCommand;
+-        EFI_TCG2_GET_ACTIVE_PCR_BANKS GetActivePcrBanks;
+-        EFI_TCG2_SET_ACTIVE_PCR_BANKS SetActivePcrBanks;
+-        EFI_TCG2_GET_RESULT_OF_SET_ACTIVE_PCR_BANKS GetResultOfSetActivePcrBanks;
+-} EFI_TCG2;
++#include "missing_efi.h"
+ 
+ static EFI_STATUS tpm1_measure_to_pcr_and_event_log(const EFI_TCG *tcg, UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer,
+                                                     UINTN buffer_size, const CHAR16 *description) {
+diff --git a/src/boot/efi/missing_efi.h b/src/boot/efi/missing_efi.h
+index 91bf3e65d..badf0017a 100644
+--- a/src/boot/efi/missing_efi.h
++++ b/src/boot/efi/missing_efi.h
+@@ -3,6 +3,8 @@
+ 
+ #include <efi.h>
+ 
++#include "macro-fundamental.h"
++
+ #ifndef EFI_RNG_PROTOCOL_GUID
+ 
+ #define EFI_RNG_PROTOCOL_GUID                                           \
+@@ -159,4 +161,173 @@ struct _EFI_DT_FIXUP_PROTOCOL {
+         EFI_DT_FIXUP   Fixup;
+ };
+ 
++#define EFI_TCG_GUID \
++        &(const EFI_GUID) { 0xf541796d, 0xa62e, 0x4954, { 0xa7, 0x75, 0x95, 0x84, 0xf6, 0x1b, 0x9c, 0xdd } }
++
++typedef struct _TCG_VERSION {
++        UINT8 Major;
++        UINT8 Minor;
++        UINT8 RevMajor;
++        UINT8 RevMinor;
++} TCG_VERSION;
++
++typedef struct tdEFI_TCG2_VERSION {
++        UINT8 Major;
++        UINT8 Minor;
++} EFI_TCG2_VERSION;
++
++typedef struct _TCG_BOOT_SERVICE_CAPABILITY {
++        UINT8 Size;
++        struct _TCG_VERSION StructureVersion;
++        struct _TCG_VERSION ProtocolSpecVersion;
++        UINT8 HashAlgorithmBitmap;
++        BOOLEAN TPMPresentFlag;
++        BOOLEAN TPMDeactivatedFlag;
++} TCG_BOOT_SERVICE_CAPABILITY;
++
++typedef struct tdTREE_BOOT_SERVICE_CAPABILITY {
++        UINT8 Size;
++        EFI_TCG2_VERSION StructureVersion;
++        EFI_TCG2_VERSION ProtocolVersion;
++        UINT32 HashAlgorithmBitmap;
++        UINT32 SupportedEventLogs;
++        BOOLEAN TrEEPresentFlag;
++        UINT16 MaxCommandSize;
++        UINT16 MaxResponseSize;
++        UINT32 ManufacturerID;
++} TREE_BOOT_SERVICE_CAPABILITY;
++
++typedef UINT32 TCG_ALGORITHM_ID;
++#define TCG_ALG_SHA 0x00000004  // The SHA1 algorithm
++
++#define SHA1_DIGEST_SIZE 20
++
++typedef struct _TCG_DIGEST {
++        UINT8 Digest[SHA1_DIGEST_SIZE];
++} TCG_DIGEST;
++
++#define EV_IPL 13
++
++typedef struct _TCG_PCR_EVENT {
++        UINT32 PCRIndex;
++        UINT32 EventType;
++        struct _TCG_DIGEST digest;
++        UINT32 EventSize;
++        UINT8 Event[1];
++} TCG_PCR_EVENT;
++
++INTERFACE_DECL(_EFI_TCG);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG_STATUS_CHECK) (IN struct _EFI_TCG * This,
++                                                   OUT struct _TCG_BOOT_SERVICE_CAPABILITY * ProtocolCapability,
++                                                   OUT UINT32 * TCGFeatureFlags,
++                                                   OUT EFI_PHYSICAL_ADDRESS * EventLogLocation,
++                                                   OUT EFI_PHYSICAL_ADDRESS * EventLogLastEntry);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG_HASH_ALL) (IN struct _EFI_TCG * This,
++                                               IN UINT8 * HashData,
++                                               IN UINT64 HashDataLen,
++                                               IN TCG_ALGORITHM_ID AlgorithmId,
++                                               IN OUT UINT64 * HashedDataLen, IN OUT UINT8 ** HashedDataResult);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG_LOG_EVENT) (IN struct _EFI_TCG * This,
++                                                IN struct _TCG_PCR_EVENT * TCGLogData,
++                                                IN OUT UINT32 * EventNumber, IN UINT32 Flags);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG_PASS_THROUGH_TO_TPM) (IN struct _EFI_TCG * This,
++                                                          IN UINT32 TpmInputParameterBlockSize,
++                                                          IN UINT8 * TpmInputParameterBlock,
++                                                          IN UINT32 TpmOutputParameterBlockSize,
++                                                          IN UINT8 * TpmOutputParameterBlock);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG_HASH_LOG_EXTEND_EVENT) (IN struct _EFI_TCG * This,
++                                                            IN EFI_PHYSICAL_ADDRESS HashData,
++                                                            IN UINT64 HashDataLen,
++                                                            IN TCG_ALGORITHM_ID AlgorithmId,
++                                                            IN struct _TCG_PCR_EVENT * TCGLogData,
++                                                            IN OUT UINT32 * EventNumber,
++                                                            OUT EFI_PHYSICAL_ADDRESS * EventLogLastEntry);
++
++typedef struct _EFI_TCG {
++        EFI_TCG_STATUS_CHECK StatusCheck;
++        EFI_TCG_HASH_ALL HashAll;
++        EFI_TCG_LOG_EVENT LogEvent;
++        EFI_TCG_PASS_THROUGH_TO_TPM PassThroughToTPM;
++        EFI_TCG_HASH_LOG_EXTEND_EVENT HashLogExtendEvent;
++} EFI_TCG;
++
++#define EFI_TCG2_GUID \
++        &(const EFI_GUID) { 0x607f766c, 0x7455, 0x42be, { 0x93, 0x0b, 0xe4, 0xd7, 0x6d, 0xb2, 0x72, 0x0f } }
++
++typedef struct tdEFI_TCG2_PROTOCOL EFI_TCG2_PROTOCOL;
++
++typedef UINT32 EFI_TCG2_EVENT_LOG_BITMAP;
++typedef UINT32 EFI_TCG2_EVENT_LOG_FORMAT;
++typedef UINT32 EFI_TCG2_EVENT_ALGORITHM_BITMAP;
++
++typedef struct tdEFI_TCG2_BOOT_SERVICE_CAPABILITY {
++        UINT8 Size;
++        EFI_TCG2_VERSION StructureVersion;
++        EFI_TCG2_VERSION ProtocolVersion;
++        EFI_TCG2_EVENT_ALGORITHM_BITMAP HashAlgorithmBitmap;
++        EFI_TCG2_EVENT_LOG_BITMAP SupportedEventLogs;
++        BOOLEAN TPMPresentFlag;
++        UINT16 MaxCommandSize;
++        UINT16 MaxResponseSize;
++        UINT32 ManufacturerID;
++        UINT32 NumberOfPCRBanks;
++        EFI_TCG2_EVENT_ALGORITHM_BITMAP ActivePcrBanks;
++} EFI_TCG2_BOOT_SERVICE_CAPABILITY;
++
++#define EFI_TCG2_EVENT_HEADER_VERSION  1
++
++typedef struct {
++        UINT32 HeaderSize;
++        UINT16 HeaderVersion;
++        UINT32 PCRIndex;
++        UINT32 EventType;
++} _packed_ EFI_TCG2_EVENT_HEADER;
++
++typedef struct tdEFI_TCG2_EVENT {
++        UINT32 Size;
++        EFI_TCG2_EVENT_HEADER Header;
++        UINT8 Event[1];
++} _packed_ EFI_TCG2_EVENT;
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_CAPABILITY) (IN EFI_TCG2_PROTOCOL * This,
++                                                      IN OUT EFI_TCG2_BOOT_SERVICE_CAPABILITY * ProtocolCapability);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_EVENT_LOG) (IN EFI_TCG2_PROTOCOL * This,
++                                                     IN EFI_TCG2_EVENT_LOG_FORMAT EventLogFormat,
++                                                     OUT EFI_PHYSICAL_ADDRESS * EventLogLocation,
++                                                     OUT EFI_PHYSICAL_ADDRESS * EventLogLastEntry,
++                                                     OUT BOOLEAN * EventLogTruncated);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG2_HASH_LOG_EXTEND_EVENT) (IN EFI_TCG2_PROTOCOL * This,
++                                                             IN UINT64 Flags,
++                                                             IN EFI_PHYSICAL_ADDRESS DataToHash,
++                                                             IN UINT64 DataToHashLen, IN EFI_TCG2_EVENT * EfiTcgEvent);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG2_SUBMIT_COMMAND) (IN EFI_TCG2_PROTOCOL * This,
++                                                      IN UINT32 InputParameterBlockSize,
++                                                      IN UINT8 * InputParameterBlock,
++                                                      IN UINT32 OutputParameterBlockSize, IN UINT8 * OutputParameterBlock);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_ACTIVE_PCR_BANKS) (IN EFI_TCG2_PROTOCOL * This, OUT UINT32 * ActivePcrBanks);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG2_SET_ACTIVE_PCR_BANKS) (IN EFI_TCG2_PROTOCOL * This, IN UINT32 ActivePcrBanks);
++
++typedef EFI_STATUS(EFIAPI * EFI_TCG2_GET_RESULT_OF_SET_ACTIVE_PCR_BANKS) (IN EFI_TCG2_PROTOCOL * This,
++                                                                          OUT UINT32 * OperationPresent, OUT UINT32 * Response);
++
++typedef struct tdEFI_TCG2_PROTOCOL {
++        EFI_TCG2_GET_CAPABILITY GetCapability;
++        EFI_TCG2_GET_EVENT_LOG GetEventLog;
++        EFI_TCG2_HASH_LOG_EXTEND_EVENT HashLogExtendEvent;
++        EFI_TCG2_SUBMIT_COMMAND SubmitCommand;
++        EFI_TCG2_GET_ACTIVE_PCR_BANKS GetActivePcrBanks;
++        EFI_TCG2_SET_ACTIVE_PCR_BANKS SetActivePcrBanks;
++        EFI_TCG2_GET_RESULT_OF_SET_ACTIVE_PCR_BANKS GetResultOfSetActivePcrBanks;
++} EFI_TCG2;
++
+ #endif
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0033-boot-modernize-measure.c.patch
+++ b/vendor/systemd-patches/0033-boot-modernize-measure.c.patch
@@ -1,0 +1,207 @@
+From a0fc95dc80abc576a01ea269e95c98496c376aad Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 20 Sep 2021 13:33:18 +0200
+Subject: [PATCH 33/73] boot: modernize measure.c
+
+Let's use _cleanup_freepool_, compound literals for initialization,
+OFFSETOF() and let's remove some unnecessary casts.
+
+No change in behaviour.
+---
+ src/boot/efi/measure.c | 129 ++++++++++++++++++++++-------------------
+ 1 file changed, 69 insertions(+), 60 deletions(-)
+
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index 112acd78c..fbca67bbf 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -8,91 +8,101 @@
+ #include "macro-fundamental.h"
+ #include "measure.h"
+ #include "missing_efi.h"
++#include "util.h"
+ 
+-static EFI_STATUS tpm1_measure_to_pcr_and_event_log(const EFI_TCG *tcg, UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer,
+-                                                    UINTN buffer_size, const CHAR16 *description) {
+-        EFI_STATUS status;
+-        TCG_PCR_EVENT *tcg_event;
+-        UINT32 event_number;
++static EFI_STATUS tpm1_measure_to_pcr_and_event_log(
++                const EFI_TCG *tcg,
++                UINT32 pcrindex,
++                EFI_PHYSICAL_ADDRESS buffer,
++                UINTN buffer_size,
++                const CHAR16 *description) {
++
++        _cleanup_freepool_ TCG_PCR_EVENT *tcg_event = NULL;
+         EFI_PHYSICAL_ADDRESS event_log_last;
++        UINT32 event_number = 1;
+         UINTN desc_len;
+ 
+         assert(tcg);
+         assert(description);
+ 
+         desc_len = StrSize(description);
+-        tcg_event = AllocateZeroPool(desc_len + sizeof(TCG_PCR_EVENT));
+-
++        tcg_event = AllocateZeroPool(OFFSETOF(TCG_PCR_EVENT, Event) + desc_len);
+         if (!tcg_event)
+                 return EFI_OUT_OF_RESOURCES;
+ 
+-        tcg_event->EventSize = desc_len;
+-        CopyMem((VOID *) & tcg_event->Event[0], (VOID *) description, desc_len);
+-
+-        tcg_event->PCRIndex = pcrindex;
+-        tcg_event->EventType = EV_IPL;
+-
+-        event_number = 1;
+-        status = uefi_call_wrapper(tcg->HashLogExtendEvent, 7,
+-                                   (EFI_TCG *) tcg, buffer, buffer_size, TCG_ALG_SHA, tcg_event, &event_number, &event_log_last);
+-
+-        if (EFI_ERROR(status))
+-                return status;
+-
+-        uefi_call_wrapper(BS->FreePool, 1, tcg_event);
+-
+-        return EFI_SUCCESS;
++        *tcg_event = (TCG_PCR_EVENT) {
++                .EventSize = desc_len,
++                .PCRIndex = pcrindex,
++                .EventType = EV_IPL,
++        };
++        CopyMem(tcg_event->Event, description, desc_len);
++
++        return uefi_call_wrapper(
++                        tcg->HashLogExtendEvent, 7,
++                        (EFI_TCG *) tcg,
++                        buffer, buffer_size,
++                        TCG_ALG_SHA,
++                        tcg_event,
++                        &event_number,
++                        &event_log_last);
+ }
+ 
+-static EFI_STATUS tpm2_measure_to_pcr_and_event_log(const EFI_TCG2 *tcg, UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer,
+-                                                    UINT64 buffer_size, const CHAR16 *description) {
+-        EFI_STATUS status;
+-        EFI_TCG2_EVENT *tcg_event;
++static EFI_STATUS tpm2_measure_to_pcr_and_event_log(
++                EFI_TCG2 *tcg,
++                UINT32 pcrindex,
++                EFI_PHYSICAL_ADDRESS buffer,
++                UINT64 buffer_size,
++                const CHAR16 *description) {
++
++        _cleanup_freepool_ EFI_TCG2_EVENT *tcg_event = NULL;
+         UINTN desc_len;
+ 
+         assert(tcg);
+         assert(description);
+ 
+         desc_len = StrSize(description);
+-        tcg_event = AllocateZeroPool(sizeof(*tcg_event) - sizeof(tcg_event->Event) + desc_len);
+-
++        tcg_event = AllocateZeroPool(OFFSETOF(EFI_TCG2_EVENT, Event) + desc_len);
+         if (!tcg_event)
+                 return EFI_OUT_OF_RESOURCES;
+ 
+-        tcg_event->Size = sizeof(*tcg_event) - sizeof(tcg_event->Event) + desc_len;
+-        tcg_event->Header.HeaderSize = sizeof(EFI_TCG2_EVENT_HEADER);
+-        tcg_event->Header.HeaderVersion = EFI_TCG2_EVENT_HEADER_VERSION;
+-        tcg_event->Header.PCRIndex = pcrindex;
+-        tcg_event->Header.EventType = EV_IPL;
+-
+-        CopyMem((VOID *) tcg_event->Event, (VOID *) description, desc_len);
+-
+-        status = uefi_call_wrapper(tcg->HashLogExtendEvent, 5, (EFI_TCG2 *) tcg, 0, buffer, (UINT64) buffer_size, tcg_event);
+-
+-        uefi_call_wrapper(BS->FreePool, 1, tcg_event);
+-
+-        if (EFI_ERROR(status))
+-                return status;
+-
+-        return EFI_SUCCESS;
++        *tcg_event = (EFI_TCG2_EVENT) {
++                .Size = OFFSETOF(EFI_TCG2_EVENT, Event) + desc_len,
++                .Header.HeaderSize = sizeof(EFI_TCG2_EVENT_HEADER),
++                .Header.HeaderVersion = EFI_TCG2_EVENT_HEADER_VERSION,
++                .Header.PCRIndex = pcrindex,
++                .Header.EventType = EV_IPL,
++        };
++
++        CopyMem(tcg_event->Event, description, desc_len);
++
++        return uefi_call_wrapper(
++                        tcg->HashLogExtendEvent, 5,
++                        tcg,
++                        0,
++                        buffer, buffer_size,
++                        tcg_event);
+ }
+ 
+-static EFI_TCG * tcg1_interface_check(void) {
++static EFI_TCG *tcg1_interface_check(void) {
++        EFI_PHYSICAL_ADDRESS event_log_location, event_log_last_entry;
++        TCG_BOOT_SERVICE_CAPABILITY capability = {
++                .Size = sizeof(capability),
++        };
+         EFI_STATUS status;
+-        EFI_TCG *tcg;
+-        TCG_BOOT_SERVICE_CAPABILITY capability;
+         UINT32 features;
+-        EFI_PHYSICAL_ADDRESS event_log_location;
+-        EFI_PHYSICAL_ADDRESS event_log_last_entry;
++        EFI_TCG *tcg;
+ 
+         status = LibLocateProtocol((EFI_GUID*) EFI_TCG_GUID, (void **) &tcg);
+-
+         if (EFI_ERROR(status))
+                 return NULL;
+ 
+-        capability.Size = (UINT8) sizeof(capability);
+-        status = uefi_call_wrapper(tcg->StatusCheck, 5, tcg, &capability, &features, &event_log_location, &event_log_last_entry);
+-
++        status = uefi_call_wrapper(
++                        tcg->StatusCheck, 5,
++                        tcg,
++                        &capability,
++                        &features,
++                        &event_log_location,
++                        &event_log_last_entry);
+         if (EFI_ERROR(status))
+                 return NULL;
+ 
+@@ -106,25 +116,24 @@ static EFI_TCG * tcg1_interface_check(void) {
+ }
+ 
+ static EFI_TCG2 * tcg2_interface_check(void) {
++        EFI_TCG2_BOOT_SERVICE_CAPABILITY capability = {
++                .Size = sizeof(capability),
++        };
+         EFI_STATUS status;
+         EFI_TCG2 *tcg;
+-        EFI_TCG2_BOOT_SERVICE_CAPABILITY capability;
+ 
+         status = LibLocateProtocol((EFI_GUID*) EFI_TCG2_GUID, (void **) &tcg);
+-
+         if (EFI_ERROR(status))
+                 return NULL;
+ 
+-        capability.Size = (UINT8) sizeof(EFI_TCG2_BOOT_SERVICE_CAPABILITY);
+         status = uefi_call_wrapper(tcg->GetCapability, 2, tcg, &capability);
+-
+         if (EFI_ERROR(status))
+                 return NULL;
+ 
+         if (capability.StructureVersion.Major == 1 &&
+             capability.StructureVersion.Minor == 0) {
+-                TCG_BOOT_SERVICE_CAPABILITY *caps_1_0;
+-                caps_1_0 = (TCG_BOOT_SERVICE_CAPABILITY *)&capability;
++                TCG_BOOT_SERVICE_CAPABILITY *caps_1_0 =
++                        (TCG_BOOT_SERVICE_CAPABILITY*) &capability;
+                 if (caps_1_0->TPMPresentFlag)
+                         return tcg;
+         }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0034-boot-ReallocatePool-supports-NULL-pointers-as-first-.patch
+++ b/vendor/systemd-patches/0034-boot-ReallocatePool-supports-NULL-pointers-as-first-.patch
@@ -1,0 +1,42 @@
+From 51c580cbf0f5ca33b856d275a91abfc71afd80b8 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 20 Sep 2021 14:06:23 +0200
+Subject: [PATCH 34/73] boot: ReallocatePool() supports NULL pointers as first
+ argument
+
+Just like userspace realloc() the EFIlib ReallocatePool() function is
+happy to use a NULL pointer as input, in which case it is equivalent to
+AllocatePool(). See:
+
+https://github.com/vathpela/gnu-efi/blob/269ef9dbc77ebec2723e0e6ae082bbca9516f5f1/lib/misc.c#L57
+---
+ src/boot/efi/boot.c | 13 +++++--------
+ 1 file changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 106fda925..074a85659 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -912,14 +912,11 @@ static VOID config_add_entry(Config *config, ConfigEntry *entry) {
+         assert(entry);
+ 
+         if ((config->entry_count & 15) == 0) {
+-                UINTN i;
+-
+-                i = config->entry_count + 16;
+-                if (config->entry_count == 0)
+-                        config->entries = AllocatePool(sizeof(VOID *) * i);
+-                else
+-                        config->entries = ReallocatePool(config->entries,
+-                                                         sizeof(VOID *) * config->entry_count, sizeof(VOID *) * i);
++                UINTN i = config->entry_count + 16;
++                config->entries = ReallocatePool(
++                                config->entries,
++                                sizeof(VOID *) * config->entry_count,
++                                sizeof(VOID *) * i);
+         }
+         config->entries[config->entry_count++] = entry;
+ }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0035-stub-use-proper-enums-instead-of-hardcoded-numeric-i.patch
+++ b/vendor/systemd-patches/0035-stub-use-proper-enums-instead-of-hardcoded-numeric-i.patch
@@ -1,0 +1,90 @@
+From 551d428215ec4e64709d38a0c2687a4a9825ce3b Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Thu, 16 Sep 2021 23:59:39 +0200
+Subject: [PATCH 35/73] stub: use proper enums instead of hardcoded numeric
+ indexes for identifying PE sections
+
+---
+ src/boot/efi/stub.c | 45 +++++++++++++++++++++++++++------------------
+ 1 file changed, 27 insertions(+), 18 deletions(-)
+
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 5758b5cd9..4879896ac 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -17,17 +17,26 @@ static const char __attribute__((used)) magic[] = "#### LoaderInfo: systemd-stub
+ 
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         EFI_LOADED_IMAGE *loaded_image;
+-        const CHAR8 *sections[] = {
+-                (CHAR8 *)".cmdline",
+-                (CHAR8 *)".linux",
+-                (CHAR8 *)".initrd",
+-                (CHAR8 *)".splash",
+-                NULL
++
++        enum {
++                SECTION_CMDLINE,
++                SECTION_LINUX,
++                SECTION_INITRD,
++                SECTION_SPLASH,
++                _SECTION_MAX,
++        };
++
++        const CHAR8* const sections[] = {
++                [SECTION_CMDLINE] = (const CHAR8*) ".cmdline",
++                [SECTION_LINUX]   = (const CHAR8*) ".linux",
++                [SECTION_INITRD]  = (const CHAR8*) ".initrd",
++                [SECTION_SPLASH]  = (const CHAR8*) ".splash",
++                NULL,
+         };
+-        UINTN addrs[ELEMENTSOF(sections)-1] = {};
+-        UINTN szs[ELEMENTSOF(sections)-1] = {};
++        UINTN addrs[_SECTION_MAX] = {};
++        UINTN szs[_SECTION_MAX] = {};
+         CHAR8 *cmdline = NULL;
+-        UINTN cmdline_len;
++        UINTN cmdline_len = 0;
+         CHAR16 uuid[37];
+         EFI_STATUS err;
+ 
+@@ -38,14 +47,14 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Error getting a LoadedImageProtocol handle: %r", err);
+ 
+-        err = pe_memory_locate_sections(loaded_image->ImageBase, sections, addrs, szs);
++        err = pe_memory_locate_sections(loaded_image->ImageBase, (const CHAR8**) sections, addrs, szs);
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Unable to locate embedded .linux section: %r", err);
+ 
+-        if (szs[0] > 0)
+-                cmdline = (CHAR8 *)(loaded_image->ImageBase) + addrs[0];
+-
+-        cmdline_len = szs[0];
++        if (szs[SECTION_CMDLINE] > 0) {
++                cmdline = (CHAR8 *)(loaded_image->ImageBase) + addrs[SECTION_CMDLINE];
++                cmdline_len = szs[SECTION_CMDLINE];
++        }
+ 
+         /* if we are not in secure boot mode, or none was provided, accept a custom command line and replace the built-in one */
+         if ((!secure_boot_enabled() || cmdline_len == 0) && loaded_image->LoadOptionsSize > 0 &&
+@@ -109,12 +118,12 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         if (efivar_get_raw(LOADER_GUID, L"StubInfo", NULL, NULL) != EFI_SUCCESS)
+                 efivar_set(LOADER_GUID, L"StubInfo", L"systemd-stub " GIT_VERSION, 0);
+ 
+-        if (szs[3] > 0)
+-                graphics_splash((UINT8 *)((UINTN)loaded_image->ImageBase + addrs[3]), szs[3], NULL);
++        if (szs[SECTION_SPLASH] > 0)
++                graphics_splash((UINT8 *)((UINTN)loaded_image->ImageBase + addrs[SECTION_SPLASH]), szs[SECTION_SPLASH], NULL);
+ 
+         err = linux_exec(image, cmdline, cmdline_len,
+-                         (UINTN)loaded_image->ImageBase + addrs[1],
+-                         (UINTN)loaded_image->ImageBase + addrs[2], szs[2]);
++                         (UINTN)loaded_image->ImageBase + addrs[SECTION_LINUX],
++                         (UINTN)loaded_image->ImageBase + addrs[SECTION_INITRD], szs[SECTION_INITRD]);
+ 
+         graphics_mode(FALSE);
+         return log_error_status_stall(err, L"Execution of embedded linux image failed: %r", err);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0036-stub-prepare-section-pointers-in-separate-steps.patch
+++ b/vendor/systemd-patches/0036-stub-prepare-section-pointers-in-separate-steps.patch
@@ -1,0 +1,64 @@
+From 4ad186acf7a0cb1a9a50b0dd958b7e8c1411059f Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Fri, 17 Sep 2021 10:15:57 +0200
+Subject: [PATCH 36/73] stub: prepare section pointers in separate steps
+
+In a follow-up patch we are going to modify the initrd, hence prepare
+the pointers/"physical addresses" to it, first, so that we can do so
+easily.
+
+Also, do some other tweaks and cleanups to physical address/pointer
+conversion.
+---
+ src/boot/efi/stub.c | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 4879896ac..9a3c9982d 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -33,10 +33,12 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 [SECTION_SPLASH]  = (const CHAR8*) ".splash",
+                 NULL,
+         };
++
++        EFI_PHYSICAL_ADDRESS linux_base, initrd_base;
++        UINTN cmdline_len = 0, initrd_size;
+         UINTN addrs[_SECTION_MAX] = {};
+         UINTN szs[_SECTION_MAX] = {};
+         CHAR8 *cmdline = NULL;
+-        UINTN cmdline_len = 0;
+         CHAR16 uuid[37];
+         EFI_STATUS err;
+ 
+@@ -52,7 +54,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 return log_error_status_stall(err, L"Unable to locate embedded .linux section: %r", err);
+ 
+         if (szs[SECTION_CMDLINE] > 0) {
+-                cmdline = (CHAR8 *)(loaded_image->ImageBase) + addrs[SECTION_CMDLINE];
++                cmdline = (CHAR8*) loaded_image->ImageBase + addrs[SECTION_CMDLINE];
+                 cmdline_len = szs[SECTION_CMDLINE];
+         }
+ 
+@@ -119,11 +121,14 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 efivar_set(LOADER_GUID, L"StubInfo", L"systemd-stub " GIT_VERSION, 0);
+ 
+         if (szs[SECTION_SPLASH] > 0)
+-                graphics_splash((UINT8 *)((UINTN)loaded_image->ImageBase + addrs[SECTION_SPLASH]), szs[SECTION_SPLASH], NULL);
++                graphics_splash((UINT8*) (UINTN) loaded_image->ImageBase + addrs[SECTION_SPLASH], szs[SECTION_SPLASH], NULL);
++
++        linux_base = (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->ImageBase + addrs[SECTION_LINUX];
++
++        initrd_size = szs[SECTION_INITRD];
++        initrd_base = initrd_size != 0 ? (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->ImageBase + addrs[SECTION_INITRD] : 0;
+ 
+-        err = linux_exec(image, cmdline, cmdline_len,
+-                         (UINTN)loaded_image->ImageBase + addrs[SECTION_LINUX],
+-                         (UINTN)loaded_image->ImageBase + addrs[SECTION_INITRD], szs[SECTION_INITRD]);
++        err = linux_exec(image, cmdline, cmdline_len, linux_base, initrd_base, initrd_size);
+ 
+         graphics_mode(FALSE);
+         return log_error_status_stall(err, L"Execution of embedded linux image failed: %r", err);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0037-boot-add-a-way-to-indicate-overflow-in-ALIGN_TO.patch
+++ b/vendor/systemd-patches/0037-boot-add-a-way-to-indicate-overflow-in-ALIGN_TO.patch
@@ -1,0 +1,54 @@
+From c54c3663f5f0cdc36b79943e80418f433f6a142e Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Fri, 17 Sep 2021 10:48:46 +0200
+Subject: [PATCH 37/73] boot: add a way to indicate overflow in ALIGN_TO()
+
+---
+ src/boot/efi/util.h | 23 +++++++++++++----------
+ 1 file changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index a5b6435f1..2ee4f2b51 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -8,8 +8,20 @@
+ 
+ #define OFFSETOF(x,y) __builtin_offsetof(x,y)
+ 
++#define UINTN_MAX (~(UINTN)0)
++#define INTN_MAX ((INTN)(UINTN_MAX>>1))
++#ifndef UINT32_MAX
++#define UINT32_MAX ((UINT32) -1)
++#endif
++#ifndef UINT64_MAX
++#define UINT64_MAX ((UINT64) -1)
++#endif
++
+ static inline UINTN ALIGN_TO(UINTN l, UINTN ali) {
+-        return ((l + ali - 1) & ~(ali - 1));
++        if (l > UINTN_MAX - (ali - 1)) /* Overflow? */
++                return UINTN_MAX;
++
++        return ((l + (ali - 1)) & ~(ali - 1));
+ }
+ 
+ EFI_STATUS parse_boolean(const CHAR8 *v, BOOLEAN *b);
+@@ -65,15 +77,6 @@ static inline void FileHandleClosep(EFI_FILE_HANDLE *handle) {
+         &(const EFI_GUID) { 0x4a67b082, 0x0a4c, 0x41cf, { 0xb6, 0xc7, 0x44, 0x0b, 0x29, 0xbb, 0x8c, 0x4f } }
+ #define EFI_GLOBAL_GUID &(const EFI_GUID) EFI_GLOBAL_VARIABLE
+ 
+-#define UINTN_MAX (~(UINTN)0)
+-#define INTN_MAX ((INTN)(UINTN_MAX>>1))
+-#ifndef UINT32_MAX
+-#define UINT32_MAX ((UINT32) -1)
+-#endif
+-#ifndef UINT64_MAX
+-#define UINT64_MAX ((UINT64) -1)
+-#endif
+-
+ VOID log_error_stall(const CHAR16 *fmt, ...);
+ EFI_STATUS log_oom(void);
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0038-boot-add-a-bunch-of-new-helper-calls.patch
+++ b/vendor/systemd-patches/0038-boot-add-a-bunch-of-new-helper-calls.patch
@@ -1,0 +1,258 @@
+From f78d1cd5c921fa9ed030625b25dcf2e9db921330 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 20 Sep 2021 13:47:44 +0200
+Subject: [PATCH 38/73] boot: add a bunch of new helper calls
+
+---
+ src/boot/efi/util.c | 194 +++++++++++++++++++++++++++++++++++++++++++-
+ src/boot/efi/util.h |  17 ++++
+ 2 files changed, 207 insertions(+), 4 deletions(-)
+
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index 065e1ea39..68053c2c3 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -428,11 +428,14 @@ CHAR16 *stra_to_path(const CHAR8 *stra) {
+ }
+ 
+ CHAR8 *strchra(const CHAR8 *s, CHAR8 c) {
+-        assert(s);
++        if (!s)
++                return NULL;
++
+         do {
+                 if (*s == c)
+                         return (CHAR8*) s;
+         } while (*s++);
++
+         return NULL;
+ }
+ 
+@@ -451,9 +454,9 @@ EFI_STATUS file_read(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN off, UINTN s
+         if (size == 0) {
+                 _cleanup_freepool_ EFI_FILE_INFO *info = NULL;
+ 
+-                info = LibFileInfo(handle);
+-                if (!info)
+-                        return EFI_OUT_OF_RESOURCES;
++                err = get_file_info_harder(handle, &info, NULL);
++                if (EFI_ERROR(err))
++                        return err;
+ 
+                 size = info->FileSize+1;
+         }
+@@ -527,3 +530,186 @@ VOID clear_screen(UINTN attr) {
+         uefi_call_wrapper(ST->ConOut->SetAttribute, 2, ST->ConOut, attr);
+         uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+ }
++
++EFI_STATUS get_file_info_harder(
++                EFI_FILE_HANDLE handle,
++                EFI_FILE_INFO **ret,
++                UINTN *ret_size) {
++
++        static const EFI_GUID EfiFileInfoGuid = EFI_FILE_INFO_ID;
++        UINTN size = OFFSETOF(EFI_FILE_INFO, FileName) + 256;
++        _cleanup_freepool_ EFI_FILE_INFO *fi = NULL;
++        EFI_STATUS err;
++
++        assert(handle);
++        assert(ret);
++
++        /* A lot like LibFileInfo() but with useful error propagation */
++
++        fi = AllocatePool(size);
++        if (!fi)
++                return EFI_OUT_OF_RESOURCES;
++
++        err = uefi_call_wrapper(handle->GetInfo, 4, handle, (EFI_GUID*) &EfiFileInfoGuid, &size, fi);
++        if (err == EFI_BUFFER_TOO_SMALL) {
++                FreePool(fi);
++                fi = AllocatePool(size);  /* GetInfo tells us the required size, let's use that now */
++                if (!fi)
++                        return EFI_OUT_OF_RESOURCES;
++
++                err = uefi_call_wrapper(handle->GetInfo, 4, handle, (EFI_GUID*) &EfiFileInfoGuid, &size, fi);
++        }
++
++        if (EFI_ERROR(err))
++                return err;
++
++        *ret = TAKE_PTR(fi);
++
++        if (ret_size)
++                *ret_size = size;
++
++        return EFI_SUCCESS;
++}
++
++EFI_STATUS readdir_harder(
++                EFI_FILE_HANDLE handle,
++                EFI_FILE_INFO **buffer,
++                UINTN *buffer_size) {
++
++        EFI_STATUS err;
++        UINTN sz;
++
++        assert(handle);
++        assert(buffer);
++        assert(buffer_size);
++
++        /* buffer/buffer_size are both in and output parameters. Should be zero-initialized initially, and
++         * the specified buffer needs to be freed by caller, after final use. */
++
++        if (!*buffer) {
++                sz = OFFSETOF(EFI_FILE_INFO, FileName) /* + 256 */;
++
++                *buffer = AllocatePool(sz);
++                if (!*buffer)
++                        return EFI_OUT_OF_RESOURCES;
++
++                *buffer_size = sz;
++        } else
++                sz = *buffer_size;
++
++        err = uefi_call_wrapper(handle->Read, 3, handle, &sz, *buffer);
++        if (err == EFI_BUFFER_TOO_SMALL) {
++                FreePool(*buffer);
++
++                *buffer = AllocatePool(sz);
++                if (!*buffer) {
++                        *buffer_size = 0;
++                        return EFI_OUT_OF_RESOURCES;
++                }
++
++                *buffer_size = sz;
++
++                err = uefi_call_wrapper(handle->Read, 3, handle, &sz, *buffer);
++        }
++        if (EFI_ERROR(err))
++                return err;
++
++        if (sz == 0) {
++                /* End of directory */
++                FreePool(*buffer);
++                *buffer = NULL;
++                *buffer_size = 0;
++        }
++
++        return EFI_SUCCESS;
++}
++
++UINTN strnlena(const CHAR8 *p, UINTN maxlen) {
++        UINTN c;
++
++        if (!p)
++                return 0;
++
++        for (c = 0; c < maxlen; c++)
++                if (p[c] == 0)
++                        break;
++
++        return c;
++}
++
++CHAR8 *strndup8(const CHAR8 *p, UINTN sz) {
++        CHAR8 *n;
++
++        /* Following efilib's naming scheme this function would be called strndupa(), but we already have a
++         * function named like this in userspace, and it does something different there, hence to minimize
++         * confusion, let's pick a different name here */
++
++        assert(p || sz == 0);
++
++        sz = strnlena(p, sz);
++
++        n = AllocatePool(sz + 1);
++        if (!n)
++                return NULL;
++
++        if (sz > 0)
++                CopyMem(n, p, sz);
++        n[sz] = 0;
++
++        return n;
++}
++
++BOOLEAN is_ascii(const CHAR16 *f) {
++        if (!f)
++                return FALSE;
++
++        for (; *f != 0; f++)
++                if (*f > 127)
++                        return FALSE;
++
++        return TRUE;
++}
++
++CHAR16 **strv_free(CHAR16 **v) {
++        if (!v)
++                return NULL;
++
++        for (CHAR16 **i = v; *i; i++)
++                FreePool(*i);
++
++        FreePool(v);
++        return NULL;
++}
++
++EFI_STATUS open_directory(
++                EFI_FILE_HANDLE root,
++                const CHAR16 *path,
++                EFI_FILE_HANDLE *ret) {
++
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE dir = NULL;
++        _cleanup_freepool_ EFI_FILE_INFO *file_info = NULL;
++        EFI_STATUS err;
++
++        assert(root);
++
++        /* Opens a file, and then verifies it is actually a directory */
++
++        err = uefi_call_wrapper(
++                        root->Open, 5,
++                        root,
++                        &dir,
++                        (CHAR16*) path,
++                        EFI_FILE_MODE_READ,
++                        0ULL);
++        if (EFI_ERROR(err))
++                return err;
++
++        err = get_file_info_harder(dir, &file_info, NULL);
++        if (EFI_ERROR(err))
++                return err;
++        if (!(file_info->Attribute & EFI_FILE_DIRECTORY))
++                return EFI_LOAD_ERROR;
++
++        *ret = TAKE_PTR(dir);
++        return EFI_SUCCESS;
++}
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index 2ee4f2b51..45e6b940c 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -97,3 +97,20 @@ static inline VOID *mempmem_safe(const VOID *haystack, UINTN haystack_len, const
+ 
+ VOID print_at(UINTN x, UINTN y, UINTN attr, const CHAR16 *str);
+ VOID clear_screen(UINTN attr);
++
++EFI_STATUS get_file_info_harder(EFI_FILE_HANDLE handle, EFI_FILE_INFO **ret, UINTN *ret_size);
++
++EFI_STATUS readdir_harder(EFI_FILE_HANDLE handle, EFI_FILE_INFO **buffer, UINTN *buffer_size);
++
++UINTN strnlena(const CHAR8 *p, UINTN maxlen);
++CHAR8 *strndup8(const CHAR8 *p, UINTN sz);
++
++BOOLEAN is_ascii(const CHAR16 *f);
++
++CHAR16 **strv_free(CHAR16 **l);
++
++static inline void strv_freep(CHAR16 ***p) {
++        strv_free(*p);
++}
++
++EFI_STATUS open_directory(EFI_FILE_HANDLE root_dir, const CHAR16 *path, EFI_FILE_HANDLE *ret);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0039-boot-generalize-sorting-code.patch
+++ b/vendor/systemd-patches/0039-boot-generalize-sorting-code.patch
@@ -1,0 +1,109 @@
+From e606573e17505a20c6415b48fbb2b5491b4c3cd3 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 20 Sep 2021 14:07:42 +0200
+Subject: [PATCH 39/73] boot: generalize sorting code
+
+Let's make this generic, so that we can reuse it elsewhere later.
+---
+ src/boot/efi/boot.c | 21 ++-------------------
+ src/boot/efi/util.c | 30 ++++++++++++++++++++++++++++++
+ src/boot/efi/util.h |  3 +++
+ 3 files changed, 35 insertions(+), 19 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 074a85659..734ae56fb 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1529,7 +1529,7 @@ static VOID config_load_entries(
+         }
+ }
+ 
+-static INTN config_entry_compare(ConfigEntry *a, ConfigEntry *b) {
++static INTN config_entry_compare(const ConfigEntry *a, const ConfigEntry *b) {
+         INTN r;
+ 
+         assert(a);
+@@ -1567,24 +1567,7 @@ static INTN config_entry_compare(ConfigEntry *a, ConfigEntry *b) {
+ static VOID config_sort_entries(Config *config) {
+         assert(config);
+ 
+-        for (UINTN i = 1; i < config->entry_count; i++) {
+-                BOOLEAN more;
+-
+-                more = FALSE;
+-                for (UINTN k = 0; k < config->entry_count - i; k++) {
+-                        ConfigEntry *entry;
+-
+-                        if (config_entry_compare(config->entries[k], config->entries[k+1]) <= 0)
+-                                continue;
+-
+-                        entry = config->entries[k];
+-                        config->entries[k] = config->entries[k+1];
+-                        config->entries[k+1] = entry;
+-                        more = TRUE;
+-                }
+-                if (!more)
+-                        break;
+-        }
++        sort_pointer_array((void**) config->entries, config->entry_count, (compare_pointer_func_t) config_entry_compare);
+ }
+ 
+ static INTN config_entry_find(Config *config, CHAR16 *id) {
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index 68053c2c3..e500069d5 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -531,6 +531,36 @@ VOID clear_screen(UINTN attr) {
+         uefi_call_wrapper(ST->ConOut->ClearScreen, 1, ST->ConOut);
+ }
+ 
++void sort_pointer_array(
++                VOID **array,
++                UINTN n_members,
++                compare_pointer_func_t compare) {
++
++        assert(array || n_members == 0);
++        assert(compare);
++
++        if (n_members <= 1)
++                return;
++
++        for (UINTN i = 1; i < n_members; i++) {
++                BOOLEAN more = FALSE;
++
++                for (UINTN k = 0; k < n_members - i; k++) {
++                        void *entry;
++
++                        if (compare(array[k], array[k+1]) <= 0)
++                                continue;
++
++                        entry = array[k];
++                        array[k] = array[k+1];
++                        array[k+1] = entry;
++                        more = TRUE;
++                }
++                if (!more)
++                        break;
++        }
++}
++
+ EFI_STATUS get_file_info_harder(
+                 EFI_FILE_HANDLE handle,
+                 EFI_FILE_INFO **ret,
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index 45e6b940c..ea32a7616 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -98,6 +98,9 @@ static inline VOID *mempmem_safe(const VOID *haystack, UINTN haystack_len, const
+ VOID print_at(UINTN x, UINTN y, UINTN attr, const CHAR16 *str);
+ VOID clear_screen(UINTN attr);
+ 
++typedef INTN (*compare_pointer_func_t)(const VOID *a, const VOID *b);
++void sort_pointer_array(VOID **array, UINTN n_members, compare_pointer_func_t compare);
++
+ EFI_STATUS get_file_info_harder(EFI_FILE_HANDLE handle, EFI_FILE_INFO **ret, UINTN *ret_size);
+ 
+ EFI_STATUS readdir_harder(EFI_FILE_HANDLE handle, EFI_FILE_INFO **buffer, UINTN *buffer_size);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0040-stub-when-booting-a-kernel-foo.efi-then-pack-foo.efi.patch
+++ b/vendor/systemd-patches/0040-stub-when-booting-a-kernel-foo.efi-then-pack-foo.efi.patch
@@ -1,0 +1,751 @@
+From 7a6d06a0c2e80dd52959dea3b7b7a8afd8828f98 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 20 Sep 2021 13:47:32 +0200
+Subject: [PATCH 40/73] stub: when booting a kernel foo.efi then pack
+ foo.efi.extra.d/*.{cred,raw} up as synthetic initrd
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This adds support for the EFI stub to look for credential files and
+sysext files next to the EFI kernel image being loaded, and pack them up
+in an initrd cpio image, and pass them to the kernel.
+
+Specifically, for a kernel image foo.efi it looks for
+foo.efi.extra.d/*.cred and packs these files up in an initrd, placing it
+inside a directory /.extra/credentials/. It then looks for
+foo.efi.extra.d/*.raw and pack these files up in an initrd, placing them
+inside a directory /.extra/sysexts/. It then concatenates any other
+initrd with these two initrds, so they are combined.
+
+Or in other words auxiliary files placed next to the kernel image are
+picked up automatically by the EFI stub and be made available in the
+initrd in the /.extra/ directory.
+
+What's the usecase for this? This is supposed to be useful in context of
+implementing fully trusted initrds, i.e. initrds that are not built
+locally on the system and unsigned/unmeasured – as we do things
+currently —, but instead are built by the vendor, and measured to TPM.
+The idea is that a basic initrd is always linked into the kernel EFI
+image anyway. This will already be sufficient for many cases. However,
+in some cases it is necessary to parameterize initrds, or to extend the
+basic initrds with additional subsystems (e.g. think complex storage, or
+passing server info/certificates/… to initrds). The idea is that the
+parameterization is done using the "credentials" logic we already have
+in systemd, with these credential files (which can optionally be
+encrypted+authenticated by TPM2) being placed in the ESP next to the
+kernel image. And the initrd extension via the "sysext" logic we already
+have in systemd too.
+
+Note that the files read by this code are not verified immediately, they
+are copied *as-is* and placed into /.extra/ in the initrd. In a trusted
+environment they need to be validated later, but before first use. For
+the credentials logic this should be done via the TPM2
+encryption/authentication logic. For the sysext stuff the idea is that
+this is done via signed images, as implemented by #20691.
+---
+ src/boot/efi/cpio.c      | 466 +++++++++++++++++++++++++++++++++++++++
+ src/boot/efi/cpio.h      |  15 ++
+ src/boot/efi/meson.build |   2 +
+ src/boot/efi/stub.c      | 122 +++++++++-
+ src/boot/efi/util.h      |   7 +
+ 5 files changed, 609 insertions(+), 3 deletions(-)
+ create mode 100644 src/boot/efi/cpio.c
+ create mode 100644 src/boot/efi/cpio.h
+
+diff --git a/src/boot/efi/cpio.c b/src/boot/efi/cpio.c
+new file mode 100644
+index 000000000..9c99454d9
+--- /dev/null
++++ b/src/boot/efi/cpio.c
+@@ -0,0 +1,466 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include "cpio.h"
++#include "measure.h"
++#include "util.h"
++
++#define EXTRA_DIR_SUFFIX L".extra.d"
++
++static CHAR8* write_cpio_word(CHAR8 *p, UINT32 v) {
++        static const char hex[] = "0123456789abcdef";
++
++        assert(p);
++
++        /* Writes a CPIO header 8 character hex value */
++
++        for (UINTN i = 0; i < 8; i++)
++                p[7-i] = hex[(v >> (4 * i)) & 0xF];
++
++        return p + 8;
++}
++
++static CHAR8* mangle_filename(CHAR8 *p, const CHAR16 *f) {
++        CHAR8* w;
++
++        assert(p);
++        assert(f);
++
++        /* Basically converts UTF-16 to plain ASCII (note that we filtered non-ASCII filenames beforehand, so
++         * this operation is always safe) */
++
++        for (w = p; *f != 0; f++) {
++                assert(*f <= 0x7fu);
++
++                *(w++) = *f;
++        }
++
++        *w = 0;
++        return w;
++}
++
++static CHAR8* pad4(CHAR8 *p, const CHAR8* start) {
++        assert(p);
++        assert(start);
++        assert(p >= start);
++
++        /* Appends NUL bytes to 'p', until the address is divisable by 4, when taken relative to 'start' */
++
++        while ((p - start) % 4 != 0)
++                *(p++) = 0;
++
++        return p;
++}
++
++static EFI_STATUS pack_cpio_one(
++                const CHAR16 *fname,
++                const VOID *contents,
++                UINTN contents_size,
++                const CHAR8 *target_dir_prefix,
++                UINT32 access_mode,
++                UINT32 *inode_counter,
++                VOID **cpio_buffer,
++                UINTN *cpio_buffer_size) {
++
++        UINTN l, target_dir_prefix_size, fname_size, q;
++        CHAR8 *a;
++
++        assert(fname);
++        assert(contents_size || contents_size == 0);
++        assert(target_dir_prefix);
++        assert(inode_counter);
++        assert(cpio_buffer);
++        assert(cpio_buffer_size);
++
++        /* Serializes one file in the cpio format understood by the kernel initrd logic.
++         *
++         * See: https://www.kernel.org/doc/Documentation/early-userspace/buffer-format.txt */
++
++        if (contents_size > UINT32_MAX) /* cpio cannot deal with > 32bit file sizes */
++                return EFI_LOAD_ERROR;
++
++        if (*inode_counter == UINT32_MAX) /* more than 2^32-1 inodes? yikes. cpio doesn't support that either */
++                return EFI_OUT_OF_RESOURCES;
++
++        l = 6 + 13*8 + 1 + 1; /* Fixed CPIO header size, slash separator, and NUL byte after the file name*/
++
++        target_dir_prefix_size = strlena(target_dir_prefix);
++        if (l > UINTN_MAX - target_dir_prefix_size)
++                return EFI_OUT_OF_RESOURCES;
++        l += target_dir_prefix_size;
++
++        fname_size = StrLen(fname);
++        if (l > UINTN_MAX - fname_size)
++                return EFI_OUT_OF_RESOURCES;
++        l += fname_size; /* append space for file name */
++
++        /* CPIO can't deal with fnames longer than 2^32-1 */
++        if (target_dir_prefix_size + fname_size >= UINT32_MAX)
++                return EFI_OUT_OF_RESOURCES;
++
++        /* Align the whole header to 4 byte size */
++        l = ALIGN_TO(l, 4);
++        if (l == UINTN_MAX) /* overflow check */
++                return EFI_OUT_OF_RESOURCES;
++
++        /* Align the contents to 4 byte size */
++        q = ALIGN_TO(contents_size, 4);
++        if (q == UINTN_MAX) /* overflow check */
++                return EFI_OUT_OF_RESOURCES;
++
++        if (l > UINTN_MAX - q) /* overflow check */
++                return EFI_OUT_OF_RESOURCES;
++        l += q; /* Add contents to header */
++
++        if (*cpio_buffer_size > UINTN_MAX - l) /* overflow check */
++                return EFI_OUT_OF_RESOURCES;
++        a = ReallocatePool(*cpio_buffer, *cpio_buffer_size, *cpio_buffer_size + l);
++        if (!a)
++                return EFI_OUT_OF_RESOURCES;
++
++        *cpio_buffer = a;
++        a = (CHAR8*) *cpio_buffer + *cpio_buffer_size;
++
++        CopyMem(a, "070701", 6); /* magic ID */
++        a += 6;
++
++        a = write_cpio_word(a, (*inode_counter)++);                         /* inode */
++        a = write_cpio_word(a, access_mode | 0100000 /* = S_IFREG */);      /* mode */
++        a = write_cpio_word(a, 0);                                          /* uid */
++        a = write_cpio_word(a, 0);                                          /* gid */
++        a = write_cpio_word(a, 1);                                          /* nlink */
++
++        /* Note: we don't make any attempt to propagate the mtime here, for two reasons: it's a mess given
++         * that FAT usually is assumed to operate with timezoned timestamps, while UNIX does not. More
++         * importantly though: the modifications times would hamper our goals of providing stable
++         * measurements for the same boots. After all we extend the initrds we generate here into TPM2
++         * PCRs. */
++        a = write_cpio_word(a, 0);                                          /* mtime */
++        a = write_cpio_word(a, contents_size);                              /* size */
++        a = write_cpio_word(a, 0);                                          /* major(dev) */
++        a = write_cpio_word(a, 0);                                          /* minor(dev) */
++        a = write_cpio_word(a, 0);                                          /* major(rdev) */
++        a = write_cpio_word(a, 0);                                          /* minor(rdev) */
++        a = write_cpio_word(a, target_dir_prefix_size + fname_size + 1);    /* fname size */
++        a = write_cpio_word(a, 0);                                          /* "crc" */
++
++        CopyMem(a, target_dir_prefix, target_dir_prefix_size);
++        a += target_dir_prefix_size;
++        *(a++) = '/';
++        a = mangle_filename(a, fname);
++
++        /* Pad to next multiple of 4 */
++        a = pad4(a, *cpio_buffer);
++
++        CopyMem(a, contents, contents_size);
++        a += contents_size;
++
++        /* Pad to next multiple of 4 */
++        a = pad4(a, *cpio_buffer);
++
++        assert(a == (CHAR8*) *cpio_buffer + *cpio_buffer_size + l);
++        *cpio_buffer_size += l;
++
++        return EFI_SUCCESS;
++}
++
++static EFI_STATUS pack_cpio_dir(
++                const CHAR8 *path,
++                UINT32 access_mode,
++                UINT32 *inode_counter,
++                VOID **cpio_buffer,
++                UINTN *cpio_buffer_size) {
++
++        UINTN l, path_size;
++        CHAR8 *a;
++
++        assert(path);
++        assert(inode_counter);
++        assert(cpio_buffer);
++        assert(cpio_buffer_size);
++
++        /* Serializes one directory inode in cpio format. Note that cpio archives must first create the dirs
++         * they want to place files in. */
++
++        if (*inode_counter == UINT32_MAX)
++                return EFI_OUT_OF_RESOURCES;
++
++        l = 6 + 13*8 + 1; /* Fixed CPIO header size, and NUL byte after the file name*/
++
++        path_size = strlena(path);
++        if (l > UINTN_MAX - path_size)
++                return EFI_OUT_OF_RESOURCES;
++        l += path_size;
++
++        /* Align the whole header to 4 byte size */
++        l = ALIGN_TO(l, 4);
++        if (l == UINTN_MAX) /* overflow check */
++                return EFI_OUT_OF_RESOURCES;
++
++        if (*cpio_buffer_size > UINTN_MAX - l) /* overflow check */
++                return EFI_OUT_OF_RESOURCES;
++        a = ReallocatePool(*cpio_buffer, *cpio_buffer_size, *cpio_buffer_size + l);
++        if (!a)
++                return EFI_OUT_OF_RESOURCES;
++
++        *cpio_buffer = a;
++        a = (CHAR8*) *cpio_buffer + *cpio_buffer_size;
++
++        CopyMem(a, "070701", 6); /* magic ID */
++        a += 6;
++
++        a = write_cpio_word(a, (*inode_counter)++);                         /* inode */
++        a = write_cpio_word(a, access_mode | 0040000 /* = S_IFDIR */);      /* mode */
++        a = write_cpio_word(a, 0);                                          /* uid */
++        a = write_cpio_word(a, 0);                                          /* gid */
++        a = write_cpio_word(a, 1);                                          /* nlink */
++        a = write_cpio_word(a, 0);                                          /* mtime */
++        a = write_cpio_word(a, 0);                                          /* size */
++        a = write_cpio_word(a, 0);                                          /* major(dev) */
++        a = write_cpio_word(a, 0);                                          /* minor(dev) */
++        a = write_cpio_word(a, 0);                                          /* major(rdev) */
++        a = write_cpio_word(a, 0);                                          /* minor(rdev) */
++        a = write_cpio_word(a, path_size + 1);                              /* fname size */
++        a = write_cpio_word(a, 0);                                          /* "crc" */
++
++        CopyMem(a, path, path_size + 1);
++        a += path_size + 1;
++
++        /* Pad to next multiple of 4 */
++        a = pad4(a, *cpio_buffer);
++
++        assert(a == (CHAR8*) *cpio_buffer + *cpio_buffer_size + l);
++
++        *cpio_buffer_size += l;
++        return EFI_SUCCESS;
++}
++
++static EFI_STATUS pack_cpio_prefix(
++                const CHAR8 *path,
++                UINT32 dir_mode,
++                UINT32 *inode_counter,
++                VOID **cpio_buffer,
++                UINTN *cpio_buffer_size) {
++
++        EFI_STATUS err;
++
++        assert(path);
++        assert(inode_counter);
++        assert(cpio_buffer);
++        assert(cpio_buffer_size);
++
++        /* Serializes directory inodes of all prefix paths of the specified path in cpio format. Note that
++         * (similar to mkdir -p behaviour) all leading paths are created with 0555 access mode, only the
++         * final dir is created with the specified directory access mode. */
++
++        for (const CHAR8 *p = path;;) {
++                const CHAR8 *e;
++
++                e = strchra(p, '/');
++                if (!e)
++                        break;
++
++                if (e > p) {
++                        _cleanup_freepool_ CHAR8 *t = NULL;
++
++                        t = strndup8(path, e - path);
++                        if (!t)
++                                return EFI_OUT_OF_RESOURCES;
++
++                        err = pack_cpio_dir(t, 0555, inode_counter, cpio_buffer, cpio_buffer_size);
++                        if (EFI_ERROR(err))
++                                return err;
++                }
++
++                p = e + 1;
++        }
++
++        return pack_cpio_dir(path, dir_mode, inode_counter, cpio_buffer, cpio_buffer_size);
++}
++
++static EFI_STATUS pack_cpio_trailer(
++                VOID **cpio_buffer,
++                UINTN *cpio_buffer_size) {
++
++        static const char trailer[] =
++                "070701"
++                "00000000"
++                "00000000"
++                "00000000"
++                "00000000"
++                "00000001"
++                "00000000"
++                "00000000"
++                "00000000"
++                "00000000"
++                "00000000"
++                "00000000"
++                "0000000B"
++                "00000000"
++                "TRAILER!!!\0\0\0"; /* There's a fourth NUL byte appended here, because this is a string */
++
++        VOID *a;
++
++        /* Generates the cpio trailer record that indicates the end of our initrd cpio archive */
++
++        assert(cpio_buffer);
++        assert(cpio_buffer_size);
++        assert_cc(sizeof(trailer) % 4 == 0);
++
++        a = ReallocatePool(*cpio_buffer, *cpio_buffer_size, *cpio_buffer_size + sizeof(trailer));
++        if (!a)
++                return EFI_OUT_OF_RESOURCES;
++
++        *cpio_buffer = a;
++        CopyMem((UINT8*) *cpio_buffer + *cpio_buffer_size, trailer, sizeof(trailer));
++        *cpio_buffer_size += sizeof(trailer);
++
++        return EFI_SUCCESS;
++}
++
++EFI_STATUS pack_cpio(
++                EFI_LOADED_IMAGE *loaded_image,
++                const CHAR16 *match_suffix,
++                const CHAR8 *target_dir_prefix,
++                UINT32 dir_mode,
++                UINT32 access_mode,
++                UINTN tpm_pcr,
++                const CHAR16 *tpm_description,
++                VOID **ret_buffer,
++                UINTN *ret_buffer_size) {
++
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE root = NULL, extra_dir = NULL;
++        UINTN dirent_size = 0, buffer_size = 0, n_items = 0, n_allocated = 0;
++        _cleanup_freepool_ CHAR16 *loaded_image_path = NULL, *j = NULL;
++        _cleanup_freepool_ EFI_FILE_INFO *dirent = NULL;
++        _cleanup_(strv_freep) CHAR16 **items = NULL;
++        _cleanup_freepool_ VOID *buffer = NULL;
++        UINT32 inode = 1; /* inode counter, so that each item gets a new inode */
++        EFI_STATUS err;
++
++        assert(loaded_image);
++        assert(target_dir_prefix);
++        assert(ret_buffer);
++        assert(ret_buffer_size);
++
++        root = LibOpenRoot(loaded_image->DeviceHandle);
++        if (!root)
++                return log_error_status_stall(EFI_LOAD_ERROR, L"Unable to open root directory.");
++
++        loaded_image_path = DevicePathToStr(loaded_image->FilePath);
++        if (!loaded_image_path)
++                return log_oom();
++
++        j = PoolPrint(L"%s" EXTRA_DIR_SUFFIX, loaded_image_path);
++        if (!j)
++                return log_oom();
++
++        err = open_directory(root, j, &extra_dir);
++        if (err == EFI_NOT_FOUND) {
++                /* No extra subdir, that's totally OK */
++                *ret_buffer = NULL;
++                *ret_buffer_size = 0;
++                return EFI_SUCCESS;
++        }
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to open extra directory of loaded image: %r", err);
++
++        for (;;) {
++                _cleanup_freepool_ CHAR16 *d = NULL;
++
++                err = readdir_harder(extra_dir, &dirent, &dirent_size);
++                if (EFI_ERROR(err))
++                        return log_error_status_stall(err, L"Failed to read extra directory of loaded image: %r", err);
++                if (!dirent) /* End of directory */
++                        break;
++
++                if (dirent->FileName[0] == '.')
++                        continue;
++                if (dirent->Attribute & EFI_FILE_DIRECTORY)
++                        continue;
++                if (match_suffix && !endswith_no_case(dirent->FileName, match_suffix))
++                        continue;
++                if (!is_ascii(dirent->FileName))
++                        continue;
++                if (StrLen(dirent->FileName) > 255) /* Max filename size on Linux */
++                        continue;
++
++                d = StrDuplicate(dirent->FileName);
++                if (!d)
++                        return log_oom();
++
++                if (n_items+2 > n_allocated) {
++                        UINTN m;
++
++                        /* We allocate 16 entries at a time, as a matter of optimization */
++                        if (n_items > (UINTN_MAX / sizeof(UINT16)) - 16) /* Overflow check, just in case */
++                                return log_oom();
++
++                        m = n_items + 16;
++                        items = ReallocatePool(items, n_allocated * sizeof(UINT16*), m * sizeof(UINT16*));
++                        if (!items)
++                                return log_oom();
++
++                        n_allocated = m;
++                }
++
++                items[n_items++] = TAKE_PTR(d);
++                items[n_items] = NULL; /* Let's always NUL terminate, to make freeing via strv_free() easy */
++        }
++
++        if (n_items == 0) {
++                /* Empty directory */
++                *ret_buffer = NULL;
++                *ret_buffer_size = 0;
++                return EFI_SUCCESS;
++        }
++
++        /* Now, sort the files we found, to make this uniform and stable (and to ensure the TPM measurements
++         * are not dependent on read order) */
++        sort_pointer_array((VOID**) items, n_items, (compare_pointer_func_t) StrCmp);
++
++        /* Generate the leading directory inodes right before adding the first files, to the
++         * archive. Otherwise the cpio archive cannot be unpacked, since the leading dirs won't exist. */
++        err = pack_cpio_prefix(target_dir_prefix, dir_mode, &inode, &buffer, &buffer_size);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to pack cpio prefix: %r", err);
++
++        for (UINTN i = 0; i < n_items; i++) {
++                _cleanup_freepool_ CHAR8 *content = NULL;
++                UINTN contentsize;
++
++                err = file_read(extra_dir, items[i], 0, 0, &content, &contentsize);
++                if (EFI_ERROR(err)) {
++                        log_error_status_stall(err, L"Failed to read %s, ignoring: %r", items[i], err);
++                        continue;
++                }
++
++                err = pack_cpio_one(
++                                items[i],
++                                content, contentsize,
++                                target_dir_prefix,
++                                access_mode,
++                                &inode,
++                                &buffer, &buffer_size);
++                if (EFI_ERROR(err))
++                        return log_error_status_stall(err, L"Failed to pack cpio file %s: %r", dirent->FileName, err);
++        }
++
++        err = pack_cpio_trailer(&buffer, &buffer_size);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to pack cpio trailer: %r");
++
++#if ENABLE_TPM
++        err = tpm_log_event(
++                        tpm_pcr,
++                        (EFI_PHYSICAL_ADDRESS) (UINTN) buffer,
++                        buffer_size,
++                        tpm_description);
++        if (EFI_ERROR(err))
++                log_error_stall(L"Unable to add initrd TPM measurement for PCR %u (%s), ignoring: %r", tpm_pcr, tpm_description, err);
++#endif
++
++        *ret_buffer = TAKE_PTR(buffer);
++        *ret_buffer_size = buffer_size;
++
++        return EFI_SUCCESS;
++}
+diff --git a/src/boot/efi/cpio.h b/src/boot/efi/cpio.h
+new file mode 100644
+index 000000000..8a6d09312
+--- /dev/null
++++ b/src/boot/efi/cpio.h
+@@ -0,0 +1,15 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++#pragma once
++
++#include <efi.h>
++
++EFI_STATUS pack_cpio(
++                EFI_LOADED_IMAGE *loaded_image,
++                const CHAR16 *match_suffix,
++                const CHAR8 *target_dir_prefix,
++                UINT32 dir_mode,
++                UINT32 access_mode,
++                UINTN pcr,
++                const CHAR16 *tpm_description,
++                VOID **ret_buffer,
++                UINTN *ret_buffer_size);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index e5925dd42..1f974d3d6 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -2,6 +2,7 @@
+ 
+ efi_headers = files('''
+         console.h
++        cpio.h
+         devicetree.h
+         disk.h
+         graphics.h
+@@ -39,6 +40,7 @@ stub_sources = '''
+         linux.c
+         splash.c
+         stub.c
++        cpio.c
+ '''.split()
+ 
+ if conf.get('ENABLE_EFI') == 1 and get_option('gnu-efi') != 'false'
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 9a3c9982d..ae0659900 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -3,6 +3,7 @@
+ #include <efi.h>
+ #include <efilib.h>
+ 
++#include "cpio.h"
+ #include "disk.h"
+ #include "graphics.h"
+ #include "linux.h"
+@@ -15,8 +16,80 @@
+ /* magic string to find in the binary image */
+ static const char __attribute__((used)) magic[] = "#### LoaderInfo: systemd-stub " GIT_VERSION " ####";
+ 
++static EFI_STATUS combine_initrd(
++                EFI_PHYSICAL_ADDRESS initrd_base, UINTN initrd_size,
++                const VOID *credential_initrd, UINTN credential_initrd_size,
++                const VOID *sysext_initrd, UINTN sysext_initrd_size,
++                EFI_PHYSICAL_ADDRESS *ret_initrd_base, UINTN *ret_initrd_size) {
++
++        EFI_PHYSICAL_ADDRESS base = UINT32_MAX; /* allocate an area below the 32bit boundary for this */
++        EFI_STATUS err;
++        UINT8 *p;
++        UINTN n;
++
++        assert(ret_initrd_base);
++        assert(ret_initrd_size);
++
++        /* Combines three initrds into one, by simple concatenation in memory */
++
++        n = ALIGN_TO(initrd_size, 4); /* main initrd might not be padded yet */
++        if (credential_initrd) {
++                if (n > UINTN_MAX - credential_initrd_size)
++                        return EFI_OUT_OF_RESOURCES;
++
++                n += credential_initrd_size;
++        }
++        if (sysext_initrd) {
++                if (n > UINTN_MAX - sysext_initrd_size)
++                        return EFI_OUT_OF_RESOURCES;
++
++                n += sysext_initrd_size;
++        }
++
++        err = uefi_call_wrapper(
++                        BS->AllocatePages, 4,
++                        AllocateMaxAddress,
++                        EfiLoaderData,
++                        EFI_SIZE_TO_PAGES(n),
++                        &base);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to allocate space for combined initrd: %r", err);
++
++        p = (UINT8*) (UINTN) base;
++        if (initrd_base != 0) {
++                UINTN pad;
++
++                /* Order matters, the real initrd must come first, since it might include microcode updates
++                 * which the kernel only looks for in the first cpio archive */
++                CopyMem(p, (VOID*) (UINTN) initrd_base, initrd_size);
++                p += initrd_size;
++
++                pad = ALIGN_TO(initrd_size, 4) - initrd_size;
++                if (pad > 0)  {
++                        ZeroMem(p, pad);
++                        p += pad;
++                }
++        }
++
++        if (credential_initrd) {
++                CopyMem(p, credential_initrd, credential_initrd_size);
++                p += credential_initrd_size;
++        }
++
++        if (sysext_initrd) {
++                CopyMem(p, sysext_initrd, sysext_initrd_size);
++                p += sysext_initrd_size;
++        }
++
++        assert((UINT8*) (UINTN) base + n == p);
++
++        *ret_initrd_base = base;
++        *ret_initrd_size = n;
++
++        return EFI_SUCCESS;
++}
++
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+-        EFI_LOADED_IMAGE *loaded_image;
+ 
+         enum {
+                 SECTION_CMDLINE,
+@@ -34,8 +107,10 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 NULL,
+         };
+ 
++        UINTN cmdline_len = 0, initrd_size, credential_initrd_size = 0, sysext_initrd_size = 0;
++        _cleanup_freepool_ VOID *credential_initrd = NULL, *sysext_initrd = NULL;
+         EFI_PHYSICAL_ADDRESS linux_base, initrd_base;
+-        UINTN cmdline_len = 0, initrd_size;
++        EFI_LOADED_IMAGE *loaded_image;
+         UINTN addrs[_SECTION_MAX] = {};
+         UINTN szs[_SECTION_MAX] = {};
+         CHAR8 *cmdline = NULL;
+@@ -123,13 +198,54 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         if (szs[SECTION_SPLASH] > 0)
+                 graphics_splash((UINT8*) (UINTN) loaded_image->ImageBase + addrs[SECTION_SPLASH], szs[SECTION_SPLASH], NULL);
+ 
++        (VOID) pack_cpio(loaded_image,
++                         L".cred",
++                         (const CHAR8*) ".extra/credentials",
++                         /* dir_mode= */ 0500,
++                         /* access_mode= */ 0400,
++                         /* tpm_pcr= */ TPM_PCR_INDEX_KERNEL_PARAMETERS,
++                         L"Credentials initrd",
++                         &credential_initrd,
++                         &credential_initrd_size);
++
++        (VOID) pack_cpio(loaded_image,
++                         L".raw",
++                         (const CHAR8*) ".extra/sysext",
++                         /* dir_mode= */ 0555,
++                         /* access_mode= */ 0444,
++                         /* tpm_pcr= */ TPM_PCR_INDEX_INITRD,
++                         L"System extension initrd",
++                         &sysext_initrd,
++                         &sysext_initrd_size);
++
+         linux_base = (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->ImageBase + addrs[SECTION_LINUX];
+ 
+         initrd_size = szs[SECTION_INITRD];
+         initrd_base = initrd_size != 0 ? (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->ImageBase + addrs[SECTION_INITRD] : 0;
+ 
+-        err = linux_exec(image, cmdline, cmdline_len, linux_base, initrd_base, initrd_size);
++        if (credential_initrd || sysext_initrd) {
++                /* If we have generated initrds dynamically, let's combine them with the built-in initrd. */
++                err = combine_initrd(
++                                initrd_base, initrd_size,
++                                credential_initrd, credential_initrd_size,
++                                sysext_initrd, sysext_initrd_size,
++                                &initrd_base, &initrd_size);
++                if (EFI_ERROR(err))
++                        return err;
++
++                /* Given these might be large let's free them explicitly, quickly. */
++                if (credential_initrd) {
++                        FreePool(credential_initrd);
++                        credential_initrd = NULL;
++                }
++
++                if (sysext_initrd) {
++                        FreePool(sysext_initrd);
++                        sysext_initrd = NULL;
++                }
++        }
+ 
++        err = linux_exec(image, cmdline, cmdline_len, linux_base, initrd_base, initrd_size);
+         graphics_mode(FALSE);
+         return log_error_status_stall(err, L"Execution of embedded linux image failed: %r", err);
+ }
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index ea32a7616..3a29ff2d7 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -6,6 +6,13 @@
+ 
+ #include "string-util-fundamental.h"
+ 
++/* This TPM PCR is where most Linux infrastructure extends the kernel command line into, and so do we. We also extend
++ * any passed credentials here. */
++#define TPM_PCR_INDEX_KERNEL_PARAMETERS 8
++
++/* This TPM PCR is where most Linux infrastructure extends the initrd binary images into, and so do we. */
++#define TPM_PCR_INDEX_INITRD 4
++
+ #define OFFSETOF(x,y) __builtin_offsetof(x,y)
+ 
+ #define UINTN_MAX (~(UINTN)0)
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0041-boot-unify-code-that-measures-image-options-kernel-c.patch
+++ b/vendor/systemd-patches/0041-boot-unify-code-that-measures-image-options-kernel-c.patch
@@ -1,0 +1,98 @@
+From 62200e3a7ef28cd47961d526d881e4c8dc3b2477 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 19:27:25 +0200
+Subject: [PATCH 41/73] boot: unify code that measures image options/kernel
+ command line
+
+Commiter: Patch modified to still use configurable PCR.
+---
+ src/boot/efi/boot.c    |  6 +-----
+ src/boot/efi/measure.c | 14 ++++++++++++++
+ src/boot/efi/measure.h |  2 ++
+ src/boot/efi/stub.c    | 13 ++++++-------
+ 4 files changed, 23 insertions(+), 12 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 734ae56fb..704213dee 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -2349,11 +2349,7 @@ static EFI_STATUS image_start(
+ 
+ #if ENABLE_TPM
+                 /* Try to log any options to the TPM, especially to catch manually edited options */
+-                err = tpm_log_event(SD_TPM_PCR,
+-                                    (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->LoadOptions,
+-                                    loaded_image->LoadOptionsSize, loaded_image->LoadOptions);
+-                if (EFI_ERROR(err))
+-                        log_error_stall(L"Unable to add image options measurement: %r", err);
++                (VOID) tpm_log_load_options(options);
+ #endif
+         }
+ 
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index fbca67bbf..0e9a523b1 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -162,4 +162,18 @@ EFI_STATUS tpm_log_event(UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer, UIN
+         return EFI_SUCCESS;
+ }
+ 
++EFI_STATUS tpm_log_load_options(const CHAR16 *load_options) {
++        EFI_STATUS err;
++
++        /* Measures a load options string into the TPM2, i.e. the kernel command line */
++
++        err = tpm_log_event(SD_TPM_PCR,
++                            (EFI_PHYSICAL_ADDRESS) (UINTN) load_options,
++                            StrSize(load_options), load_options);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Unable to add load options (i.e. kernel command) line measurement: %r", err);
++
++        return EFI_SUCCESS;
++}
++
+ #endif
+diff --git a/src/boot/efi/measure.h b/src/boot/efi/measure.h
+index e2873adae..69eb682a2 100644
+--- a/src/boot/efi/measure.h
++++ b/src/boot/efi/measure.h
+@@ -4,3 +4,5 @@
+ #include <efi.h>
+ 
+ EFI_STATUS tpm_log_event(UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer, UINTN buffer_size, const CHAR16 *description);
++
++EFI_STATUS tpm_log_load_options(const CHAR16 *cmdline);
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index ae0659900..c0dc121a7 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -147,12 +147,11 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 cmdline = line;
+ 
+ #if ENABLE_TPM
+-                /* Try to log any options to the TPM, especially manually edited options */
+-                err = tpm_log_event(SD_TPM_PCR,
+-                                    (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->LoadOptions,
+-                                    loaded_image->LoadOptionsSize, loaded_image->LoadOptions);
+-                if (EFI_ERROR(err))
+-                        log_error_stall(L"Unable to add image options measurement: %r", err);
++                /* Let's measure the passed kernel command line into the TPM. Note that this possibly
++                 * duplicates what we already did in the boot menu, if that was already used. However, since
++                 * we want the boot menu to support an EFI binary, and want to this stub to be usable from
++                 * any boot menu, let's measure things anyway. */
++                (VOID) tpm_log_load_options(loaded_image->LoadOptions);
+ #endif
+         }
+ 
+@@ -203,7 +202,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                          (const CHAR8*) ".extra/credentials",
+                          /* dir_mode= */ 0500,
+                          /* access_mode= */ 0400,
+-                         /* tpm_pcr= */ TPM_PCR_INDEX_KERNEL_PARAMETERS,
++                         /* tpm_pcr= */ SD_TPM_PCR,
+                          L"Credentials initrd",
+                          &credential_initrd,
+                          &credential_initrd_size);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0042-stub-split-out-code-that-sets-the-various-efi-vars-i.patch
+++ b/vendor/systemd-patches/0042-stub-split-out-code-that-sets-the-various-efi-vars-i.patch
@@ -1,0 +1,124 @@
+From 3b5f0b6976fd6bdb42eaebee6a305c90a9734b72 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 19:28:18 +0200
+Subject: [PATCH 42/73] stub: split out code that sets the various efi vars
+ into function of its own
+
+Just some refactoring, no code changes beyond the splitting out.
+---
+ src/boot/efi/stub.c | 85 ++++++++++++++++++++++++---------------------
+ 1 file changed, 46 insertions(+), 39 deletions(-)
+
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index c0dc121a7..08cf654c8 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -89,6 +89,51 @@ static EFI_STATUS combine_initrd(
+         return EFI_SUCCESS;
+ }
+ 
++static VOID export_variables(EFI_LOADED_IMAGE *loaded_image) {
++        CHAR16 uuid[37];
++
++        assert(loaded_image);
++
++        /* Export the device path this image is started from, if it's not set yet */
++        if (efivar_get_raw(LOADER_GUID, L"LoaderDevicePartUUID", NULL, NULL) != EFI_SUCCESS)
++                if (disk_get_part_uuid(loaded_image->DeviceHandle, uuid) == EFI_SUCCESS)
++                        efivar_set(LOADER_GUID, L"LoaderDevicePartUUID", uuid, 0);
++
++        /* If LoaderImageIdentifier is not set, assume the image with this stub was loaded directly from the
++         * UEFI firmware without any boot loader, and hence set the LoaderImageIdentifier ourselves. Note
++         * that some boot chain loaders neither set LoaderImageIdentifier nor make FilePath available to us,
++         * in which case there's simple nothing to set for us. (The UEFI spec doesn't really say who's wrong
++         * here, i.e. whether FilePath may be NULL or not, hence handle this gracefully and check if FilePath
++         * is non-NULL explicitly.) */
++        if (efivar_get_raw(LOADER_GUID, L"LoaderImageIdentifier", NULL, NULL) != EFI_SUCCESS &&
++            loaded_image->FilePath) {
++                _cleanup_freepool_ CHAR16 *s = NULL;
++
++                s = DevicePathToStr(loaded_image->FilePath);
++                efivar_set(LOADER_GUID, L"LoaderImageIdentifier", s, 0);
++        }
++
++        /* if LoaderFirmwareInfo is not set, let's set it */
++        if (efivar_get_raw(LOADER_GUID, L"LoaderFirmwareInfo", NULL, NULL) != EFI_SUCCESS) {
++                _cleanup_freepool_ CHAR16 *s = NULL;
++
++                s = PoolPrint(L"%s %d.%02d", ST->FirmwareVendor, ST->FirmwareRevision >> 16, ST->FirmwareRevision & 0xffff);
++                efivar_set(LOADER_GUID, L"LoaderFirmwareInfo", s, 0);
++        }
++
++        /* ditto for LoaderFirmwareType */
++        if (efivar_get_raw(LOADER_GUID, L"LoaderFirmwareType", NULL, NULL) != EFI_SUCCESS) {
++                _cleanup_freepool_ CHAR16 *s = NULL;
++
++                s = PoolPrint(L"UEFI %d.%02d", ST->Hdr.Revision >> 16, ST->Hdr.Revision & 0xffff);
++                efivar_set(LOADER_GUID, L"LoaderFirmwareType", s, 0);
++        }
++
++        /* add StubInfo */
++        if (efivar_get_raw(LOADER_GUID, L"StubInfo", NULL, NULL) != EFI_SUCCESS)
++                efivar_set(LOADER_GUID, L"StubInfo", L"systemd-stub " GIT_VERSION, 0);
++}
++
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+ 
+         enum {
+@@ -114,7 +159,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         UINTN addrs[_SECTION_MAX] = {};
+         UINTN szs[_SECTION_MAX] = {};
+         CHAR8 *cmdline = NULL;
+-        CHAR16 uuid[37];
+         EFI_STATUS err;
+ 
+         InitializeLib(image, sys_table);
+@@ -155,44 +199,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+ #endif
+         }
+ 
+-        /* Export the device path this image is started from, if it's not set yet */
+-        if (efivar_get_raw(LOADER_GUID, L"LoaderDevicePartUUID", NULL, NULL) != EFI_SUCCESS)
+-                if (disk_get_part_uuid(loaded_image->DeviceHandle, uuid) == EFI_SUCCESS)
+-                        efivar_set(LOADER_GUID, L"LoaderDevicePartUUID", uuid, 0);
+-
+-        /* If LoaderImageIdentifier is not set, assume the image with this stub was loaded directly from the
+-         * UEFI firmware without any boot loader, and hence set the LoaderImageIdentifier ourselves. Note
+-         * that some boot chain loaders neither set LoaderImageIdentifier nor make FilePath available to us,
+-         * in which case there's simple nothing to set for us. (The UEFI spec doesn't really say who's wrong
+-         * here, i.e. whether FilePath may be NULL or not, hence handle this gracefully and check if FilePath
+-         * is non-NULL explicitly.) */
+-        if (efivar_get_raw(LOADER_GUID, L"LoaderImageIdentifier", NULL, NULL) != EFI_SUCCESS &&
+-            loaded_image->FilePath) {
+-                _cleanup_freepool_ CHAR16 *s = NULL;
+-
+-                s = DevicePathToStr(loaded_image->FilePath);
+-                efivar_set(LOADER_GUID, L"LoaderImageIdentifier", s, 0);
+-        }
+-
+-        /* if LoaderFirmwareInfo is not set, let's set it */
+-        if (efivar_get_raw(LOADER_GUID, L"LoaderFirmwareInfo", NULL, NULL) != EFI_SUCCESS) {
+-                _cleanup_freepool_ CHAR16 *s = NULL;
+-
+-                s = PoolPrint(L"%s %d.%02d", ST->FirmwareVendor, ST->FirmwareRevision >> 16, ST->FirmwareRevision & 0xffff);
+-                efivar_set(LOADER_GUID, L"LoaderFirmwareInfo", s, 0);
+-        }
+-
+-        /* ditto for LoaderFirmwareType */
+-        if (efivar_get_raw(LOADER_GUID, L"LoaderFirmwareType", NULL, NULL) != EFI_SUCCESS) {
+-                _cleanup_freepool_ CHAR16 *s = NULL;
+-
+-                s = PoolPrint(L"UEFI %d.%02d", ST->Hdr.Revision >> 16, ST->Hdr.Revision & 0xffff);
+-                efivar_set(LOADER_GUID, L"LoaderFirmwareType", s, 0);
+-        }
+-
+-        /* add StubInfo */
+-        if (efivar_get_raw(LOADER_GUID, L"StubInfo", NULL, NULL) != EFI_SUCCESS)
+-                efivar_set(LOADER_GUID, L"StubInfo", L"systemd-stub " GIT_VERSION, 0);
++        export_variables(loaded_image);
+ 
+         if (szs[SECTION_SPLASH] > 0)
+                 graphics_splash((UINT8*) (UINTN) loaded_image->ImageBase + addrs[SECTION_SPLASH], szs[SECTION_SPLASH], NULL);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0043-stub-show-splash-screen-earlier.patch
+++ b/vendor/systemd-patches/0043-stub-show-splash-screen-earlier.patch
@@ -1,0 +1,59 @@
+From f60c81de60efb4b1d0635e20c98a212a5ee80b90 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 19:33:01 +0200
+Subject: [PATCH 43/73] stub: show splash screen earlier
+
+let's move showing of the splash screen to the earliest place we know
+the splash bmp address. After all a splash screen is all about showing
+as early as we can. This matters as doing TPM stuff or packing up a
+large cpio might take time.
+
+While we are at it, move the conditionalization of the splash screen
+into the function instead of doing it ahead of calling it. This should
+encapsulate things more nicely.
+---
+ src/boot/efi/splash.c | 3 +++
+ src/boot/efi/stub.c   | 6 +++---
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/src/boot/efi/splash.c b/src/boot/efi/splash.c
+index 0286a5a90..bbc151767 100644
+--- a/src/boot/efi/splash.c
++++ b/src/boot/efi/splash.c
+@@ -259,6 +259,9 @@ EFI_STATUS graphics_splash(UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_
+         UINTN y_pos = 0;
+         EFI_STATUS err;
+ 
++        if (len == 0)
++                return EFI_SUCCESS;
++
+         assert(content);
+ 
+         if (!background) {
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 08cf654c8..d0b4972dc 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -172,6 +172,9 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Unable to locate embedded .linux section: %r", err);
+ 
++        /* Show splash screen as early as possible */
++        graphics_splash((UINT8*) loaded_image->ImageBase + addrs[SECTION_SPLASH], szs[SECTION_SPLASH], NULL);
++
+         if (szs[SECTION_CMDLINE] > 0) {
+                 cmdline = (CHAR8*) loaded_image->ImageBase + addrs[SECTION_CMDLINE];
+                 cmdline_len = szs[SECTION_CMDLINE];
+@@ -201,9 +204,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+ 
+         export_variables(loaded_image);
+ 
+-        if (szs[SECTION_SPLASH] > 0)
+-                graphics_splash((UINT8*) (UINTN) loaded_image->ImageBase + addrs[SECTION_SPLASH], szs[SECTION_SPLASH], NULL);
+-
+         (VOID) pack_cpio(loaded_image,
+                          L".cred",
+                          (const CHAR8*) ".extra/credentials",
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0044-stub-make-splash-image-payload-const.patch
+++ b/vendor/systemd-patches/0044-stub-make-splash-image-payload-const.patch
@@ -1,0 +1,91 @@
+From 4355e946c53e264126667dbc9da4172b15975efb Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 20 Sep 2021 17:26:48 +0200
+Subject: [PATCH 44/73] stub: make splash image payload const
+
+---
+ src/boot/efi/splash.c | 24 ++++++++++++++++--------
+ src/boot/efi/splash.h |  2 +-
+ src/boot/efi/stub.c   |  2 +-
+ 3 files changed, 18 insertions(+), 10 deletions(-)
+
+diff --git a/src/boot/efi/splash.c b/src/boot/efi/splash.c
+index bbc151767..0071a9317 100644
+--- a/src/boot/efi/splash.c
++++ b/src/boot/efi/splash.c
+@@ -37,8 +37,13 @@ struct bmp_map {
+         UINT8 reserved;
+ } _packed_;
+ 
+-static EFI_STATUS bmp_parse_header(UINT8 *bmp, UINTN size, struct bmp_dib **ret_dib,
+-                            struct bmp_map **ret_map, UINT8 **pixmap) {
++static EFI_STATUS bmp_parse_header(
++                const UINT8 *bmp,
++                UINTN size,
++                struct bmp_dib **ret_dib,
++                struct bmp_map **ret_map,
++                const UINT8 **pixmap) {
++
+         struct bmp_file *file;
+         struct bmp_dib *dib;
+         struct bmp_map *map;
+@@ -154,10 +159,13 @@ static VOID pixel_blend(UINT32 *dst, const UINT32 source) {
+         *dst = (rb | g);
+ }
+ 
+-static EFI_STATUS bmp_to_blt(EFI_GRAPHICS_OUTPUT_BLT_PIXEL *buf,
+-                      struct bmp_dib *dib, struct bmp_map *map,
+-                      UINT8 *pixmap) {
+-        UINT8 *in;
++static EFI_STATUS bmp_to_blt(
++                EFI_GRAPHICS_OUTPUT_BLT_PIXEL *buf,
++                struct bmp_dib *dib,
++                struct bmp_map *map,
++                const UINT8 *pixmap) {
++
++        const UINT8 *in;
+ 
+         assert(buf);
+         assert(dib);
+@@ -246,13 +254,13 @@ static EFI_STATUS bmp_to_blt(EFI_GRAPHICS_OUTPUT_BLT_PIXEL *buf,
+         return EFI_SUCCESS;
+ }
+ 
+-EFI_STATUS graphics_splash(UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_BLT_PIXEL *background) {
++EFI_STATUS graphics_splash(const UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_BLT_PIXEL *background) {
+         EFI_GRAPHICS_OUTPUT_BLT_PIXEL pixel = {};
+         static const EFI_GUID GraphicsOutputProtocolGuid = EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID;
+         EFI_GRAPHICS_OUTPUT_PROTOCOL *GraphicsOutput = NULL;
+         struct bmp_dib *dib;
+         struct bmp_map *map;
+-        UINT8 *pixmap;
++        const UINT8 *pixmap;
+         UINT64 blt_size;
+         _cleanup_freepool_ VOID *blt = NULL;
+         UINTN x_pos = 0;
+diff --git a/src/boot/efi/splash.h b/src/boot/efi/splash.h
+index b9f74ffbf..37ccc6b6a 100644
+--- a/src/boot/efi/splash.h
++++ b/src/boot/efi/splash.h
+@@ -3,4 +3,4 @@
+ 
+ #include <efi.h>
+ 
+-EFI_STATUS graphics_splash(UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_BLT_PIXEL *background);
++EFI_STATUS graphics_splash(const UINT8 *content, UINTN len, const EFI_GRAPHICS_OUTPUT_BLT_PIXEL *background);
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index d0b4972dc..9a71aff16 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -173,7 +173,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 return log_error_status_stall(err, L"Unable to locate embedded .linux section: %r", err);
+ 
+         /* Show splash screen as early as possible */
+-        graphics_splash((UINT8*) loaded_image->ImageBase + addrs[SECTION_SPLASH], szs[SECTION_SPLASH], NULL);
++        graphics_splash((const UINT8*) loaded_image->ImageBase + addrs[SECTION_SPLASH], szs[SECTION_SPLASH], NULL);
+ 
+         if (szs[SECTION_CMDLINE] > 0) {
+                 cmdline = (CHAR8*) loaded_image->ImageBase + addrs[SECTION_CMDLINE];
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0045-boot-split-out-code-that-sets-various-EFI-vars-from-.patch
+++ b/vendor/systemd-patches/0045-boot-split-out-code-that-sets-various-EFI-vars-from-.patch
@@ -1,0 +1,122 @@
+From 9cd12aca49aca67963a42029a236d533498379b2 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 14:36:56 +0200
+Subject: [PATCH 45/73] boot: split out code that sets various EFI vars from
+ main()
+
+Just some refactoring, no actual code changes.
+---
+ src/boot/efi/boot.c | 62 ++++++++++++++++++++++++++++++---------------
+ 1 file changed, 41 insertions(+), 21 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 704213dee..3cb990abd 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -2415,7 +2415,11 @@ static VOID config_write_entries_to_variable(Config *config) {
+         (void) efivar_set_raw(LOADER_GUID, L"LoaderEntries", buffer, sz, 0);
+ }
+ 
+-EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
++static VOID export_variables(
++                EFI_LOADED_IMAGE *loaded_image,
++                const CHAR16 *loaded_image_path,
++                UINT64 init_usec) {
++
+         static const UINT64 loader_features =
+                 EFI_LOADER_FEATURE_CONFIG_TIMEOUT |
+                 EFI_LOADER_FEATURE_CONFIG_TIMEOUT_ONE_SHOT |
+@@ -2427,18 +2431,11 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 0;
+ 
+         _cleanup_freepool_ CHAR16 *infostr = NULL, *typestr = NULL;
+-        UINT64 osind = 0;
+-        EFI_LOADED_IMAGE *loaded_image;
+-        EFI_FILE *root_dir;
+-        CHAR16 *loaded_image_path;
+-        EFI_STATUS err;
+-        Config config;
+-        UINT64 init_usec;
+-        BOOLEAN menu = FALSE;
+         CHAR16 uuid[37];
+ 
+-        InitializeLib(image, sys_table);
+-        init_usec = time_usec();
++        assert(loaded_image);
++        assert(loaded_image_path);
++
+         efivar_set_time_usec(LOADER_GUID, L"LoaderTimeInitUSec", init_usec);
+         efivar_set(LOADER_GUID, L"LoaderInfo", L"systemd-boot " GIT_VERSION, 0);
+ 
+@@ -2450,14 +2447,43 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+ 
+         (void) efivar_set_uint64_le(LOADER_GUID, L"LoaderFeatures", loader_features, 0);
+ 
+-        err = uefi_call_wrapper(BS->OpenProtocol, 6, image, &LoadedImageProtocol, (VOID **)&loaded_image,
+-                                image, NULL, EFI_OPEN_PROTOCOL_GET_PROTOCOL);
+-        if (EFI_ERROR(err))
+-                return log_error_status_stall(err, L"Error getting a LoadedImageProtocol handle: %r", err);
++        /* the filesystem path to this image, to prevent adding ourselves to the menu */
++        efivar_set(LOADER_GUID, L"LoaderImageIdentifier", loaded_image_path, 0);
+ 
+         /* export the device path this image is started from */
+         if (disk_get_part_uuid(loaded_image->DeviceHandle, uuid) == EFI_SUCCESS)
+                 efivar_set(LOADER_GUID, L"LoaderDevicePartUUID", uuid, 0);
++}
++
++EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
++        _cleanup_freepool_ EFI_LOADED_IMAGE *loaded_image = NULL;
++        UINT64 osind = 0;
++        _cleanup_(FileHandleClosep) EFI_FILE *root_dir = NULL;
++        CHAR16 *loaded_image_path;
++        EFI_STATUS err;
++        Config config;
++        UINT64 init_usec;
++        BOOLEAN menu = FALSE;
++
++        InitializeLib(image, sys_table);
++        init_usec = time_usec();
++
++        err = uefi_call_wrapper(
++                        BS->OpenProtocol, 6,
++                        image,
++                        &LoadedImageProtocol,
++                        (VOID **)&loaded_image,
++                        image,
++                        NULL,
++                        EFI_OPEN_PROTOCOL_GET_PROTOCOL);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Error getting a LoadedImageProtocol handle: %r", err);
++
++        loaded_image_path = DevicePathToStr(loaded_image->FilePath);
++        if (!loaded_image_path)
++                return log_oom();
++
++        export_variables(loaded_image, loaded_image_path, init_usec);
+ 
+         root_dir = LibOpenRoot(loaded_image->DeviceHandle);
+         if (!root_dir)
+@@ -2469,10 +2495,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                         return log_error_status_stall(err, L"Error installing security policy: %r", err);
+         }
+ 
+-        /* the filesystem path to this image, to prevent adding ourselves to the menu */
+-        loaded_image_path = DevicePathToStr(loaded_image->FilePath);
+-        efivar_set(LOADER_GUID, L"LoaderImageIdentifier", loaded_image_path, 0);
+-
+         config_load_defaults(&config, root_dir);
+ 
+         /* scan /EFI/Linux/ directory */
+@@ -2580,9 +2602,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         }
+         err = EFI_SUCCESS;
+ out:
+-        FreePool(loaded_image_path);
+         config_free(&config);
+-        uefi_call_wrapper(root_dir->Close, 1, root_dir);
+         uefi_call_wrapper(BS->CloseProtocol, 4, image, &LoadedImageProtocol, image, NULL);
+         return err;
+ }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0046-boot-split-out-code-that-loads-the-various-menu-entr.patch
+++ b/vendor/systemd-patches/0046-boot-split-out-code-that-loads-the-various-menu-entr.patch
@@ -1,0 +1,118 @@
+From e867d8c531aab8a0c3ea96f39d8bb863d0b9f65a Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 14:45:55 +0200
+Subject: [PATCH 46/73] boot: split out code that loads the various menu
+ entries into helper call
+
+Just some refactoring, no real code changes.
+---
+ src/boot/efi/boot.c | 77 +++++++++++++++++++++++++++------------------
+ 1 file changed, 46 insertions(+), 31 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 3cb990abd..62fc13e15 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1487,7 +1487,7 @@ static VOID config_load_entries(
+                 Config *config,
+                 EFI_HANDLE *device,
+                 EFI_FILE *root_dir,
+-                CHAR16 *loaded_image_path) {
++                const CHAR16 *loaded_image_path) {
+ 
+         _cleanup_(FileHandleClosep) EFI_FILE_HANDLE entries_dir = NULL;
+         EFI_STATUS err;
+@@ -2455,9 +2455,52 @@ static VOID export_variables(
+                 efivar_set(LOADER_GUID, L"LoaderDevicePartUUID", uuid, 0);
+ }
+ 
++static VOID config_load_all_entries(
++                Config *config,
++                EFI_LOADED_IMAGE *loaded_image,
++                const CHAR16 *loaded_image_path,
++                EFI_FILE *root_dir) {
++
++        UINT64 osind = 0;
++
++        assert(config);
++        assert(loaded_image);
++        assert(loaded_image_path);
++        assert(root_dir);
++
++        config_load_defaults(config, root_dir);
++
++        /* scan /EFI/Linux/ directory */
++        config_entry_add_linux(config, loaded_image->DeviceHandle, root_dir);
++
++        /* scan /loader/entries/\*.conf files */
++        config_load_entries(config, loaded_image->DeviceHandle, root_dir, loaded_image_path);
++
++        /* Similar, but on any XBOOTLDR partition */
++        config_load_xbootldr(config, loaded_image->DeviceHandle);
++
++        /* sort entries after version number */
++        config_sort_entries(config);
++
++        /* if we find some well-known loaders, add them to the end of the list */
++        config_entry_add_osx(config);
++        config_entry_add_windows(config, loaded_image->DeviceHandle, root_dir);
++        config_entry_add_loader_auto(config, loaded_image->DeviceHandle, root_dir, NULL,
++                                     L"auto-efi-shell", 's', L"EFI Shell", L"\\shell" EFI_MACHINE_TYPE_NAME ".efi");
++        config_entry_add_loader_auto(config, loaded_image->DeviceHandle, root_dir, loaded_image_path,
++                                     L"auto-efi-default", '\0', L"EFI Default Loader", NULL);
++
++        if (config->auto_firmware && efivar_get_uint64_le(EFI_GLOBAL_GUID, L"OsIndicationsSupported", &osind) == EFI_SUCCESS) {
++                if (osind & EFI_OS_INDICATIONS_BOOT_TO_FW_UI)
++                        config_entry_add_call(config,
++                                              L"auto-reboot-to-firmware-setup",
++                                              L"Reboot Into Firmware Interface",
++                                              reboot_into_firmware);
++        }
++}
++
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         _cleanup_freepool_ EFI_LOADED_IMAGE *loaded_image = NULL;
+-        UINT64 osind = 0;
+         _cleanup_(FileHandleClosep) EFI_FILE *root_dir = NULL;
+         CHAR16 *loaded_image_path;
+         EFI_STATUS err;
+@@ -2495,35 +2538,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                         return log_error_status_stall(err, L"Error installing security policy: %r", err);
+         }
+ 
+-        config_load_defaults(&config, root_dir);
+-
+-        /* scan /EFI/Linux/ directory */
+-        config_entry_add_linux(&config, loaded_image->DeviceHandle, root_dir);
+-
+-        /* scan /loader/entries/\*.conf files */
+-        config_load_entries(&config, loaded_image->DeviceHandle, root_dir, loaded_image_path);
+-
+-        /* Similar, but on any XBOOTLDR partition */
+-        config_load_xbootldr(&config, loaded_image->DeviceHandle);
+-
+-        /* sort entries after version number */
+-        config_sort_entries(&config);
+-
+-        /* if we find some well-known loaders, add them to the end of the list */
+-        config_entry_add_osx(&config);
+-        config_entry_add_windows(&config, loaded_image->DeviceHandle, root_dir);
+-        config_entry_add_loader_auto(&config, loaded_image->DeviceHandle, root_dir, NULL,
+-                                     L"auto-efi-shell", 's', L"EFI Shell", L"\\shell" EFI_MACHINE_TYPE_NAME ".efi");
+-        config_entry_add_loader_auto(&config, loaded_image->DeviceHandle, root_dir, loaded_image_path,
+-                                     L"auto-efi-default", '\0', L"EFI Default Loader", NULL);
+-
+-        if (config.auto_firmware && efivar_get_uint64_le(EFI_GLOBAL_GUID, L"OsIndicationsSupported", &osind) == EFI_SUCCESS) {
+-                if (osind & EFI_OS_INDICATIONS_BOOT_TO_FW_UI)
+-                        config_entry_add_call(&config,
+-                                              L"auto-reboot-to-firmware-setup",
+-                                              L"Reboot Into Firmware Interface",
+-                                              reboot_into_firmware);
+-        }
++        config_load_all_entries(&config, loaded_image, loaded_image_path, root_dir);
+ 
+         if (config.entry_count == 0) {
+                 log_error_stall(L"No loader found. Configuration files in \\loader\\entries\\*.conf are needed.");
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0047-boot-automatically-load-drop-in-EFI-drivers-off-the-.patch
+++ b/vendor/systemd-patches/0047-boot-automatically-load-drop-in-EFI-drivers-off-the-.patch
@@ -1,0 +1,262 @@
+From eba5eb652182fee13411817126dcf694e5a80744 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 14:47:05 +0200
+Subject: [PATCH 47/73] boot: automatically load drop-in EFI drivers off the
+ ESP
+
+Fixes: #15617
+---
+ src/boot/bootctl.c                    |   1 +
+ src/boot/efi/boot.c                   |   4 +
+ src/boot/efi/drivers.c                | 150 ++++++++++++++++++++++++++
+ src/boot/efi/drivers.h                |   9 ++
+ src/boot/efi/meson.build              |   2 +
+ src/fundamental/efi-loader-features.h |   1 +
+ 6 files changed, 167 insertions(+)
+ create mode 100644 src/boot/efi/drivers.c
+ create mode 100644 src/boot/efi/drivers.h
+
+diff --git a/src/boot/bootctl.c b/src/boot/bootctl.c
+index bd9681224..47ceba657 100644
+--- a/src/boot/bootctl.c
++++ b/src/boot/bootctl.c
+@@ -1288,6 +1288,7 @@ static int verb_status(int argc, char *argv[], void *userdata) {
+                         { EFI_LOADER_FEATURE_ENTRY_ONESHOT,           "One-shot entry control"                },
+                         { EFI_LOADER_FEATURE_XBOOTLDR,                "Support for XBOOTLDR partition"        },
+                         { EFI_LOADER_FEATURE_RANDOM_SEED,             "Support for passing random seed to OS" },
++                        { EFI_LOADER_FEATURE_LOAD_DRIVER,             "Load drop-in drivers"                  },
+                 };
+ 
+                 _cleanup_free_ char *fw_type = NULL, *fw_info = NULL, *loader = NULL, *loader_path = NULL, *stub = NULL;
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 62fc13e15..f1777d8de 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -7,6 +7,7 @@
+ #include "console.h"
+ #include "devicetree.h"
+ #include "disk.h"
++#include "drivers.h"
+ #include "efi-loader-features.h"
+ #include "graphics.h"
+ #include "linux.h"
+@@ -2428,6 +2429,7 @@ static VOID export_variables(
+                 EFI_LOADER_FEATURE_BOOT_COUNTING |
+                 EFI_LOADER_FEATURE_XBOOTLDR |
+                 EFI_LOADER_FEATURE_RANDOM_SEED |
++                EFI_LOADER_FEATURE_LOAD_DRIVER |
+                 0;
+ 
+         _cleanup_freepool_ CHAR16 *infostr = NULL, *typestr = NULL;
+@@ -2538,6 +2540,8 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                         return log_error_status_stall(err, L"Error installing security policy: %r", err);
+         }
+ 
++        (VOID) load_drivers(image, loaded_image, root_dir);
++
+         config_load_all_entries(&config, loaded_image, loaded_image_path, root_dir);
+ 
+         if (config.entry_count == 0) {
+diff --git a/src/boot/efi/drivers.c b/src/boot/efi/drivers.c
+new file mode 100644
+index 000000000..a876c3df7
+--- /dev/null
++++ b/src/boot/efi/drivers.c
+@@ -0,0 +1,150 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include <efi.h>
++#include <efilib.h>
++
++#include "drivers.h"
++#include "util.h"
++
++static VOID efi_unload_image(EFI_HANDLE *h) {
++        if (*h)
++                (VOID) uefi_call_wrapper(BS->UnloadImage, 1, *h);
++}
++
++static EFI_STATUS load_one_driver(
++                EFI_HANDLE parent_image,
++                EFI_LOADED_IMAGE *loaded_image,
++                const CHAR16 *fname) {
++
++        _cleanup_(efi_unload_image) EFI_HANDLE image = NULL;
++        _cleanup_freepool_ EFI_DEVICE_PATH *path = NULL;
++        _cleanup_freepool_ CHAR16 *spath = NULL;
++        EFI_STATUS err;
++
++        assert(parent_image);
++        assert(loaded_image);
++        assert(fname);
++
++        spath = PoolPrint(L"\\EFI\\systemd\\drivers\\%s", fname);
++        if (!spath)
++                return log_oom();
++
++        path = FileDevicePath(loaded_image->DeviceHandle, spath);
++        if (!path)
++                return log_oom();
++
++        err = uefi_call_wrapper(
++                        BS->LoadImage, 6,
++                        FALSE,
++                        parent_image,
++                        path,
++                        NULL, 0,
++                        &image);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to load image %s: %r", fname, err);
++
++        err = uefi_call_wrapper(
++                        BS->HandleProtocol, 3,
++                        image,
++                        &LoadedImageProtocol,
++                        (VOID **)&loaded_image);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to find protocol in driver image s: %r", fname, err);
++
++        if (loaded_image->ImageCodeType != EfiBootServicesCode &&
++            loaded_image->ImageCodeType != EfiRuntimeServicesCode)
++                return log_error_status_stall(EFI_INVALID_PARAMETER, L"Image %s is not a driver, refusing: %r", fname);
++
++        err = uefi_call_wrapper(
++                        BS->StartImage, 3,
++                        image,
++                        NULL,
++                        NULL);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to start image %s: %r", fname, err);
++
++        TAKE_PTR(image);
++        return EFI_SUCCESS;
++}
++
++static EFI_STATUS reconnect(VOID) {
++          _cleanup_freepool_ EFI_HANDLE *handles = NULL;
++          UINTN n_handles = 0;
++          EFI_STATUS err;
++
++          /* Reconnects all handles, so that any loaded drivers can take effect. */
++
++          err = uefi_call_wrapper(
++                          BS->LocateHandleBuffer, 5,
++                          AllHandles,
++                          NULL,
++                          NULL,
++                          &n_handles,
++                          &handles);
++          if (EFI_ERROR(err))
++                  return log_error_status_stall(err, L"Failed to get list of handles: %r", err);
++
++          for (UINTN i = 0; i < n_handles; i++) {
++                  err = uefi_call_wrapper(
++                                  BS->ConnectController, 4,
++                                  handles[i],
++                                  NULL,
++                                  NULL,
++                                  TRUE);
++                  if (err == EFI_NOT_FOUND) /* No drivers for this handle */
++                          continue;
++                  if (EFI_ERROR(err))
++                          log_error_status_stall(err, L"Failed to reconnect handle %u, ignoring: %r", i, err);
++          }
++
++          return EFI_SUCCESS;
++}
++
++EFI_STATUS load_drivers(
++                EFI_HANDLE parent_image,
++                EFI_LOADED_IMAGE *loaded_image,
++                EFI_FILE_HANDLE root_dir) {
++
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE drivers_dir = NULL;
++        _cleanup_freepool_ EFI_FILE_INFO *dirent = NULL;
++        _cleanup_freepool_ EFI_DEVICE_PATH *path = NULL;
++        UINTN dirent_size = 0, n_succeeded = 0;
++        EFI_STATUS err;
++
++        err = open_directory(
++                        root_dir,
++                        L"\\EFI\\systemd\\drivers",
++                        &drivers_dir);
++        if (err == EFI_NOT_FOUND)
++                return EFI_SUCCESS;
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to open \\EFI\\systemd\\drivers: %r", err);
++
++        for (;;) {
++                _cleanup_freepool_ CHAR16 *d = NULL;
++
++                err = readdir_harder(drivers_dir, &dirent, &dirent_size);
++                if (EFI_ERROR(err))
++                        return log_error_status_stall(err, L"Failed to read extra directory of loaded image: %r", err);
++                if (!dirent) /* End of directory */
++                        break;
++
++                if (dirent->FileName[0] == '.')
++                        continue;
++                if (dirent->Attribute & EFI_FILE_DIRECTORY)
++                        continue;
++                if (!endswith_no_case(dirent->FileName, EFI_MACHINE_TYPE_NAME L".efi"))
++                        continue;
++
++                err = load_one_driver(parent_image, loaded_image, dirent->FileName);
++                if (EFI_ERROR(err))
++                        continue;
++
++                n_succeeded++;
++        }
++
++        if (n_succeeded > 0)
++                (VOID) reconnect();
++
++        return EFI_SUCCESS;
++}
+diff --git a/src/boot/efi/drivers.h b/src/boot/efi/drivers.h
+new file mode 100644
+index 000000000..c192c6d44
+--- /dev/null
++++ b/src/boot/efi/drivers.h
+@@ -0,0 +1,9 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++#pragma once
++
++#include <efi.h>
++
++EFI_STATUS load_drivers(
++                EFI_HANDLE parent_image,
++                EFI_LOADED_IMAGE *loaded_image,
++                EFI_FILE_HANDLE root_dir);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index 1f974d3d6..04ec24792 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -5,6 +5,7 @@ efi_headers = files('''
+         cpio.h
+         devicetree.h
+         disk.h
++        drivers.h
+         graphics.h
+         linux.h
+         measure.h
+@@ -31,6 +32,7 @@ systemd_boot_sources = '''
+         boot.c
+         console.c
+         devicetree.c
++        drivers.c
+         random-seed.c
+         sha256.c
+         shim.c
+diff --git a/src/fundamental/efi-loader-features.h b/src/fundamental/efi-loader-features.h
+index f07dacb85..287ae3c89 100644
+--- a/src/fundamental/efi-loader-features.h
++++ b/src/fundamental/efi-loader-features.h
+@@ -12,3 +12,4 @@
+ #define EFI_LOADER_FEATURE_BOOT_COUNTING           (UINT64_C(1) << 4)
+ #define EFI_LOADER_FEATURE_XBOOTLDR                (UINT64_C(1) << 5)
+ #define EFI_LOADER_FEATURE_RANDOM_SEED             (UINT64_C(1) << 6)
++#define EFI_LOADER_FEATURE_LOAD_DRIVER             (UINT64_C(1) << 7)
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0048-boot-port-more-code-to-use-open_directory-helper.patch
+++ b/vendor/systemd-patches/0048-boot-port-more-code-to-use-open_directory-helper.patch
@@ -1,0 +1,34 @@
+From ecdd2d2e178d054143c35dff12fccf32c52b0312 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 15:13:29 +0200
+Subject: [PATCH 48/73] boot: port more code to use open_directory() helper
+
+---
+ src/boot/efi/boot.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index f1777d8de..dd7731c4d 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1498,7 +1498,7 @@ static VOID config_load_entries(
+         assert(root_dir);
+         assert(loaded_image_path);
+ 
+-        err = uefi_call_wrapper(root_dir->Open, 5, root_dir, &entries_dir, (CHAR16*) L"\\loader\\entries", EFI_FILE_MODE_READ, 0ULL);
++        err = open_directory(root_dir, L"\\loader\\entries", &entries_dir);
+         if (EFI_ERROR(err))
+                 return;
+ 
+@@ -1969,7 +1969,7 @@ static VOID config_entry_add_linux(
+         assert(device);
+         assert(root_dir);
+ 
+-        err = uefi_call_wrapper(root_dir->Open, 5, root_dir, &linux_dir, (CHAR16*) L"\\EFI\\Linux", EFI_FILE_MODE_READ, 0ULL);
++        err = open_directory(root_dir, L"\\EFI\\Linux", &linux_dir);
+         if (EFI_ERROR(err))
+                 return;
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0049-boot-use-_cleanup_freepool_-at-more-places.patch
+++ b/vendor/systemd-patches/0049-boot-use-_cleanup_freepool_-at-more-places.patch
@@ -1,0 +1,76 @@
+From 96d5ab10bc66c6b15c49dfb9f3b334a9e886212c Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 15:20:40 +0200
+Subject: [PATCH 49/73] boot: use _cleanup_freepool_ at more places
+
+---
+ src/boot/efi/boot.c | 22 +++++-----------------
+ 1 file changed, 5 insertions(+), 17 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index dd7731c4d..caeb6aa12 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -518,7 +518,8 @@ static BOOLEAN menu_run(
+         BOOLEAN refresh = TRUE, highlight = FALSE;
+         UINTN x_start = 0, y_start = 0, y_status = 0;
+         UINTN x_max, y_max;
+-        CHAR16 **lines = NULL, *status = NULL, *clearline = NULL;
++        CHAR16 **lines = NULL;
++        _cleanup_freepool_ CHAR16 *clearline = NULL, *status = NULL;
+         UINTN timeout_remain = config->timeout_sec;
+         INT16 idx;
+         BOOLEAN exit = FALSE, run = TRUE;
+@@ -902,7 +903,6 @@ static BOOLEAN menu_run(
+         for (UINTN i = 0; i < config->entry_count; i++)
+                 FreePool(lines[i]);
+         FreePool(lines);
+-        FreePool(clearline);
+ 
+         clear_screen(COLOR_NORMAL);
+         return run;
+@@ -1974,6 +1974,9 @@ static VOID config_entry_add_linux(
+                 return;
+ 
+         for (;;) {
++                _cleanup_freepool_ CHAR16 *os_name_pretty = NULL, *os_name = NULL, *os_id = NULL,
++                        *os_version = NULL, *os_version_id = NULL, *os_build_id = NULL;
++                _cleanup_freepool_ CHAR8 *content = NULL;
+                 CHAR16 buf[256];
+                 UINTN bufsize = sizeof buf;
+                 EFI_FILE_INFO *f;
+@@ -1984,16 +1987,9 @@ static VOID config_entry_add_linux(
+                 };
+                 UINTN offs[ELEMENTSOF(sections)-1] = {};
+                 UINTN szs[ELEMENTSOF(sections)-1] = {};
+-                CHAR8 *content = NULL;
+                 CHAR8 *line;
+                 UINTN pos = 0;
+                 CHAR8 *key, *value;
+-                CHAR16 *os_name_pretty = NULL;
+-                CHAR16 *os_name = NULL;
+-                CHAR16 *os_id = NULL;
+-                CHAR16 *os_version = NULL;
+-                CHAR16 *os_version_id = NULL;
+-                CHAR16 *os_build_id = NULL;
+ 
+                 err = uefi_call_wrapper(linux_dir->Read, 3, linux_dir, &bufsize, buf);
+                 if (bufsize == 0 || EFI_ERROR(err))
+@@ -2082,14 +2078,6 @@ static VOID config_entry_add_linux(
+ 
+                         config_entry_parse_tries(entry, L"\\EFI\\Linux", f->FileName, L".efi");
+                 }
+-
+-                FreePool(os_name_pretty);
+-                FreePool(os_name);
+-                FreePool(os_id);
+-                FreePool(os_version);
+-                FreePool(os_version_id);
+-                FreePool(os_build_id);
+-                FreePool(content);
+         }
+ }
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0050-boot-port-more-code-to-readdir_harder.patch
+++ b/vendor/systemd-patches/0050-boot-port-more-code-to-readdir_harder.patch
@@ -1,0 +1,81 @@
+From a93bb5beb83138ab0953eba7f458bdfb3fed45a7 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 15:24:50 +0200
+Subject: [PATCH 50/73] boot: port more code to readdir_harder()
+
+---
+ src/boot/efi/boot.c | 23 +++++++++--------------
+ 1 file changed, 9 insertions(+), 14 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index caeb6aa12..40fb933af 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1491,6 +1491,8 @@ static VOID config_load_entries(
+                 const CHAR16 *loaded_image_path) {
+ 
+         _cleanup_(FileHandleClosep) EFI_FILE_HANDLE entries_dir = NULL;
++        _cleanup_freepool_ EFI_FILE_INFO *f = NULL;
++        UINTN f_size = 0;
+         EFI_STATUS err;
+ 
+         assert(config);
+@@ -1503,17 +1505,12 @@ static VOID config_load_entries(
+                 return;
+ 
+         for (;;) {
+-                CHAR16 buf[256];
+-                UINTN bufsize;
+-                EFI_FILE_INFO *f;
+                 _cleanup_freepool_ CHAR8 *content = NULL;
+ 
+-                bufsize = sizeof(buf);
+-                err = uefi_call_wrapper(entries_dir->Read, 3, entries_dir, &bufsize, buf);
+-                if (bufsize == 0 || EFI_ERROR(err))
++                err = readdir_harder(entries_dir, &f, &f_size);
++                if (f_size == 0 || EFI_ERROR(err))
+                         break;
+ 
+-                f = (EFI_FILE_INFO *) buf;
+                 if (f->FileName[0] == '.')
+                         continue;
+                 if (f->Attribute & EFI_FILE_DIRECTORY)
+@@ -1962,8 +1959,10 @@ static VOID config_entry_add_linux(
+                 EFI_FILE *root_dir) {
+ 
+         _cleanup_(FileHandleClosep) EFI_FILE_HANDLE linux_dir = NULL;
+-        EFI_STATUS err;
++        _cleanup_freepool_ EFI_FILE_INFO *f = NULL;
+         ConfigEntry *entry;
++        UINTN f_size = 0;
++        EFI_STATUS err;
+ 
+         assert(config);
+         assert(device);
+@@ -1977,9 +1976,6 @@ static VOID config_entry_add_linux(
+                 _cleanup_freepool_ CHAR16 *os_name_pretty = NULL, *os_name = NULL, *os_id = NULL,
+                         *os_version = NULL, *os_version_id = NULL, *os_build_id = NULL;
+                 _cleanup_freepool_ CHAR8 *content = NULL;
+-                CHAR16 buf[256];
+-                UINTN bufsize = sizeof buf;
+-                EFI_FILE_INFO *f;
+                 const CHAR8 *sections[] = {
+                         (CHAR8 *)".osrel",
+                         (CHAR8 *)".cmdline",
+@@ -1991,11 +1987,10 @@ static VOID config_entry_add_linux(
+                 UINTN pos = 0;
+                 CHAR8 *key, *value;
+ 
+-                err = uefi_call_wrapper(linux_dir->Read, 3, linux_dir, &bufsize, buf);
+-                if (bufsize == 0 || EFI_ERROR(err))
++                err = readdir_harder(linux_dir, &f, &f_size);
++                if (f_size == 0 || EFI_ERROR(err))
+                         break;
+ 
+-                f = (EFI_FILE_INFO *) buf;
+                 if (f->FileName[0] == '.')
+                         continue;
+                 if (f->Attribute & EFI_FILE_DIRECTORY)
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0051-boot-port-more-code-over-to-get_file_info_harder.patch
+++ b/vendor/systemd-patches/0051-boot-port-more-code-over-to-get_file_info_harder.patch
@@ -1,0 +1,91 @@
+From 19657cca321dffe4d490779c89d50463f029d362 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 15:29:03 +0200
+Subject: [PATCH 51/73] boot: port more code over to get_file_info_harder()
+
+---
+ src/boot/efi/boot.c        | 25 ++++---------------------
+ src/boot/efi/devicetree.c  |  6 +++---
+ src/boot/efi/random-seed.c |  6 +++---
+ 3 files changed, 10 insertions(+), 27 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 40fb933af..386ee678e 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1226,7 +1226,7 @@ static VOID config_entry_bump_counters(
+         _cleanup_(FileHandleClosep) EFI_FILE_HANDLE handle = NULL;
+         static const EFI_GUID EfiFileInfoGuid = EFI_FILE_INFO_ID;
+         _cleanup_freepool_ EFI_FILE_INFO *file_info = NULL;
+-        UINTN file_info_size, a, b;
++        UINTN file_info_size;
+         EFI_STATUS r;
+ 
+         assert(entry);
+@@ -1244,26 +1244,9 @@ static VOID config_entry_bump_counters(
+         if (EFI_ERROR(r))
+                 return;
+ 
+-        a = StrLen(entry->current_name);
+-        b = StrLen(entry->next_name);
+-
+-        file_info_size = OFFSETOF(EFI_FILE_INFO, FileName) + (a > b ? a : b) + 1;
+-
+-        for (;;) {
+-                file_info = AllocatePool(file_info_size);
+-
+-                r = uefi_call_wrapper(handle->GetInfo, 4, handle, (EFI_GUID*) &EfiFileInfoGuid, &file_info_size, file_info);
+-                if (!EFI_ERROR(r))
+-                        break;
+-
+-                if (r != EFI_BUFFER_TOO_SMALL || file_info_size * 2 < file_info_size) {
+-                        log_error_stall(L"Failed to get file info for '%s': %r", old_path, r);
+-                        return;
+-                }
+-
+-                file_info_size *= 2;
+-                FreePool(file_info);
+-        }
++        r = get_file_info_harder(handle, &file_info, &file_info_size);
++        if (EFI_ERROR(r))
++                return;
+ 
+         /* And rename the file */
+         StrCpy(file_info->FileName, entry->next_name);
+diff --git a/src/boot/efi/devicetree.c b/src/boot/efi/devicetree.c
+index c65936bdb..87ae97a52 100644
+--- a/src/boot/efi/devicetree.c
++++ b/src/boot/efi/devicetree.c
+@@ -91,9 +91,9 @@ EFI_STATUS devicetree_install(struct devicetree_state *state,
+         if (EFI_ERROR(err))
+                 return err;
+ 
+-        info = LibFileInfo(handle);
+-        if (!info)
+-                return EFI_OUT_OF_RESOURCES;
++        err = get_file_info_harder(handle, &info, NULL);
++        if (EFI_ERROR(err))
++                return err;
+         if (info->FileSize < FDT_V1_SIZE || info->FileSize > 32 * 1024 * 1024)
+                 /* 32MB device tree blob doesn't seem right */
+                 return EFI_INVALID_PARAMETER;
+diff --git a/src/boot/efi/random-seed.c b/src/boot/efi/random-seed.c
+index d20923eac..1505b9d93 100644
+--- a/src/boot/efi/random-seed.c
++++ b/src/boot/efi/random-seed.c
+@@ -263,9 +263,9 @@ EFI_STATUS process_random_seed(EFI_FILE *root_dir, RandomSeedMode mode) {
+                 return err;
+         }
+ 
+-        info = LibFileInfo(handle);
+-        if (!info)
+-                return log_oom();
++        err = get_file_info_harder(handle, &info, NULL);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(err, L"Failed to get file info for random seed: %r");
+ 
+         size = info->FileSize;
+         if (size < RANDOM_MAX_SIZE_MIN)
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0052-boot-move-TPM-conditionalization-into-measure.h-head.patch
+++ b/vendor/systemd-patches/0052-boot-move-TPM-conditionalization-into-measure.h-head.patch
@@ -1,0 +1,73 @@
+From fec64b74963f41836d219fc66defe3259c32538a Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 15:39:47 +0200
+Subject: [PATCH 52/73] boot: move TPM conditionalization into measure.h header
+
+Let's move conditionalization of tpm_log_load_options() into the
+measure.h to encapsulate the ifdeffery a bit more.
+---
+ src/boot/efi/boot.c    |  2 --
+ src/boot/efi/measure.h | 14 +++++++++++++-
+ src/boot/efi/stub.c    |  2 --
+ 3 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 386ee678e..9efd157a8 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -2314,10 +2314,8 @@ static EFI_STATUS image_start(
+                 loaded_image->LoadOptions = options;
+                 loaded_image->LoadOptionsSize = StrSize(loaded_image->LoadOptions);
+ 
+-#if ENABLE_TPM
+                 /* Try to log any options to the TPM, especially to catch manually edited options */
+                 (VOID) tpm_log_load_options(options);
+-#endif
+         }
+ 
+         efivar_set_time_usec(LOADER_GUID, L"LoaderTimeExecUSec", 0);
+diff --git a/src/boot/efi/measure.h b/src/boot/efi/measure.h
+index 69eb682a2..b92d0574c 100644
+--- a/src/boot/efi/measure.h
++++ b/src/boot/efi/measure.h
+@@ -3,6 +3,18 @@
+ 
+ #include <efi.h>
+ 
+-EFI_STATUS tpm_log_event(UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer, UINTN buffer_size, const CHAR16 *description);
++#if ENABLE_TPM
+ 
++EFI_STATUS tpm_log_event(UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer, UINTN buffer_size, const CHAR16 *description);
+ EFI_STATUS tpm_log_load_options(const CHAR16 *cmdline);
++
++#else
++
++static inline EFI_STATUS tpm_log_event(UINT32 pcrindex, const EFI_PHYSICAL_ADDRESS buffer, UINTN buffer_size, const CHAR16 *description) {
++        return EFI_SUCCESS;
++}
++static inline EFI_STATUS tpm_log_load_options(const CHAR16 *cmdline) {
++        return EFI_SUCCESS;
++}
++
++#endif
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 9a71aff16..3a42ff422 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -193,13 +193,11 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                         line[i] = options[i];
+                 cmdline = line;
+ 
+-#if ENABLE_TPM
+                 /* Let's measure the passed kernel command line into the TPM. Note that this possibly
+                  * duplicates what we already did in the boot menu, if that was already used. However, since
+                  * we want the boot menu to support an EFI binary, and want to this stub to be usable from
+                  * any boot menu, let's measure things anyway. */
+                 (VOID) tpm_log_load_options(loaded_image->LoadOptions);
+-#endif
+         }
+ 
+         export_variables(loaded_image);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0053-boot-add-helper-for-converting-EFI_PHYSICAL_ADDRESS-.patch
+++ b/vendor/systemd-patches/0053-boot-add-helper-for-converting-EFI_PHYSICAL_ADDRESS-.patch
@@ -1,0 +1,199 @@
+From 4051cf25d9d4cb59bd3b948d8d736c906bd822c6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alfonso=20S=C3=A1nchez-Beato?=
+ <alfonso.sanchez-beato@canonical.com>
+Date: Fri, 25 Feb 2022 15:57:41 +0100
+Subject: [PATCH 53/73] boot: add helper for converting EFI_PHYSICAL_ADDRESS to
+ a pointer
+
+This isn't trivial when trying to be compatible with 32bit archs, hence
+add a set of helper macro-like functions that make the conversion safe.
+---
+ src/boot/efi/cpio.c       |  2 +-
+ src/boot/efi/devicetree.c | 18 ++++++------------
+ src/boot/efi/linux.c      |  7 ++++---
+ src/boot/efi/measure.c    |  2 +-
+ src/boot/efi/stub.c       | 10 +++++-----
+ src/boot/efi/util.h       | 20 ++++++++++++++++++++
+ 6 files changed, 37 insertions(+), 22 deletions(-)
+
+diff --git a/src/boot/efi/cpio.c b/src/boot/efi/cpio.c
+index 9c99454d9..10a044cc9 100644
+--- a/src/boot/efi/cpio.c
++++ b/src/boot/efi/cpio.c
+@@ -452,7 +452,7 @@ EFI_STATUS pack_cpio(
+ #if ENABLE_TPM
+         err = tpm_log_event(
+                         tpm_pcr,
+-                        (EFI_PHYSICAL_ADDRESS) (UINTN) buffer,
++                        POINTER_TO_PHYSICAL_ADDRESS(buffer),
+                         buffer_size,
+                         tpm_description);
+         if (EFI_ERROR(err))
+diff --git a/src/boot/efi/devicetree.c b/src/boot/efi/devicetree.c
+index 87ae97a52..fd4b9c406 100644
+--- a/src/boot/efi/devicetree.c
++++ b/src/boot/efi/devicetree.c
+@@ -28,12 +28,6 @@ static UINTN devicetree_allocated(const struct devicetree_state *state) {
+         return state->pages * EFI_PAGE_SIZE;
+ }
+ 
+-static VOID *devicetree_ptr(const struct devicetree_state *state) {
+-        assert(state);
+-        assert(state->addr <= UINTN_MAX);
+-        return (VOID *)(UINTN)state->addr;
+-}
+-
+ static EFI_STATUS devicetree_fixup(struct devicetree_state *state, UINTN len) {
+         EFI_DT_FIXUP_PROTOCOL *fixup;
+         UINTN size;
+@@ -47,24 +41,24 @@ static EFI_STATUS devicetree_fixup(struct devicetree_state *state, UINTN len) {
+                                               L"Could not locate device tree fixup protocol, skipping.");
+ 
+         size = devicetree_allocated(state);
+-        err = uefi_call_wrapper(fixup->Fixup, 4, fixup, devicetree_ptr(state), &size,
++        err = uefi_call_wrapper(fixup->Fixup, 4, fixup, PHYSICAL_ADDRESS_TO_POINTER(state->addr), &size,
+                                 EFI_DT_APPLY_FIXUPS | EFI_DT_RESERVE_MEMORY);
+         if (err == EFI_BUFFER_TOO_SMALL) {
+                 EFI_PHYSICAL_ADDRESS oldaddr = state->addr;
+                 UINTN oldpages = state->pages;
+-                VOID *oldptr = devicetree_ptr(state);
++                VOID *oldptr = PHYSICAL_ADDRESS_TO_POINTER(state->addr);
+ 
+                 err = devicetree_allocate(state, size);
+                 if (EFI_ERROR(err))
+                         return err;
+ 
+-                CopyMem(devicetree_ptr(state), oldptr, len);
++                CopyMem(PHYSICAL_ADDRESS_TO_POINTER(state->addr), oldptr, len);
+                 err = uefi_call_wrapper(BS->FreePages, 2, oldaddr, oldpages);
+                 if (EFI_ERROR(err))
+                         return err;
+ 
+                 size = devicetree_allocated(state);
+-                err = uefi_call_wrapper(fixup->Fixup, 4, fixup, devicetree_ptr(state), &size,
++                err = uefi_call_wrapper(fixup->Fixup, 4, fixup, PHYSICAL_ADDRESS_TO_POINTER(state->addr), &size,
+                                         EFI_DT_APPLY_FIXUPS | EFI_DT_RESERVE_MEMORY);
+         }
+ 
+@@ -104,7 +98,7 @@ EFI_STATUS devicetree_install(struct devicetree_state *state,
+         if (EFI_ERROR(err))
+                 return err;
+ 
+-        err = uefi_call_wrapper(handle->Read, 3, handle, &len, devicetree_ptr(state));
++        err = uefi_call_wrapper(handle->Read, 3, handle, &len, PHYSICAL_ADDRESS_TO_POINTER(state->addr));
+         if (EFI_ERROR(err))
+                 return err;
+ 
+@@ -112,7 +106,7 @@ EFI_STATUS devicetree_install(struct devicetree_state *state,
+         if (EFI_ERROR(err))
+                 return err;
+ 
+-        return uefi_call_wrapper(BS->InstallConfigurationTable, 2, &EfiDtbTableGuid, devicetree_ptr(state));
++        return uefi_call_wrapper(BS->InstallConfigurationTable, 2, &EfiDtbTableGuid, PHYSICAL_ADDRESS_TO_POINTER(state->addr));
+ }
+ 
+ void devicetree_cleanup(struct devicetree_state *state) {
+diff --git a/src/boot/efi/linux.c b/src/boot/efi/linux.c
+index 529325fef..3af69e4d5 100644
+--- a/src/boot/efi/linux.c
++++ b/src/boot/efi/linux.c
+@@ -66,9 +66,10 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
+                                         EFI_SIZE_TO_PAGES(cmdline_len + 1), &addr);
+                 if (EFI_ERROR(err))
+                         return err;
+-                CopyMem((VOID *)(UINTN)addr, cmdline, cmdline_len);
+-                ((CHAR8 *)(UINTN)addr)[cmdline_len] = 0;
+-                boot_params->hdr.cmd_line_ptr = (UINT32)addr;
++
++                CopyMem(PHYSICAL_ADDRESS_TO_POINTER(addr), cmdline, cmdline_len);
++                ((CHAR8 *) PHYSICAL_ADDRESS_TO_POINTER(addr))[cmdline_len] = 0;
++                boot_params->hdr.cmd_line_ptr = (UINT32) addr;
+         }
+ 
+         boot_params->hdr.ramdisk_image = (UINT32)initrd_addr;
+diff --git a/src/boot/efi/measure.c b/src/boot/efi/measure.c
+index 0e9a523b1..be9d0ccb2 100644
+--- a/src/boot/efi/measure.c
++++ b/src/boot/efi/measure.c
+@@ -168,7 +168,7 @@ EFI_STATUS tpm_log_load_options(const CHAR16 *load_options) {
+         /* Measures a load options string into the TPM2, i.e. the kernel command line */
+ 
+         err = tpm_log_event(SD_TPM_PCR,
+-                            (EFI_PHYSICAL_ADDRESS) (UINTN) load_options,
++                            POINTER_TO_PHYSICAL_ADDRESS(load_options),
+                             StrSize(load_options), load_options);
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Unable to add load options (i.e. kernel command) line measurement: %r", err);
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 3a42ff422..555d08fb8 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -55,13 +55,13 @@ static EFI_STATUS combine_initrd(
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Failed to allocate space for combined initrd: %r", err);
+ 
+-        p = (UINT8*) (UINTN) base;
++        p = PHYSICAL_ADDRESS_TO_POINTER(base);
+         if (initrd_base != 0) {
+                 UINTN pad;
+ 
+                 /* Order matters, the real initrd must come first, since it might include microcode updates
+                  * which the kernel only looks for in the first cpio archive */
+-                CopyMem(p, (VOID*) (UINTN) initrd_base, initrd_size);
++                CopyMem(p, PHYSICAL_ADDRESS_TO_POINTER(initrd_base), initrd_size);
+                 p += initrd_size;
+ 
+                 pad = ALIGN_TO(initrd_size, 4) - initrd_size;
+@@ -81,7 +81,7 @@ static EFI_STATUS combine_initrd(
+                 p += sysext_initrd_size;
+         }
+ 
+-        assert((UINT8*) (UINTN) base + n == p);
++        assert((UINT8*) PHYSICAL_ADDRESS_TO_POINTER(base) + n == p);
+ 
+         *ret_initrd_base = base;
+         *ret_initrd_size = n;
+@@ -222,10 +222,10 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                          &sysext_initrd,
+                          &sysext_initrd_size);
+ 
+-        linux_base = (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->ImageBase + addrs[SECTION_LINUX];
++        linux_base = POINTER_TO_PHYSICAL_ADDRESS(loaded_image->ImageBase) + addrs[SECTION_LINUX];
+ 
+         initrd_size = szs[SECTION_INITRD];
+-        initrd_base = initrd_size != 0 ? (EFI_PHYSICAL_ADDRESS) (UINTN) loaded_image->ImageBase + addrs[SECTION_INITRD] : 0;
++        initrd_base = initrd_size != 0 ? POINTER_TO_PHYSICAL_ADDRESS(loaded_image->ImageBase) + addrs[SECTION_INITRD] : 0;
+ 
+         if (credential_initrd || sysext_initrd) {
+                 /* If we have generated initrds dynamically, let's combine them with the built-in initrd. */
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index 3a29ff2d7..ca95514d7 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -124,3 +124,23 @@ static inline void strv_freep(CHAR16 ***p) {
+ }
+ 
+ EFI_STATUS open_directory(EFI_FILE_HANDLE root_dir, const CHAR16 *path, EFI_FILE_HANDLE *ret);
++
++/* Conversion between EFI_PHYSICAL_ADDRESS and pointers is not obvious. The former is always 64bit, even on
++ * 32bit archs. And gcc complains if we cast a pointer to an integer of a different size. Hence let's do the
++ * conversion indirectly: first into UINTN (which is defined by UEFI to have the same size as a pointer), and
++ * then extended to EFI_PHYSICAL_ADDRESS. */
++static inline EFI_PHYSICAL_ADDRESS POINTER_TO_PHYSICAL_ADDRESS(const void *p) {
++        return (EFI_PHYSICAL_ADDRESS) (UINTN) p;
++}
++
++static inline void *PHYSICAL_ADDRESS_TO_POINTER(EFI_PHYSICAL_ADDRESS addr) {
++#if __SIZEOF_POINTER__ == 4
++        /* On 32bit systems the address might not be convertible (as pointers are 32bit but
++         * EFI_PHYSICAL_ADDRESS 64bit) */
++        assert(addr <= UINT32_MAX);
++#elif __SIZEOF_POINTER__ != 8
++        #error "Unexpected pointer size"
++#endif
++
++        return (void*) (UINTN) addr;
++}
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0054-stub-various-modernizations-to-linux.c.patch
+++ b/vendor/systemd-patches/0054-stub-various-modernizations-to-linux.c.patch
@@ -1,0 +1,100 @@
+From e0dba0f2c34a3d40a22caa4ac52d2ad0256f3529 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 22:00:06 +0200
+Subject: [PATCH 54/73] stub: various modernizations to linux.c
+
+Let's make some stuff const. Most importanly call AllocatePages() with
+a pointer to an EFI_PHYSICAL_ADDRESS instead of a pointer to a
+pointer. On 64bit this makes no difference, but on i386 this is simply
+not correct, since EFI_PHYSICAL_ADDRESS is 64bit there, even though
+pointers are 32bit.
+---
+ src/boot/efi/linux.c | 34 +++++++++++++++++++++++-----------
+ 1 file changed, 23 insertions(+), 11 deletions(-)
+
+diff --git a/src/boot/efi/linux.c b/src/boot/efi/linux.c
+index 3af69e4d5..5232a3ba4 100644
+--- a/src/boot/efi/linux.c
++++ b/src/boot/efi/linux.c
+@@ -13,6 +13,7 @@
+ #endif
+ 
+ typedef VOID(*handover_f)(VOID *image, EFI_SYSTEM_TABLE *table, struct boot_params *params) __regparm0__;
++
+ static VOID linux_efi_handover(EFI_HANDLE image, struct boot_params *params) {
+         handover_f handover;
+         UINTN start = (UINTN)params->hdr.code32_start;
+@@ -31,16 +32,17 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
+                       CHAR8 *cmdline, UINTN cmdline_len,
+                       UINTN linux_addr,
+                       UINTN initrd_addr, UINTN initrd_size) {
+-        struct boot_params *image_params;
++
++        const struct boot_params *image_params;
+         struct boot_params *boot_params;
+-        UINT8 setup_sectors;
+         EFI_PHYSICAL_ADDRESS addr;
++        UINT8 setup_sectors;
+         EFI_STATUS err;
+ 
+         assert(image);
+         assert(cmdline);
+ 
+-        image_params = (struct boot_params *) linux_addr;
++        image_params = (const struct boot_params *) linux_addr;
+ 
+         if (image_params->hdr.boot_flag != 0xAA55 ||
+             image_params->hdr.header != SETUP_MAGIC ||
+@@ -48,22 +50,32 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
+             !image_params->hdr.relocatable_kernel)
+                 return EFI_LOAD_ERROR;
+ 
+-        boot_params = (struct boot_params *) 0xFFFFFFFF;
+-        err = uefi_call_wrapper(BS->AllocatePages, 4, AllocateMaxAddress, EfiLoaderData,
+-                                EFI_SIZE_TO_PAGES(0x4000), (EFI_PHYSICAL_ADDRESS*) &boot_params);
++        addr = UINT32_MAX; /* Below the 32bit boundary */
++        err = uefi_call_wrapper(
++                        BS->AllocatePages, 4,
++                        AllocateMaxAddress,
++                        EfiLoaderData,
++                        EFI_SIZE_TO_PAGES(0x4000),
++                        &addr);
+         if (EFI_ERROR(err))
+                 return err;
+ 
++        boot_params = (struct boot_params *) PHYSICAL_ADDRESS_TO_POINTER(addr);
+         ZeroMem(boot_params, 0x4000);
+-        CopyMem(&boot_params->hdr, &image_params->hdr, sizeof(struct setup_header));
++        boot_params->hdr = image_params->hdr;
+         boot_params->hdr.type_of_loader = 0xff;
+         setup_sectors = image_params->hdr.setup_sects > 0 ? image_params->hdr.setup_sects : 4;
+         boot_params->hdr.code32_start = (UINT32)linux_addr + (setup_sectors + 1) * 512;
+ 
+         if (cmdline) {
+                 addr = 0xA0000;
+-                err = uefi_call_wrapper(BS->AllocatePages, 4, AllocateMaxAddress, EfiLoaderData,
+-                                        EFI_SIZE_TO_PAGES(cmdline_len + 1), &addr);
++
++                err = uefi_call_wrapper(
++                                BS->AllocatePages, 4,
++                                AllocateMaxAddress,
++                                EfiLoaderData,
++                                EFI_SIZE_TO_PAGES(cmdline_len + 1),
++                                &addr);
+                 if (EFI_ERROR(err))
+                         return err;
+ 
+@@ -72,8 +84,8 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
+                 boot_params->hdr.cmd_line_ptr = (UINT32) addr;
+         }
+ 
+-        boot_params->hdr.ramdisk_image = (UINT32)initrd_addr;
+-        boot_params->hdr.ramdisk_size = (UINT32)initrd_size;
++        boot_params->hdr.ramdisk_image = (UINT32) initrd_addr;
++        boot_params->hdr.ramdisk_size = (UINT32) initrd_size;
+ 
+         linux_efi_handover(image, boot_params);
+         return EFI_LOAD_ERROR;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0055-boot-add-get_os_indications_supported-helper.patch
+++ b/vendor/systemd-patches/0055-boot-add-get_os_indications_supported-helper.patch
@@ -1,0 +1,100 @@
+From fb46af74c735df51e8a381473fcc589416d3315c Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 21 Sep 2021 22:13:23 +0200
+Subject: [PATCH 55/73] boot: add get_os_indications_supported() helper
+
+We inquire the EFI var for this at two places, let's add a helper that
+queries it and gracefully handles it if we can't get it, by returning a
+zero mask, i.e. no features supported.
+---
+ src/boot/efi/boot.c | 19 +++++++------------
+ src/boot/efi/util.c | 14 ++++++++++++++
+ src/boot/efi/util.h |  2 ++
+ 3 files changed, 23 insertions(+), 12 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 9efd157a8..b0e16f710 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -367,7 +367,7 @@ static UINTN entry_lookup_key(Config *config, UINTN start, CHAR16 key) {
+ }
+ 
+ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+-        UINT64 key, indvar;
++        UINT64 key;
+         UINTN timeout;
+         BOOLEAN modevar;
+         _cleanup_freepool_ CHAR16 *partstr = NULL, *defaultstr = NULL;
+@@ -395,8 +395,7 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         if (shim_loaded())
+                 Print(L"Shim:                   present\n");
+ 
+-        if (efivar_get_uint64_le(EFI_GLOBAL_GUID, L"OsIndicationsSupported", &indvar) == EFI_SUCCESS)
+-                Print(L"OsIndicationsSupported: %d\n", indvar);
++        Print(L"OsIndicationsSupported: %d\n", get_os_indications_supported());
+ 
+         Print(L"\n--- press key ---\n\n");
+         console_key_read(&key, 0);
+@@ -2427,8 +2426,6 @@ static VOID config_load_all_entries(
+                 const CHAR16 *loaded_image_path,
+                 EFI_FILE *root_dir) {
+ 
+-        UINT64 osind = 0;
+-
+         assert(config);
+         assert(loaded_image);
+         assert(loaded_image_path);
+@@ -2456,13 +2453,11 @@ static VOID config_load_all_entries(
+         config_entry_add_loader_auto(config, loaded_image->DeviceHandle, root_dir, loaded_image_path,
+                                      L"auto-efi-default", '\0', L"EFI Default Loader", NULL);
+ 
+-        if (config->auto_firmware && efivar_get_uint64_le(EFI_GLOBAL_GUID, L"OsIndicationsSupported", &osind) == EFI_SUCCESS) {
+-                if (osind & EFI_OS_INDICATIONS_BOOT_TO_FW_UI)
+-                        config_entry_add_call(config,
+-                                              L"auto-reboot-to-firmware-setup",
+-                                              L"Reboot Into Firmware Interface",
+-                                              reboot_into_firmware);
+-        }
++        if (config->auto_firmware && (get_os_indications_supported() & EFI_OS_INDICATIONS_BOOT_TO_FW_UI))
++                config_entry_add_call(config,
++                                      L"auto-reboot-to-firmware-setup",
++                                      L"Reboot Into Firmware Interface",
++                                      reboot_into_firmware);
+ }
+ 
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+diff --git a/src/boot/efi/util.c b/src/boot/efi/util.c
+index e500069d5..13697c943 100644
+--- a/src/boot/efi/util.c
++++ b/src/boot/efi/util.c
+@@ -743,3 +743,17 @@ EFI_STATUS open_directory(
+         *ret = TAKE_PTR(dir);
+         return EFI_SUCCESS;
+ }
++
++UINT64 get_os_indications_supported(VOID) {
++        UINT64 osind;
++        EFI_STATUS err;
++
++        /* Returns the supported OS indications. If we can't acquire it, returns a zeroed out mask, i.e. no
++         * supported features. */
++
++        err = efivar_get_uint64_le(EFI_GLOBAL_GUID, L"OsIndicationsSupported", &osind);
++        if (EFI_ERROR(err))
++                return 0;
++
++        return osind;
++}
+diff --git a/src/boot/efi/util.h b/src/boot/efi/util.h
+index ca95514d7..fa17b18f4 100644
+--- a/src/boot/efi/util.h
++++ b/src/boot/efi/util.h
+@@ -144,3 +144,5 @@ static inline void *PHYSICAL_ADDRESS_TO_POINTER(EFI_PHYSICAL_ADDRESS addr) {
+ 
+         return (void*) (UINTN) addr;
+ }
++
++UINT64 get_os_indications_supported(VOID);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0056-boot-prefer-IMAGE_VERSION-from-os-release-as-version.patch
+++ b/vendor/systemd-patches/0056-boot-prefer-IMAGE_VERSION-from-os-release-as-version.patch
@@ -1,0 +1,61 @@
+From 91cc6376964aca3cb7d77f69c5b2dac02adf00de Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Thu, 23 Sep 2021 17:48:26 +0200
+Subject: [PATCH 56/73] boot: prefer IMAGE_VERSION from os-release as version
+ string
+
+If the field exists it's probably the best version we have for sorting,
+since it will change on every single OS image update.
+---
+ src/boot/efi/boot.c | 22 +++++++++++++++++-----
+ 1 file changed, 17 insertions(+), 5 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index b0e16f710..d82d679a4 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1956,7 +1956,7 @@ static VOID config_entry_add_linux(
+ 
+         for (;;) {
+                 _cleanup_freepool_ CHAR16 *os_name_pretty = NULL, *os_name = NULL, *os_id = NULL,
+-                        *os_version = NULL, *os_version_id = NULL, *os_build_id = NULL;
++                        *os_version = NULL, *os_version_id = NULL, *os_build_id = NULL, *os_image_version = NULL;
+                 _cleanup_freepool_ CHAR8 *content = NULL;
+                 const CHAR8 *sections[] = {
+                         (CHAR8 *)".osrel",
+@@ -2028,16 +2028,28 @@ static VOID config_entry_add_linux(
+                                 os_build_id = stra_to_str(value);
+                                 continue;
+                         }
++
++                        if (strcmpa((const CHAR8*) "IMAGE_VERSION", key) == 0) {
++                                FreePool(os_image_version);
++                                os_image_version = stra_to_str(value);
++                                continue;
++                        }
+                 }
+ 
+-                if ((os_name_pretty || os_name) && os_id && (os_version || os_version_id || os_build_id)) {
++                if ((os_name_pretty || os_name) && os_id && (os_image_version || os_version || os_version_id || os_build_id)) {
+                         _cleanup_freepool_ CHAR16 *path = NULL;
+ 
+                         path = PoolPrint(L"\\EFI\\Linux\\%s", f->FileName);
+ 
+-                        entry = config_entry_add_loader(config, device, LOADER_LINUX, f->FileName, 'l',
+-                                                        os_name_pretty ?: os_name, path,
+-                                                        os_version ?: (os_version_id ? : os_build_id));
++                        entry = config_entry_add_loader(
++                                        config,
++                                        device,
++                                        LOADER_LINUX,
++                                        f->FileName,
++                                        /* key= */ 'l',
++                                        os_name_pretty ?: os_name,
++                                        path,
++                                        os_image_version ?: (os_version ?: (os_version_id ? : os_build_id)));
+ 
+                         FreePool(content);
+                         content = NULL;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0057-boot-sha256-sd-ify-and-move-to-src-fundamental.patch
+++ b/vendor/systemd-patches/0057-boot-sha256-sd-ify-and-move-to-src-fundamental.patch
@@ -1,0 +1,354 @@
+From f61b1367624b0367c0651c505aaca6b9d5ae37d4 Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@microsoft.com>
+Date: Thu, 7 Oct 2021 17:15:32 +0100
+Subject: [PATCH 57/73] boot/sha256: sd-ify and move to src/fundamental
+
+---
+ src/boot/efi/meson.build               |  2 -
+ src/boot/efi/sha256.h                  | 28 --------
+ src/fundamental/meson.build            |  2 +
+ src/{boot/efi => fundamental}/sha256.c | 94 ++++++++++++++------------
+ src/fundamental/sha256.h               | 32 +++++++++
+ 5 files changed, 83 insertions(+), 75 deletions(-)
+ delete mode 100644 src/boot/efi/sha256.h
+ rename src/{boot/efi => fundamental}/sha256.c (79%)
+ create mode 100644 src/fundamental/sha256.h
+
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index 04ec24792..5a9315406 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -12,7 +12,6 @@ efi_headers = files('''
+         missing_efi.h
+         pe.h
+         random-seed.h
+-        sha256.h
+         shim.h
+         splash.h
+         util.h
+@@ -34,7 +33,6 @@ systemd_boot_sources = '''
+         devicetree.c
+         drivers.c
+         random-seed.c
+-        sha256.c
+         shim.c
+ '''.split()
+ 
+diff --git a/src/boot/efi/sha256.h b/src/boot/efi/sha256.h
+deleted file mode 100644
+index 464be59c2..000000000
+--- a/src/boot/efi/sha256.h
++++ /dev/null
+@@ -1,28 +0,0 @@
+-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+-#pragma once
+-
+-#include <efi.h>
+-#include <efilib.h>
+-
+-struct sha256_ctx {
+-        UINT32 H[8];
+-
+-        union {
+-                UINT64 total64;
+-#define TOTAL64_low (1 - (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+-#define TOTAL64_high (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+-                UINT32 total[2];
+-        };
+-
+-        UINT32 buflen;
+-
+-        union {
+-                UINT8 buffer[128]; /* NB: always correctly aligned for UINT32.  */
+-                UINT32 buffer32[32];
+-                UINT64 buffer64[16];
+-        };
+-};
+-
+-void sha256_init_ctx(struct sha256_ctx *ctx);
+-void *sha256_finish_ctx(struct sha256_ctx *ctx, VOID *resbuf);
+-void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx);
+diff --git a/src/fundamental/meson.build b/src/fundamental/meson.build
+index 40b9ab8e2..b2659c955 100644
+--- a/src/fundamental/meson.build
++++ b/src/fundamental/meson.build
+@@ -6,10 +6,12 @@ fundamental_headers = files(
+         'efi-loader-features.h',
+         'macro-fundamental.h',
+         'string-util-fundamental.h',
++        'sha256.h',
+         'type.h')
+ 
+ sources = '''
+         string-util-fundamental.c
++        sha256.c
+ '''.split()
+ 
+ # for sd-boot
+diff --git a/src/boot/efi/sha256.c b/src/fundamental/sha256.c
+similarity index 79%
+rename from src/boot/efi/sha256.c
+rename to src/fundamental/sha256.c
+index d2e267eef..0577a2492 100644
+--- a/src/boot/efi/sha256.c
++++ b/src/fundamental/sha256.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-/* Stolen from glibc and converted to UEFI style. In glibc it comes with the following copyright blurb: */
++/* Stolen from glibc and converted to our style. In glibc it comes with the following copyright blurb: */
+ 
+ /* Functions to compute SHA256 message digest of files or memory blocks.
+    according to the definition of SHA256 in FIPS 180-2.
+@@ -23,6 +23,10 @@
+ 
+ /* Written by Ulrich Drepper <drepper@redhat.com>, 2007.  */
+ 
++#ifndef SD_BOOT
++#include <string.h>
++#endif
++
+ #include "macro-fundamental.h"
+ #include "sha256.h"
+ 
+@@ -45,12 +49,12 @@
+ 
+ /* This array contains the bytes used to pad the buffer to the next
+    64-byte boundary.  (FIPS 180-2:5.1.1)  */
+-static const UINT8 fillbuf[64] = {
++static const uint8_t fillbuf[64] = {
+         0x80, 0 /* , 0, 0, ...  */
+ };
+ 
+ /* Constants for SHA256 from FIPS 180-2:4.2.2.  */
+-static const UINT32 K[64] = {
++static const uint32_t K[64] = {
+         0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+         0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+         0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+@@ -69,7 +73,7 @@ static const UINT32 K[64] = {
+         0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+ };
+ 
+-static void sha256_process_block(const void *, UINTN, struct sha256_ctx *);
++static void sha256_process_block(const void *, size_t, struct sha256_ctx *);
+ 
+ /* Initialize structure containing state of computation.
+    (FIPS 180-2:5.3.2)  */
+@@ -96,8 +100,8 @@ void sha256_init_ctx(struct sha256_ctx *ctx) {
+    aligned for a 32 bits value.  */
+ void *sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf) {
+         /* Take yet unprocessed bytes into account.  */
+-        UINT32 bytes = ctx->buflen;
+-        UINTN pad;
++        uint32_t bytes = ctx->buflen;
++        size_t pad;
+ 
+         assert(ctx);
+         assert(resbuf);
+@@ -106,7 +110,7 @@ void *sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf) {
+         ctx->total64 += bytes;
+ 
+         pad = bytes >= 56 ? 64 + 56 - bytes : 56 - bytes;
+-        CopyMem(&ctx->buffer[bytes], fillbuf, pad);
++        memcpy(&ctx->buffer[bytes], fillbuf, pad);
+ 
+         /* Put the 64-bit file length in *bits* at the end of the buffer.  */
+         ctx->buffer32[(bytes + pad + 4) / 4] = SWAP(ctx->total[TOTAL64_low] << 3);
+@@ -117,13 +121,13 @@ void *sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf) {
+         sha256_process_block(ctx->buffer, bytes + pad + 8, ctx);
+ 
+         /* Put result from CTX in first 32 bytes following RESBUF.  */
+-        for (UINTN i = 0; i < 8; ++i)
+-                ((UINT32 *) resbuf)[i] = SWAP(ctx->H[i]);
++        for (size_t i = 0; i < 8; ++i)
++                ((uint32_t *) resbuf)[i] = SWAP(ctx->H[i]);
+ 
+         return resbuf;
+ }
+ 
+-void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx) {
++void sha256_process_bytes(const void *buffer, size_t len, struct sha256_ctx *ctx) {
+         assert(buffer);
+         assert(ctx);
+ 
+@@ -131,10 +135,10 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+            both inputs first.  */
+ 
+         if (ctx->buflen != 0) {
+-                UINTN left_over = ctx->buflen;
+-                UINTN add = 128 - left_over > len ? len : 128 - left_over;
++                size_t left_over = ctx->buflen;
++                size_t add = 128 - left_over > len ? len : 128 - left_over;
+ 
+-                CopyMem(&ctx->buffer[left_over], buffer, add);
++                memcpy(&ctx->buffer[left_over], buffer, add);
+                 ctx->buflen += add;
+ 
+                 if (ctx->buflen > 64) {
+@@ -142,7 +146,7 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+ 
+                         ctx->buflen &= 63;
+                         /* The regions in the following copy operation cannot overlap.  */
+-                        CopyMem(ctx->buffer, &ctx->buffer[(left_over + add) & ~63],
++                        memcpy(ctx->buffer, &ctx->buffer[(left_over + add) & ~63],
+                                 ctx->buflen);
+                 }
+ 
+@@ -159,13 +163,13 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+ 
+ /* To check alignment gcc has an appropriate operator. Other compilers don't.  */
+ # if __GNUC__ >= 2
+-#  define UNALIGNED_P(p) (((UINTN) p) % __alignof__(UINT32) != 0)
++#  define UNALIGNED_P(p) (((size_t) p) % __alignof__(uint32_t) != 0)
+ # else
+-#  define UNALIGNED_P(p) (((UINTN) p) % sizeof(UINT32) != 0)
++#  define UNALIGNED_P(p) (((size_t) p) % sizeof(uint32_t) != 0)
+ # endif
+                 if (UNALIGNED_P(buffer))
+                         while (len > 64) {
+-                                CopyMem(ctx->buffer, buffer, 64);
++                                memcpy(ctx->buffer, buffer, 64);
+                                 sha256_process_block(ctx->buffer, 64, ctx);
+                                 buffer = (const char *) buffer + 64;
+                                 len -= 64;
+@@ -181,14 +185,14 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+ 
+         /* Move remaining bytes into internal buffer.  */
+         if (len > 0) {
+-                UINTN left_over = ctx->buflen;
++                size_t left_over = ctx->buflen;
+ 
+-                CopyMem(&ctx->buffer[left_over], buffer, len);
++                memcpy(&ctx->buffer[left_over], buffer, len);
+                 left_over += len;
+                 if (left_over >= 64) {
+                         sha256_process_block(ctx->buffer, 64, ctx);
+                         left_over -= 64;
+-                        CopyMem(ctx->buffer, &ctx->buffer[64], left_over);
++                        memcpy(ctx->buffer, &ctx->buffer[64], left_over);
+                 }
+                 ctx->buflen = left_over;
+         }
+@@ -197,21 +201,21 @@ void sha256_process_bytes(const void *buffer, UINTN len, struct sha256_ctx *ctx)
+ 
+ /* Process LEN bytes of BUFFER, accumulating context into CTX.
+    It is assumed that LEN % 64 == 0.  */
+-static void sha256_process_block(const void *buffer, UINTN len, struct sha256_ctx *ctx) {
+-        const UINT32 *words = buffer;
+-        UINTN nwords = len / sizeof(UINT32);
++static void sha256_process_block(const void *buffer, size_t len, struct sha256_ctx *ctx) {
++        const uint32_t *words = buffer;
++        size_t nwords = len / sizeof(uint32_t);
+ 
+         assert(buffer);
+         assert(ctx);
+ 
+-        UINT32 a = ctx->H[0];
+-        UINT32 b = ctx->H[1];
+-        UINT32 c = ctx->H[2];
+-        UINT32 d = ctx->H[3];
+-        UINT32 e = ctx->H[4];
+-        UINT32 f = ctx->H[5];
+-        UINT32 g = ctx->H[6];
+-        UINT32 h = ctx->H[7];
++        uint32_t a = ctx->H[0];
++        uint32_t b = ctx->H[1];
++        uint32_t c = ctx->H[2];
++        uint32_t d = ctx->H[3];
++        uint32_t e = ctx->H[4];
++        uint32_t f = ctx->H[5];
++        uint32_t g = ctx->H[6];
++        uint32_t h = ctx->H[7];
+ 
+         /* First increment the byte count.  FIPS 180-2 specifies the possible
+            length of the file up to 2^64 bits.  Here we only compute the
+@@ -221,15 +225,15 @@ static void sha256_process_block(const void *buffer, UINTN len, struct sha256_ct
+         /* Process all bytes in the buffer with 64 bytes in each round of
+            the loop.  */
+         while (nwords > 0) {
+-                UINT32 W[64];
+-                UINT32 a_save = a;
+-                UINT32 b_save = b;
+-                UINT32 c_save = c;
+-                UINT32 d_save = d;
+-                UINT32 e_save = e;
+-                UINT32 f_save = f;
+-                UINT32 g_save = g;
+-                UINT32 h_save = h;
++                uint32_t W[64];
++                uint32_t a_save = a;
++                uint32_t b_save = b;
++                uint32_t c_save = c;
++                uint32_t d_save = d;
++                uint32_t e_save = e;
++                uint32_t f_save = f;
++                uint32_t g_save = g;
++                uint32_t h_save = h;
+ 
+                 /* Operators defined in FIPS 180-2:4.1.2.  */
+ #define Ch(x, y, z) ((x & y) ^ (~x & z))
+@@ -244,17 +248,17 @@ static void sha256_process_block(const void *buffer, UINTN len, struct sha256_ct
+ #define CYCLIC(w, s) ((w >> s) | (w << (32 - s)))
+ 
+                 /* Compute the message schedule according to FIPS 180-2:6.2.2 step 2.  */
+-                for (UINTN t = 0; t < 16; ++t) {
++                for (size_t t = 0; t < 16; ++t) {
+                         W[t] = SWAP (*words);
+                         ++words;
+                 }
+-                for (UINTN t = 16; t < 64; ++t)
++                for (size_t t = 16; t < 64; ++t)
+                         W[t] = R1 (W[t - 2]) + W[t - 7] + R0 (W[t - 15]) + W[t - 16];
+ 
+                 /* The actual computation according to FIPS 180-2:6.2.2 step 3.  */
+-                for (UINTN t = 0; t < 64; ++t) {
+-                        UINT32 T1 = h + S1 (e) + Ch (e, f, g) + K[t] + W[t];
+-                        UINT32 T2 = S0 (a) + Maj (a, b, c);
++                for (size_t t = 0; t < 64; ++t) {
++                        uint32_t T1 = h + S1 (e) + Ch (e, f, g) + K[t] + W[t];
++                        uint32_t T2 = S0 (a) + Maj (a, b, c);
+                         h = g;
+                         g = f;
+                         f = e;
+diff --git a/src/fundamental/sha256.h b/src/fundamental/sha256.h
+new file mode 100644
+index 000000000..9fc090b4e
+--- /dev/null
++++ b/src/fundamental/sha256.h
+@@ -0,0 +1,32 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++#pragma once
++
++#ifdef SD_BOOT
++#include <efi.h>
++#include <efilib.h>
++#endif
++
++#include "type.h"
++
++struct sha256_ctx {
++        uint32_t H[8];
++
++        union {
++                uint64_t total64;
++#define TOTAL64_low (1 - (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
++#define TOTAL64_high (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
++                uint32_t total[2];
++        };
++
++        uint32_t buflen;
++
++        union {
++                uint8_t  buffer[128]; /* NB: always correctly aligned for UINT32.  */
++                uint32_t buffer32[32];
++                uint64_t buffer64[16];
++        };
++};
++
++void sha256_init_ctx(struct sha256_ctx *ctx);
++void *sha256_finish_ctx(struct sha256_ctx *ctx, void *resbuf);
++void sha256_process_bytes(const void *buffer, size_t len, struct sha256_ctx *ctx);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0058-sd-boot-Allow-disabling-timeout.patch
+++ b/vendor/systemd-patches/0058-sd-boot-Allow-disabling-timeout.patch
@@ -1,0 +1,266 @@
+From 4c307fe43dee78a3f0cbd349cf259a76c5da89a6 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Thu, 16 Sep 2021 10:25:10 +0200
+Subject: [PATCH 58/73] sd-boot: Allow disabling timeout
+
+---
+ man/loader.conf.xml |   7 ++-
+ src/boot/efi/boot.c | 136 ++++++++++++++++++++++++++------------------
+ 2 files changed, 86 insertions(+), 57 deletions(-)
+
+diff --git a/man/loader.conf.xml b/man/loader.conf.xml
+index ffbd897a1..26e83dfca 100644
+--- a/man/loader.conf.xml
++++ b/man/loader.conf.xml
+@@ -106,9 +106,10 @@
+         will be stored as an EFI variable in that case, overriding this option.
+         </para>
+ 
+-        <para>If the timeout is disabled, the default entry will be booted
+-        immediately. The menu can be shown by pressing and holding a key before
+-        systemd-boot is launched.</para>
++        <para>If set to <literal>menu-hidden</literal> or <literal>0</literal> no menu
++        is shown and the default entry will be booted immediately. The menu can be shown
++        by pressing and holding a key before systemd-boot is launched. Setting this to
++        <literal>menu-force</literal> disables the timeout while always showing the menu.</para>
+         </listitem>
+       </varlistentry>
+ 
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index d82d679a4..e1d8c935c 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -60,9 +60,9 @@ typedef struct {
+         UINTN entry_count;
+         INTN idx_default;
+         INTN idx_default_efivar;
+-        UINTN timeout_sec;
+-        UINTN timeout_sec_config;
+-        INTN timeout_sec_efivar;
++        UINT32 timeout_sec; /* Actual timeout used (efi_main() override > efivar > config). */
++        UINT32 timeout_sec_config;
++        UINT32 timeout_sec_efivar;
+         CHAR16 *entry_default_pattern;
+         CHAR16 *entry_oneshot;
+         CHAR16 *options_edit;
+@@ -75,6 +75,18 @@ typedef struct {
+         RandomSeedMode random_seed_mode;
+ } Config;
+ 
++/* These values have been chosen so that the transitions the user sees could
++ * employ unsigned over-/underflow like this:
++ * efivar unset ↔ force menu ↔ no timeout/skip menu ↔ 1 s ↔ 2 s ↔ … */
++enum {
++        TIMEOUT_MIN         = 1,
++        TIMEOUT_MAX         = UINT32_MAX - 2U,
++        TIMEOUT_UNSET       = UINT32_MAX - 1U,
++        TIMEOUT_MENU_FORCE  = UINT32_MAX,
++        TIMEOUT_MENU_HIDDEN = 0,
++        TIMEOUT_TYPE_MAX    = UINT32_MAX,
++};
++
+ static VOID cursor_left(UINTN *cursor, UINTN *first) {
+         assert(cursor);
+         assert(first);
+@@ -366,6 +378,38 @@ static UINTN entry_lookup_key(Config *config, UINTN start, CHAR16 key) {
+         return -1;
+ }
+ 
++static CHAR16 *update_timeout_efivar(UINT32 *t, BOOLEAN inc) {
++        assert(t);
++
++        switch (*t) {
++        case TIMEOUT_MAX:
++                *t = inc ? TIMEOUT_MAX : (*t - 1);
++                break;
++        case TIMEOUT_UNSET:
++                *t = inc ? TIMEOUT_MENU_FORCE : TIMEOUT_UNSET;
++                break;
++        case TIMEOUT_MENU_FORCE:
++                *t = inc ? TIMEOUT_MENU_HIDDEN : TIMEOUT_UNSET;
++                break;
++        case TIMEOUT_MENU_HIDDEN:
++                *t = inc ? TIMEOUT_MIN : TIMEOUT_MENU_FORCE;
++                break;
++        default:
++                *t += inc ? 1 : -1;
++        }
++
++        switch (*t) {
++        case TIMEOUT_UNSET:
++                return StrDuplicate(L"Menu timeout defined by configuration file.");
++        case TIMEOUT_MENU_FORCE:
++                return StrDuplicate(L"Timeout disabled, menu will always be shown.");
++        case TIMEOUT_MENU_HIDDEN:
++                return StrDuplicate(L"Menu disabled. Hold down key at bootup to show menu.");
++        default:
++                return PoolPrint(L"Menu timeout set to %u s.", *t);
++        }
++}
++
+ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         UINT64 key;
+         UINTN timeout;
+@@ -400,10 +444,11 @@ static VOID print_status(Config *config, CHAR16 *loaded_image_path) {
+         Print(L"\n--- press key ---\n\n");
+         console_key_read(&key, 0);
+ 
+-        Print(L"timeout:                %u\n", config->timeout_sec);
+-        if (config->timeout_sec_efivar >= 0)
+-                Print(L"timeout (EFI var):      %d\n", config->timeout_sec_efivar);
+-        Print(L"timeout (config):       %u\n", config->timeout_sec_config);
++        Print(L"timeout:                %u s\n", config->timeout_sec);
++        if (config->timeout_sec_efivar != TIMEOUT_UNSET)
++                Print(L"timeout (EFI var):      %u s\n", config->timeout_sec_efivar);
++        if (config->timeout_sec_config != TIMEOUT_UNSET)
++                Print(L"timeout (config):       %u s\n", config->timeout_sec_config);
+         if (config->entry_default_pattern)
+                 Print(L"default pattern:        '%s'\n", config->entry_default_pattern);
+         Print(L"editor:                 %s\n", yes_no(config->editor));
+@@ -519,7 +564,8 @@ static BOOLEAN menu_run(
+         UINTN x_max, y_max;
+         CHAR16 **lines = NULL;
+         _cleanup_freepool_ CHAR16 *clearline = NULL, *status = NULL;
+-        UINTN timeout_remain = config->timeout_sec;
++        UINT32 timeout_efivar_saved = config->timeout_sec_efivar;
++        UINT32 timeout_remain = config->timeout_sec == TIMEOUT_MENU_FORCE ? 0 : config->timeout_sec;
+         INT16 idx;
+         BOOLEAN exit = FALSE, run = TRUE;
+         INT64 console_mode_initial = ST->ConOut->Mode->Mode, console_mode_efivar_saved = config->console_mode_efivar;
+@@ -640,7 +686,7 @@ static BOOLEAN menu_run(
+ 
+                 if (timeout_remain > 0) {
+                         FreePool(status);
+-                        status = PoolPrint(L"Boot in %d s.", timeout_remain);
++                        status = PoolPrint(L"Boot in %u s.", timeout_remain);
+                 }
+ 
+                 /* print status at last line of screen */
+@@ -768,44 +814,12 @@ static BOOLEAN menu_run(
+ 
+                 case KEYPRESS(0, 0, '-'):
+                 case KEYPRESS(0, 0, 'T'):
+-                        if (config->timeout_sec_efivar > 0) {
+-                                config->timeout_sec_efivar--;
+-                                efivar_set_uint_string(
+-                                        LOADER_GUID,
+-                                        L"LoaderConfigTimeout",
+-                                        config->timeout_sec_efivar,
+-                                        EFI_VARIABLE_NON_VOLATILE);
+-                                if (config->timeout_sec_efivar > 0)
+-                                        status = PoolPrint(L"Menu timeout set to %d s.", config->timeout_sec_efivar);
+-                                else
+-                                        status = StrDuplicate(L"Menu disabled. Hold down key at bootup to show menu.");
+-                        } else if (config->timeout_sec_efivar <= 0){
+-                                config->timeout_sec_efivar = -1;
+-                                efivar_set(
+-                                        LOADER_GUID, L"LoaderConfigTimeout", NULL, EFI_VARIABLE_NON_VOLATILE);
+-                                if (config->timeout_sec_config > 0)
+-                                        status = PoolPrint(L"Menu timeout of %d s is defined by configuration file.",
+-                                                           config->timeout_sec_config);
+-                                else
+-                                        status = StrDuplicate(L"Menu disabled. Hold down key at bootup to show menu.");
+-                        }
++                        status = update_timeout_efivar(&config->timeout_sec_efivar, FALSE);
+                         break;
+ 
+                 case KEYPRESS(0, 0, '+'):
+                 case KEYPRESS(0, 0, 't'):
+-                        if (config->timeout_sec_efivar == -1 && config->timeout_sec_config == 0)
+-                                config->timeout_sec_efivar++;
+-                        config->timeout_sec_efivar++;
+-                        efivar_set_uint_string(
+-                                LOADER_GUID,
+-                                L"LoaderConfigTimeout",
+-                                config->timeout_sec_efivar,
+-                                EFI_VARIABLE_NON_VOLATILE);
+-                        if (config->timeout_sec_efivar > 0)
+-                                status = PoolPrint(L"Menu timeout set to %d s.",
+-                                                   config->timeout_sec_efivar);
+-                        else
+-                                status = StrDuplicate(L"Menu disabled. Hold down key at bootup to show menu.");
++                        status = update_timeout_efivar(&config->timeout_sec_efivar, TRUE);
+                         break;
+ 
+                 case KEYPRESS(0, 0, 'e'):
+@@ -888,9 +902,8 @@ static BOOLEAN menu_run(
+ 
+         *chosen_entry = config->entries[idx_highlight];
+ 
+-        /* The user is likely to cycle through several modes before
+-         * deciding to keep one. Therefore, we update the EFI var after
+-         * we left the menu to reduce nvram writes. */
++        /* Update EFI vars after we left the menu to reduce NVRAM writes. */
++
+         if (console_mode_efivar_saved != config->console_mode_efivar) {
+                 if (config->console_mode_efivar == CONSOLE_MODE_KEEP)
+                         efivar_set(LOADER_GUID, L"LoaderConfigConsoleMode", NULL, EFI_VARIABLE_NON_VOLATILE);
+@@ -899,6 +912,14 @@ static BOOLEAN menu_run(
+                                                config->console_mode_efivar, EFI_VARIABLE_NON_VOLATILE);
+         }
+ 
++        if (timeout_efivar_saved != config->timeout_sec_efivar) {
++                if (config->timeout_sec_efivar == TIMEOUT_UNSET)
++                        efivar_set(LOADER_GUID, L"LoaderConfigTimeout", NULL, EFI_VARIABLE_NON_VOLATILE);
++                else
++                        efivar_set_uint_string(LOADER_GUID, L"LoaderConfigTimeout",
++                                               config->timeout_sec_efivar, EFI_VARIABLE_NON_VOLATILE);
++        }
++
+         for (UINTN i = 0; i < config->entry_count; i++)
+                 FreePool(lines[i]);
+         FreePool(lines);
+@@ -1023,10 +1044,16 @@ static VOID config_defaults_load_from_file(Config *config, CHAR8 *content) {
+ 
+         while ((line = line_get_key_value(content, (CHAR8 *)" \t", &pos, &key, &value))) {
+                 if (strcmpa((CHAR8 *)"timeout", key) == 0) {
+-                        _cleanup_freepool_ CHAR16 *s = NULL;
++                        if (strcmpa((CHAR8*) "menu-force", value) == 0)
++                                config->timeout_sec_config = TIMEOUT_MENU_FORCE;
++                        else if (strcmpa((CHAR8*) "menu-hidden", value) == 0)
++                                config->timeout_sec_config = TIMEOUT_MENU_HIDDEN;
++                        else {
++                                _cleanup_freepool_ CHAR16 *s = NULL;
+ 
+-                        s = stra_to_str(value);
+-                        config->timeout_sec_config = Atoi(s);
++                                s = stra_to_str(value);
++                                config->timeout_sec_config = MIN(Atoi(s), TIMEOUT_TYPE_MAX);
++                        }
+                         config->timeout_sec = config->timeout_sec_config;
+                         continue;
+                 }
+@@ -1439,6 +1466,8 @@ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+                 .idx_default_efivar = -1,
+                 .console_mode = CONSOLE_MODE_KEEP,
+                 .console_mode_efivar = CONSOLE_MODE_KEEP,
++                .timeout_sec_config = TIMEOUT_UNSET,
++                .timeout_sec_efivar = TIMEOUT_UNSET,
+         };
+ 
+         err = file_read(root_dir, L"\\loader\\loader.conf", 0, 0, &content, NULL);
+@@ -1447,17 +1476,16 @@ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+ 
+         err = efivar_get_uint_string(LOADER_GUID, L"LoaderConfigTimeout", &value);
+         if (!EFI_ERROR(err)) {
+-                config->timeout_sec_efivar = value > INTN_MAX ? INTN_MAX : value;
+-                config->timeout_sec = value;
+-        } else
+-                config->timeout_sec_efivar = -1;
++                config->timeout_sec_efivar = MIN(value, TIMEOUT_TYPE_MAX);
++                config->timeout_sec = config->timeout_sec_efivar;
++        }
+ 
+         err = efivar_get_uint_string(LOADER_GUID, L"LoaderConfigTimeoutOneShot", &value);
+         if (!EFI_ERROR(err)) {
+                 /* Unset variable now, after all it's "one shot". */
+                 (void) efivar_set(LOADER_GUID, L"LoaderConfigTimeoutOneShot", NULL, EFI_VARIABLE_NON_VOLATILE);
+ 
+-                config->timeout_sec = value;
++                config->timeout_sec = MIN(value, TIMEOUT_TYPE_MAX);
+                 config->force_menu = TRUE; /* force the menu when this is set */
+         }
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0059-stub-also-move-magic-string-in-stub-into-.sdmagic-PE.patch
+++ b/vendor/systemd-patches/0059-stub-also-move-magic-string-in-stub-into-.sdmagic-PE.patch
@@ -1,0 +1,45 @@
+From b161db729598d8813b168d165f3961b3bfc09b94 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 11 Oct 2021 13:29:57 +0200
+Subject: [PATCH 59/73] stub: also move magic string in stub into .sdmagic PE
+ section
+
+We already did that for sd-boot, hence do it for sd-stub the same way.
+
+Also, move the __attribute__ stuff to the beginning of the statement,
+rather than the middle. Mostly just because we usually put it first for
+implementations for identifiers (for prototypes we put it last).
+---
+ src/boot/efi/boot.c | 2 +-
+ src/boot/efi/stub.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index e1d8c935c..30e9516dd 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -25,7 +25,7 @@
+ #define TEXT_ATTR_SWAP(c) EFI_TEXT_ATTR(((c) & 0b11110000) >> 4, (c) & 0b1111)
+ 
+ /* magic string to find in the binary image */
+-static const char _used_ _section_(".sdmagic") magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
++_used_ _section_(".sdmagic") static const char magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
+ 
+ enum loader_type {
+         LOADER_UNDEFINED,
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 555d08fb8..636baa442 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -14,7 +14,7 @@
+ #include "util.h"
+ 
+ /* magic string to find in the binary image */
+-static const char __attribute__((used)) magic[] = "#### LoaderInfo: systemd-stub " GIT_VERSION " ####";
++_used_ _section_(".sdmagic") static const char magic[] = "#### LoaderInfo: systemd-stub " GIT_VERSION " ####";
+ 
+ static EFI_STATUS combine_initrd(
+                 EFI_PHYSICAL_ADDRESS initrd_base, UINTN initrd_size,
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0060-sd-stub-Provide-initrd-with-LINUX_EFI_INITRD_MEDIA_G.patch
+++ b/vendor/systemd-patches/0060-sd-stub-Provide-initrd-with-LINUX_EFI_INITRD_MEDIA_G.patch
@@ -1,0 +1,332 @@
+From 3d35f93d24e27fd5ac7d3dd1725aea3d02bc43d1 Mon Sep 17 00:00:00 2001
+From: Max Resch <resch.max@gmail.com>
+Date: Thu, 30 Sep 2021 18:43:52 +0200
+Subject: [PATCH 60/73] sd-stub: Provide initrd with
+ LINUX_EFI_INITRD_MEDIA_GUID
+
+Register a LINUX_EFI_INITRD_MEDIA_GUID DevicePath with a LoadFile2Protocol interface and serve the initrd to a supported Linux kernel (Version 5.8+)
+Leave the x86 code for older kernels in place until supported kernels become more mainstream
+---
+ src/boot/efi/initrd.c      | 147 +++++++++++++++++++++++++++++++++++++
+ src/boot/efi/initrd.h      |  11 +++
+ src/boot/efi/linux.c       |  37 +++++++---
+ src/boot/efi/linux.h       |   9 ++-
+ src/boot/efi/meson.build   |   1 +
+ src/boot/efi/missing_efi.h |   9 +++
+ src/boot/efi/stub.c        |   4 +-
+ 7 files changed, 203 insertions(+), 15 deletions(-)
+ create mode 100644 src/boot/efi/initrd.c
+ create mode 100644 src/boot/efi/initrd.h
+
+diff --git a/src/boot/efi/initrd.c b/src/boot/efi/initrd.c
+new file mode 100644
+index 000000000..055670f23
+--- /dev/null
++++ b/src/boot/efi/initrd.c
+@@ -0,0 +1,147 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include <efi.h>
++#include <efilib.h>
++
++#include "initrd.h"
++#include "macro-fundamental.h"
++#include "missing_efi.h"
++
++/* extend LoadFileProtocol */
++struct initrd_loader {
++        EFI_LOAD_FILE_PROTOCOL load_file;
++        const VOID *address;
++        UINTN length;
++};
++
++/* static structure for LINUX_INITRD_MEDIA device path
++   see https://github.com/torvalds/linux/blob/v5.13/drivers/firmware/efi/libstub/efi-stub-helper.c
++ */
++static const struct {
++        VENDOR_DEVICE_PATH vendor;
++        EFI_DEVICE_PATH end;
++} _packed_ efi_initrd_device_path = {
++        .vendor = {
++                .Header = {
++                        .Type = MEDIA_DEVICE_PATH,
++                        .SubType = MEDIA_VENDOR_DP,
++                        .Length = { sizeof(efi_initrd_device_path.vendor), 0 }
++                },
++                .Guid = LINUX_INITRD_MEDIA_GUID
++        },
++        .end = {
++                .Type = END_DEVICE_PATH_TYPE,
++                .SubType = END_ENTIRE_DEVICE_PATH_SUBTYPE,
++                .Length = { sizeof(efi_initrd_device_path.end), 0 }
++        }
++};
++
++EFIAPI EFI_STATUS initrd_load_file(
++                EFI_LOAD_FILE_PROTOCOL *this,
++                EFI_DEVICE_PATH *file_path,
++                BOOLEAN boot_policy,
++                UINTN *buffer_size,
++                VOID *buffer) {
++
++        struct initrd_loader *loader;
++
++        if (!this || !buffer_size || !file_path)
++                return EFI_INVALID_PARAMETER;
++        if (boot_policy)
++                return EFI_UNSUPPORTED;
++
++        loader = (struct initrd_loader *) this;
++
++        if (loader->length == 0 || !loader->address)
++                return EFI_NOT_FOUND;
++
++        if (!buffer || *buffer_size < loader->length) {
++                *buffer_size = loader->length;
++                return EFI_BUFFER_TOO_SMALL;
++        }
++
++        CopyMem(buffer, loader->address, loader->length);
++        *buffer_size = loader->length;
++        return EFI_SUCCESS;
++}
++
++EFI_STATUS initrd_register(
++                const VOID *initrd_address,
++                UINTN initrd_length,
++                EFI_HANDLE *ret_initrd_handle) {
++
++        EFI_STATUS err;
++        EFI_DEVICE_PATH *dp = (EFI_DEVICE_PATH *) &efi_initrd_device_path;
++        EFI_HANDLE handle;
++        struct initrd_loader *loader;
++
++        assert(ret_initrd_handle);
++
++        if (!initrd_address || initrd_length == 0)
++                return EFI_SUCCESS;
++
++        /* check if a LINUX_INITRD_MEDIA_GUID DevicePath is already registed.
++           LocateDevicePath checks for the "closest DevicePath" and returns its handle,
++           where as InstallMultipleProtocolInterfaces only maches identical DevicePaths.
++         */
++        err = uefi_call_wrapper(BS->LocateDevicePath, 3, &EfiLoadFile2Protocol, &dp, &handle);
++        if (err != EFI_NOT_FOUND) /* InitrdMedia is already registered */
++                return EFI_ALREADY_STARTED;
++
++        loader = AllocatePool(sizeof(struct initrd_loader));
++        if (!loader)
++                return EFI_OUT_OF_RESOURCES;
++
++        *loader = (struct initrd_loader) {
++                .load_file.LoadFile = initrd_load_file,
++                .address = initrd_address,
++                .length = initrd_length
++        };
++
++        /* create a new handle and register the LoadFile2 protocol with the InitrdMediaPath on it */
++        err = uefi_call_wrapper(
++                        BS->InstallMultipleProtocolInterfaces, 8,
++                        ret_initrd_handle,
++                        &DevicePathProtocol, &efi_initrd_device_path,
++                        &EfiLoadFile2Protocol, loader,
++                        NULL);
++        if (EFI_ERROR(err))
++                FreePool(loader);
++
++        return err;
++}
++
++EFI_STATUS initrd_unregister(EFI_HANDLE initrd_handle) {
++        EFI_STATUS err;
++        struct initrd_loader *loader;
++
++        if (!initrd_handle)
++                return EFI_SUCCESS;
++
++        /* get the LoadFile2 protocol that we allocated earlier */
++        err = uefi_call_wrapper(
++                        BS->OpenProtocol, 6,
++                        initrd_handle, &EfiLoadFile2Protocol, (VOID **) &loader,
++                        NULL, NULL, EFI_OPEN_PROTOCOL_GET_PROTOCOL);
++        if (EFI_ERROR(err))
++                return err;
++
++        /* close the handle */
++        (void) uefi_call_wrapper(
++                        BS->CloseProtocol, 4,
++                        initrd_handle, &EfiLoadFile2Protocol, NULL, NULL);
++
++        /* uninstall all protocols thus destroying the handle */
++        err = uefi_call_wrapper(
++                        BS->UninstallMultipleProtocolInterfaces, 6,
++                        initrd_handle,
++                        &DevicePathProtocol, &efi_initrd_device_path,
++                        &EfiLoadFile2Protocol, loader,
++                        NULL);
++        if (EFI_ERROR(err))
++                return err;
++
++        initrd_handle = NULL;
++        FreePool(loader);
++        return EFI_SUCCESS;
++}
+diff --git a/src/boot/efi/initrd.h b/src/boot/efi/initrd.h
+new file mode 100644
+index 000000000..bb3a33478
+--- /dev/null
++++ b/src/boot/efi/initrd.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++#pragma once
++
++#include <efi.h>
++
++EFI_STATUS initrd_register(
++                const VOID *initrd_address,
++                UINTN initrd_length,
++                EFI_HANDLE *ret_initrd_handle);
++
++EFI_STATUS initrd_unregister(EFI_HANDLE initrd_handle);
+diff --git a/src/boot/efi/linux.c b/src/boot/efi/linux.c
+index 5232a3ba4..2c27ed503 100644
+--- a/src/boot/efi/linux.c
++++ b/src/boot/efi/linux.c
+@@ -4,6 +4,7 @@
+ #include <efilib.h>
+ 
+ #include "linux.h"
++#include "initrd.h"
+ #include "util.h"
+ 
+ #ifdef __i386__
+@@ -28,21 +29,25 @@ static VOID linux_efi_handover(EFI_HANDLE image, struct boot_params *params) {
+         handover(image, ST, params);
+ }
+ 
+-EFI_STATUS linux_exec(EFI_HANDLE image,
+-                      CHAR8 *cmdline, UINTN cmdline_len,
+-                      UINTN linux_addr,
+-                      UINTN initrd_addr, UINTN initrd_size) {
++EFI_STATUS linux_exec(
++                EFI_HANDLE image,
++                const CHAR8 *cmdline, UINTN cmdline_len,
++                const VOID *linux_buffer,
++                const VOID *initrd_buffer, UINTN initrd_length) {
+ 
+         const struct boot_params *image_params;
+         struct boot_params *boot_params;
++        EFI_HANDLE initrd_handle = NULL;
+         EFI_PHYSICAL_ADDRESS addr;
+         UINT8 setup_sectors;
+         EFI_STATUS err;
+ 
+         assert(image);
+-        assert(cmdline);
++        assert(cmdline || cmdline_len == 0);
++        assert(linux_buffer);
++        assert(initrd_buffer || initrd_length == 0);
+ 
+-        image_params = (const struct boot_params *) linux_addr;
++        image_params = (const struct boot_params *) linux_buffer;
+ 
+         if (image_params->hdr.boot_flag != 0xAA55 ||
+             image_params->hdr.header != SETUP_MAGIC ||
+@@ -65,7 +70,7 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
+         boot_params->hdr = image_params->hdr;
+         boot_params->hdr.type_of_loader = 0xff;
+         setup_sectors = image_params->hdr.setup_sects > 0 ? image_params->hdr.setup_sects : 4;
+-        boot_params->hdr.code32_start = (UINT32)linux_addr + (setup_sectors + 1) * 512;
++        boot_params->hdr.code32_start = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(linux_buffer) + (setup_sectors + 1) * 512;
+ 
+         if (cmdline) {
+                 addr = 0xA0000;
+@@ -84,9 +89,21 @@ EFI_STATUS linux_exec(EFI_HANDLE image,
+                 boot_params->hdr.cmd_line_ptr = (UINT32) addr;
+         }
+ 
+-        boot_params->hdr.ramdisk_image = (UINT32) initrd_addr;
+-        boot_params->hdr.ramdisk_size = (UINT32) initrd_size;
+-
++        /* Providing the initrd via LINUX_INITRD_MEDIA_GUID is only supported by Linux 5.8+ (5.7+ on ARM64).
++           Until supported kernels become more established, we continue to set ramdisk in the handover struct.
++           This value is overridden by kernels that support LINUX_INITRD_MEDIA_GUID.
++           If you need to know which protocol was used by the kernel, pass "efi=debug" to the kernel,
++           this will print a line when InitrdMediaGuid was successfully used to load the initrd.
++         */
++        boot_params->hdr.ramdisk_image = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(initrd_buffer);
++        boot_params->hdr.ramdisk_size = (UINT32) initrd_length;
++
++        /* register LINUX_INITRD_MEDIA_GUID */
++        err = initrd_register(initrd_buffer, initrd_length, &initrd_handle);
++        if (EFI_ERROR(err))
++                return err;
+         linux_efi_handover(image, boot_params);
++        (void) initrd_unregister(initrd_handle);
++        initrd_handle = NULL;
+         return EFI_LOAD_ERROR;
+ }
+diff --git a/src/boot/efi/linux.h b/src/boot/efi/linux.h
+index 773c260b7..01049d336 100644
+--- a/src/boot/efi/linux.h
++++ b/src/boot/efi/linux.h
+@@ -84,7 +84,8 @@ struct boot_params {
+         UINT8  _pad9[276];
+ } _packed_;
+ 
+-EFI_STATUS linux_exec(EFI_HANDLE image,
+-                      CHAR8 *cmdline, UINTN cmdline_size,
+-                      UINTN linux_addr,
+-                      UINTN initrd_addr, UINTN initrd_size);
++EFI_STATUS linux_exec(
++                EFI_HANDLE image,
++                const CHAR8 *cmdline, UINTN cmdline_len,
++                const VOID *linux_buffer,
++                const VOID *initrd_buffer, UINTN initrd_length);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index 5a9315406..567b22684 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -38,6 +38,7 @@ systemd_boot_sources = '''
+ 
+ stub_sources = '''
+         linux.c
++        initrd.c
+         splash.c
+         stub.c
+         cpio.c
+diff --git a/src/boot/efi/missing_efi.h b/src/boot/efi/missing_efi.h
+index badf0017a..fad75d82b 100644
+--- a/src/boot/efi/missing_efi.h
++++ b/src/boot/efi/missing_efi.h
+@@ -331,3 +331,12 @@ typedef struct tdEFI_TCG2_PROTOCOL {
+ } EFI_TCG2;
+ 
+ #endif
++
++#ifndef EFI_LOAD_FILE2_PROTOCOL_GUID
++#define EFI_LOAD_FILE2_PROTOCOL_GUID \
++        {0x4006c0c1, 0xfcb3, 0x403e, {0x99, 0x6d, 0x4a, 0x6c, 0x87, 0x24, 0xe0, 0x6d} }
++#define EfiLoadFile2Protocol ((EFI_GUID)EFI_LOAD_FILE2_PROTOCOL_GUID)
++#endif
++
++#define LINUX_INITRD_MEDIA_GUID \
++        {0x5568e427, 0x68fc, 0x4f3d, {0xac, 0x74, 0xca, 0x55, 0x52, 0x31, 0xcc, 0x68} }
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 636baa442..09171558c 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -249,7 +249,9 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 }
+         }
+ 
+-        err = linux_exec(image, cmdline, cmdline_len, linux_base, initrd_base, initrd_size);
++        err = linux_exec(image, cmdline, cmdline_len,
++                         PHYSICAL_ADDRESS_TO_POINTER(linux_base),
++                         PHYSICAL_ADDRESS_TO_POINTER(initrd_base), initrd_size);
+         graphics_mode(FALSE);
+         return log_error_status_stall(err, L"Execution of embedded linux image failed: %r", err);
+ }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0061-sd-boot-Invert-if-in-disk_get_part_uuid.patch
+++ b/vendor/systemd-patches/0061-sd-boot-Invert-if-in-disk_get_part_uuid.patch
@@ -1,0 +1,64 @@
+From 486d459823395d396b09488e59a495476743cd1f Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Fri, 24 Sep 2021 10:24:38 +0200
+Subject: [PATCH 61/73] sd-boot: Invert if in disk_get_part_uuid()
+
+---
+ src/boot/efi/disk.c | 36 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/src/boot/efi/disk.c b/src/boot/efi/disk.c
+index 196dc52be..6d3c8285a 100644
+--- a/src/boot/efi/disk.c
++++ b/src/boot/efi/disk.c
+@@ -8,29 +8,29 @@
+ 
+ EFI_STATUS disk_get_part_uuid(EFI_HANDLE *handle, CHAR16 uuid[static 37]) {
+         EFI_DEVICE_PATH *device_path;
++        _cleanup_freepool_ EFI_DEVICE_PATH *paths = NULL;
+ 
+         assert(handle);
+ 
+         /* export the device path this image is started from */
+         device_path = DevicePathFromHandle(handle);
+-        if (device_path) {
+-                _cleanup_freepool_ EFI_DEVICE_PATH *paths = NULL;
+-
+-                paths = UnpackDevicePath(device_path);
+-                for (EFI_DEVICE_PATH *path = paths; !IsDevicePathEnd(path); path = NextDevicePathNode(path)) {
+-                        HARDDRIVE_DEVICE_PATH *drive;
+-
+-                        if (DevicePathType(path) != MEDIA_DEVICE_PATH)
+-                                continue;
+-                        if (DevicePathSubType(path) != MEDIA_HARDDRIVE_DP)
+-                                continue;
+-                        drive = (HARDDRIVE_DEVICE_PATH *)path;
+-                        if (drive->SignatureType != SIGNATURE_TYPE_GUID)
+-                                continue;
+-
+-                        GuidToString(uuid, (EFI_GUID *)&drive->Signature);
+-                        return EFI_SUCCESS;
+-                }
++        if (!device_path)
++                return EFI_NOT_FOUND;
++
++        paths = UnpackDevicePath(device_path);
++        for (EFI_DEVICE_PATH *path = paths; !IsDevicePathEnd(path); path = NextDevicePathNode(path)) {
++                HARDDRIVE_DEVICE_PATH *drive;
++
++                if (DevicePathType(path) != MEDIA_DEVICE_PATH)
++                        continue;
++                if (DevicePathSubType(path) != MEDIA_HARDDRIVE_DP)
++                        continue;
++                drive = (HARDDRIVE_DEVICE_PATH *)path;
++                if (drive->SignatureType != SIGNATURE_TYPE_GUID)
++                        continue;
++
++                GuidToString(uuid, (EFI_GUID *)&drive->Signature);
++                return EFI_SUCCESS;
+         }
+ 
+         return EFI_NOT_FOUND;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0062-sd-boot-Move-xbootldr-code-into-its-own-file.patch
+++ b/vendor/systemd-patches/0062-sd-boot-Move-xbootldr-code-into-its-own-file.patch
@@ -1,0 +1,493 @@
+From f4a1780c17d8b5ec300c806a2e36db920ac6fda0 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Mon, 27 Sep 2021 10:02:50 +0200
+Subject: [PATCH 62/73] sd-boot: Move xbootldr code into its own file
+
+---
+ src/boot/efi/boot.c      | 196 +-----------------------------------
+ src/boot/efi/meson.build |   2 +
+ src/boot/efi/xbootldr.c  | 212 +++++++++++++++++++++++++++++++++++++++
+ src/boot/efi/xbootldr.h  |   8 ++
+ 4 files changed, 226 insertions(+), 192 deletions(-)
+ create mode 100644 src/boot/efi/xbootldr.c
+ create mode 100644 src/boot/efi/xbootldr.h
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 30e9516dd..e073217f3 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -17,6 +17,7 @@
+ #include "secure-boot.h"
+ #include "shim.h"
+ #include "util.h"
++#include "xbootldr.h"
+ 
+ #ifndef EFI_OS_INDICATIONS_BOOT_TO_FW_UI
+ #define EFI_OS_INDICATIONS_BOOT_TO_FW_UI 0x0000000000000001ULL
+@@ -2098,208 +2099,19 @@ static VOID config_entry_add_linux(
+         }
+ }
+ 
+-#define XBOOTLDR_GUID \
+-        &(const EFI_GUID) { 0xbc13c2ff, 0x59e6, 0x4262, { 0xa3, 0x52, 0xb2, 0x75, 0xfd, 0x6f, 0x71, 0x72 } }
+-
+-static EFI_DEVICE_PATH *path_parent(EFI_DEVICE_PATH *path, EFI_DEVICE_PATH *node) {
+-        EFI_DEVICE_PATH *parent;
+-        UINTN len;
+-
+-        assert(path);
+-        assert(node);
+-
+-        len = (UINT8*) NextDevicePathNode(node) - (UINT8*) path;
+-        parent = (EFI_DEVICE_PATH*) AllocatePool(len + sizeof(EFI_DEVICE_PATH));
+-        CopyMem(parent, path, len);
+-        CopyMem((UINT8*) parent + len, EndDevicePath, sizeof(EFI_DEVICE_PATH));
+-
+-        return parent;
+-}
+-
+ static VOID config_load_xbootldr(
+                 Config *config,
+                 EFI_HANDLE *device) {
+ 
+-        EFI_DEVICE_PATH *partition_path, *disk_path, *copy;
+-        UINT32 found_partition_number = UINT32_MAX;
+-        UINT64 found_partition_start = UINT64_MAX;
+-        UINT64 found_partition_size = UINT64_MAX;
+-        UINT8 found_partition_signature[16] = {};
+         EFI_HANDLE new_device;
+         EFI_FILE *root_dir;
+-        EFI_STATUS r;
++        EFI_STATUS err;
+ 
+         assert(config);
+         assert(device);
+ 
+-        partition_path = DevicePathFromHandle(device);
+-        if (!partition_path)
+-                return;
+-
+-        for (EFI_DEVICE_PATH *node = partition_path; !IsDevicePathEnd(node); node = NextDevicePathNode(node)) {
+-                EFI_HANDLE disk_handle;
+-                EFI_BLOCK_IO *block_io;
+-                EFI_DEVICE_PATH *p;
+-
+-                /* First, Let's look for the SCSI/SATA/USB/… device path node, i.e. one above the media
+-                 * devices */
+-                if (DevicePathType(node) != MESSAGING_DEVICE_PATH)
+-                        continue;
+-
+-                /* Determine the device path one level up */
+-                disk_path = path_parent(partition_path, node);
+-                p = disk_path;
+-                r = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &p, &disk_handle);
+-                if (EFI_ERROR(r))
+-                        continue;
+-
+-                r = uefi_call_wrapper(BS->HandleProtocol, 3, disk_handle, &BlockIoProtocol, (VOID **)&block_io);
+-                if (EFI_ERROR(r))
+-                        continue;
+-
+-                /* Filter out some block devices early. (We only care about block devices that aren't
+-                 * partitions themselves — we look for GPT partition tables to parse after all —, and only
+-                 * those which contain a medium and have at least 2 blocks.) */
+-                if (block_io->Media->LogicalPartition ||
+-                    !block_io->Media->MediaPresent ||
+-                    block_io->Media->LastBlock <= 1)
+-                        continue;
+-
+-                /* Try both copies of the GPT header, in case one is corrupted */
+-                for (UINTN nr = 0; nr < 2; nr++) {
+-                        _cleanup_freepool_ EFI_PARTITION_ENTRY* entries = NULL;
+-                        union {
+-                                EFI_PARTITION_TABLE_HEADER gpt_header;
+-                                uint8_t space[((sizeof(EFI_PARTITION_TABLE_HEADER) + 511) / 512) * 512];
+-                        } gpt_header_buffer;
+-                        EFI_PARTITION_TABLE_HEADER *h = &gpt_header_buffer.gpt_header;
+-                        UINT64 where;
+-                        UINTN sz;
+-                        UINT32 crc32, crc32_saved;
+-
+-                        if (nr == 0)
+-                                /* Read the first copy at LBA 1 */
+-                                where = 1;
+-                        else
+-                                /* Read the second copy at the very last LBA of this block device */
+-                                where = block_io->Media->LastBlock;
+-
+-                        /* Read the GPT header */
+-                        r = uefi_call_wrapper(block_io->ReadBlocks, 5,
+-                                              block_io,
+-                                              block_io->Media->MediaId,
+-                                              where,
+-                                              sizeof(gpt_header_buffer), &gpt_header_buffer);
+-                        if (EFI_ERROR(r))
+-                                continue;
+-
+-                        /* Some superficial validation of the GPT header */
+-                        if(CompareMem(&h->Header.Signature, "EFI PART", sizeof(h->Header.Signature) != 0))
+-                                continue;
+-
+-                        if (h->Header.HeaderSize < 92 ||
+-                            h->Header.HeaderSize > 512)
+-                                continue;
+-
+-                        if (h->Header.Revision != 0x00010000U)
+-                                continue;
+-
+-                        /* Calculate CRC check */
+-                        crc32_saved = h->Header.CRC32;
+-                        h->Header.CRC32 = 0;
+-                        r = BS->CalculateCrc32(&gpt_header_buffer, h->Header.HeaderSize, &crc32);
+-                        h->Header.CRC32 = crc32_saved;
+-                        if (EFI_ERROR(r) || crc32 != crc32_saved)
+-                                continue;
+-
+-                        if (h->MyLBA != where)
+-                                continue;
+-
+-                        if (h->SizeOfPartitionEntry < sizeof(EFI_PARTITION_ENTRY))
+-                                continue;
+-
+-                        if (h->NumberOfPartitionEntries <= 0 ||
+-                            h->NumberOfPartitionEntries > 1024)
+-                                continue;
+-
+-                        if (h->SizeOfPartitionEntry > UINTN_MAX / h->NumberOfPartitionEntries) /* overflow check */
+-                                continue;
+-
+-                        /* Now load the GPT entry table */
+-                        sz = ALIGN_TO((UINTN) h->SizeOfPartitionEntry * (UINTN) h->NumberOfPartitionEntries, 512);
+-                        entries = AllocatePool(sz);
+-
+-                        r = uefi_call_wrapper(block_io->ReadBlocks, 5,
+-                                              block_io,
+-                                              block_io->Media->MediaId,
+-                                              h->PartitionEntryLBA,
+-                                              sz, entries);
+-                        if (EFI_ERROR(r))
+-                                continue;
+-
+-                        /* Calculate CRC of entries array, too */
+-                        r = BS->CalculateCrc32(&entries, sz, &crc32);
+-                        if (EFI_ERROR(r) || crc32 != h->PartitionEntryArrayCRC32)
+-                                continue;
+-
+-                        for (UINTN i = 0; i < h->NumberOfPartitionEntries; i++) {
+-                                EFI_PARTITION_ENTRY *entry;
+-
+-                                entry = (EFI_PARTITION_ENTRY*) ((UINT8*) entries + h->SizeOfPartitionEntry * i);
+-
+-                                if (CompareMem(&entry->PartitionTypeGUID, XBOOTLDR_GUID, 16) == 0) {
+-                                        UINT64 end;
+-
+-                                        /* Let's use memcpy(), in case the structs are not aligned (they really should be though) */
+-                                        CopyMem(&found_partition_start, &entry->StartingLBA, sizeof(found_partition_start));
+-                                        CopyMem(&end, &entry->EndingLBA, sizeof(end));
+-
+-                                        if (end < found_partition_start) /* Bogus? */
+-                                                continue;
+-
+-                                        found_partition_size = end - found_partition_start + 1;
+-                                        CopyMem(found_partition_signature, &entry->UniquePartitionGUID, sizeof(found_partition_signature));
+-
+-                                        found_partition_number = i + 1;
+-                                        goto found;
+-                                }
+-                        }
+-
+-                        break; /* This GPT was fully valid, but we didn't find what we are looking for. This
+-                                * means there's no reason to check the second copy of the GPT header */
+-                }
+-        }
+-
+-        return; /* Not found */
+-
+-found:
+-        copy = DuplicateDevicePath(partition_path);
+-
+-        /* Patch in the data we found */
+-        for (EFI_DEVICE_PATH *node = copy; !IsDevicePathEnd(node); node = NextDevicePathNode(node)) {
+-                HARDDRIVE_DEVICE_PATH *hd;
+-
+-                if (DevicePathType(node) != MEDIA_DEVICE_PATH)
+-                        continue;
+-
+-                if (DevicePathSubType(node) != MEDIA_HARDDRIVE_DP)
+-                        continue;
+-
+-                hd = (HARDDRIVE_DEVICE_PATH*) node;
+-                hd->PartitionNumber = found_partition_number;
+-                hd->PartitionStart = found_partition_start;
+-                hd->PartitionSize = found_partition_size;
+-                CopyMem(hd->Signature, found_partition_signature, sizeof(hd->Signature));
+-                hd->MBRType = MBR_TYPE_EFI_PARTITION_TABLE_HEADER;
+-                hd->SignatureType = SIGNATURE_TYPE_GUID;
+-        }
+-
+-        r = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &copy, &new_device);
+-        if (EFI_ERROR(r))
+-                return;
+-
+-        root_dir = LibOpenRoot(new_device);
+-        if (!root_dir)
++        err = xbootldr_open(device, &new_device, &root_dir);
++        if (EFI_ERROR(err))
+                 return;
+ 
+         config_entry_add_linux(config, new_device, root_dir);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index 567b22684..605221c7e 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -15,6 +15,7 @@ efi_headers = files('''
+         shim.h
+         splash.h
+         util.h
++        xbootldr.h
+ '''.split())
+ 
+ common_sources = '''
+@@ -34,6 +35,7 @@ systemd_boot_sources = '''
+         drivers.c
+         random-seed.c
+         shim.c
++        xbootldr.c
+ '''.split()
+ 
+ stub_sources = '''
+diff --git a/src/boot/efi/xbootldr.c b/src/boot/efi/xbootldr.c
+new file mode 100644
+index 000000000..5ae205349
+--- /dev/null
++++ b/src/boot/efi/xbootldr.c
+@@ -0,0 +1,212 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include <efi.h>
++#include <efigpt.h>
++#include <efilib.h>
++
++#include "util.h"
++#include "xbootldr.h"
++
++static EFI_DEVICE_PATH *path_parent(EFI_DEVICE_PATH *path, EFI_DEVICE_PATH *node) {
++        EFI_DEVICE_PATH *parent;
++        UINTN len;
++
++        assert(path);
++        assert(node);
++
++        len = (UINT8*) NextDevicePathNode(node) - (UINT8*) path;
++        parent = (EFI_DEVICE_PATH*) AllocatePool(len + sizeof(EFI_DEVICE_PATH));
++        CopyMem(parent, path, len);
++        CopyMem((UINT8*) parent + len, EndDevicePath, sizeof(EFI_DEVICE_PATH));
++
++        return parent;
++}
++
++EFI_STATUS xbootldr_open(EFI_HANDLE *device, EFI_HANDLE *ret_device, EFI_FILE **ret_root_dir) {
++        EFI_DEVICE_PATH *partition_path, *disk_path, *copy;
++        UINT32 found_partition_number = UINT32_MAX;
++        UINT64 found_partition_start = UINT64_MAX;
++        UINT64 found_partition_size = UINT64_MAX;
++        UINT8 found_partition_signature[16] = {};
++        EFI_HANDLE new_device;
++        EFI_FILE *root_dir;
++        EFI_STATUS r;
++
++        assert(device);
++        assert(ret_device);
++        assert(ret_root_dir);
++
++        partition_path = DevicePathFromHandle(device);
++        if (!partition_path)
++                return EFI_NOT_FOUND;
++
++        for (EFI_DEVICE_PATH *node = partition_path; !IsDevicePathEnd(node); node = NextDevicePathNode(node)) {
++                EFI_HANDLE disk_handle;
++                EFI_BLOCK_IO *block_io;
++                EFI_DEVICE_PATH *p;
++
++                /* First, Let's look for the SCSI/SATA/USB/… device path node, i.e. one above the media
++                 * devices */
++                if (DevicePathType(node) != MESSAGING_DEVICE_PATH)
++                        continue;
++
++                /* Determine the device path one level up */
++                disk_path = path_parent(partition_path, node);
++                p = disk_path;
++                r = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &p, &disk_handle);
++                if (EFI_ERROR(r))
++                        continue;
++
++                r = uefi_call_wrapper(BS->HandleProtocol, 3, disk_handle, &BlockIoProtocol, (VOID **)&block_io);
++                if (EFI_ERROR(r))
++                        continue;
++
++                /* Filter out some block devices early. (We only care about block devices that aren't
++                 * partitions themselves — we look for GPT partition tables to parse after all —, and only
++                 * those which contain a medium and have at least 2 blocks.) */
++                if (block_io->Media->LogicalPartition ||
++                    !block_io->Media->MediaPresent ||
++                    block_io->Media->LastBlock <= 1)
++                        continue;
++
++                /* Try both copies of the GPT header, in case one is corrupted */
++                for (UINTN nr = 0; nr < 2; nr++) {
++                        _cleanup_freepool_ EFI_PARTITION_ENTRY* entries = NULL;
++                        union {
++                                EFI_PARTITION_TABLE_HEADER gpt_header;
++                                uint8_t space[((sizeof(EFI_PARTITION_TABLE_HEADER) + 511) / 512) * 512];
++                        } gpt_header_buffer;
++                        EFI_PARTITION_TABLE_HEADER *h = &gpt_header_buffer.gpt_header;
++                        UINT64 where;
++                        UINTN sz;
++                        UINT32 crc32, crc32_saved;
++
++                        if (nr == 0)
++                                /* Read the first copy at LBA 1 */
++                                where = 1;
++                        else
++                                /* Read the second copy at the very last LBA of this block device */
++                                where = block_io->Media->LastBlock;
++
++                        /* Read the GPT header */
++                        r = uefi_call_wrapper(block_io->ReadBlocks, 5,
++                                              block_io,
++                                              block_io->Media->MediaId,
++                                              where,
++                                              sizeof(gpt_header_buffer), &gpt_header_buffer);
++                        if (EFI_ERROR(r))
++                                continue;
++
++                        /* Some superficial validation of the GPT header */
++                        if(CompareMem(&h->Header.Signature, "EFI PART", sizeof(h->Header.Signature) != 0))
++                                continue;
++
++                        if (h->Header.HeaderSize < 92 ||
++                            h->Header.HeaderSize > 512)
++                                continue;
++
++                        if (h->Header.Revision != 0x00010000U)
++                                continue;
++
++                        /* Calculate CRC check */
++                        crc32_saved = h->Header.CRC32;
++                        h->Header.CRC32 = 0;
++                        r = BS->CalculateCrc32(&gpt_header_buffer, h->Header.HeaderSize, &crc32);
++                        h->Header.CRC32 = crc32_saved;
++                        if (EFI_ERROR(r) || crc32 != crc32_saved)
++                                continue;
++
++                        if (h->MyLBA != where)
++                                continue;
++
++                        if (h->SizeOfPartitionEntry < sizeof(EFI_PARTITION_ENTRY))
++                                continue;
++
++                        if (h->NumberOfPartitionEntries <= 0 ||
++                            h->NumberOfPartitionEntries > 1024)
++                                continue;
++
++                        if (h->SizeOfPartitionEntry > UINTN_MAX / h->NumberOfPartitionEntries) /* overflow check */
++                                continue;
++
++                        /* Now load the GPT entry table */
++                        sz = ALIGN_TO((UINTN) h->SizeOfPartitionEntry * (UINTN) h->NumberOfPartitionEntries, 512);
++                        entries = AllocatePool(sz);
++
++                        r = uefi_call_wrapper(block_io->ReadBlocks, 5,
++                                              block_io,
++                                              block_io->Media->MediaId,
++                                              h->PartitionEntryLBA,
++                                              sz, entries);
++                        if (EFI_ERROR(r))
++                                continue;
++
++                        /* Calculate CRC of entries array, too */
++                        r = BS->CalculateCrc32(&entries, sz, &crc32);
++                        if (EFI_ERROR(r) || crc32 != h->PartitionEntryArrayCRC32)
++                                continue;
++
++                        for (UINTN i = 0; i < h->NumberOfPartitionEntries; i++) {
++                                EFI_PARTITION_ENTRY *entry;
++
++                                entry = (EFI_PARTITION_ENTRY*) ((UINT8*) entries + h->SizeOfPartitionEntry * i);
++
++                                if (CompareMem(&entry->PartitionTypeGUID, XBOOTLDR_GUID, 16) == 0) {
++                                        UINT64 end;
++
++                                        /* Let's use memcpy(), in case the structs are not aligned (they really should be though) */
++                                        CopyMem(&found_partition_start, &entry->StartingLBA, sizeof(found_partition_start));
++                                        CopyMem(&end, &entry->EndingLBA, sizeof(end));
++
++                                        if (end < found_partition_start) /* Bogus? */
++                                                continue;
++
++                                        found_partition_size = end - found_partition_start + 1;
++                                        CopyMem(found_partition_signature, &entry->UniquePartitionGUID, sizeof(found_partition_signature));
++
++                                        found_partition_number = i + 1;
++                                        goto found;
++                                }
++                        }
++
++                        break; /* This GPT was fully valid, but we didn't find what we are looking for. This
++                                * means there's no reason to check the second copy of the GPT header */
++                }
++        }
++
++        return EFI_NOT_FOUND;
++
++found:
++        copy = DuplicateDevicePath(partition_path);
++
++        /* Patch in the data we found */
++        for (EFI_DEVICE_PATH *node = copy; !IsDevicePathEnd(node); node = NextDevicePathNode(node)) {
++                HARDDRIVE_DEVICE_PATH *hd;
++
++                if (DevicePathType(node) != MEDIA_DEVICE_PATH)
++                        continue;
++
++                if (DevicePathSubType(node) != MEDIA_HARDDRIVE_DP)
++                        continue;
++
++                hd = (HARDDRIVE_DEVICE_PATH*) node;
++                hd->PartitionNumber = found_partition_number;
++                hd->PartitionStart = found_partition_start;
++                hd->PartitionSize = found_partition_size;
++                CopyMem(hd->Signature, found_partition_signature, sizeof(hd->Signature));
++                hd->MBRType = MBR_TYPE_EFI_PARTITION_TABLE_HEADER;
++                hd->SignatureType = SIGNATURE_TYPE_GUID;
++        }
++
++        r = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &copy, &new_device);
++        if (EFI_ERROR(r))
++                return r;
++
++        root_dir = LibOpenRoot(new_device);
++        if (!root_dir)
++                return EFI_DEVICE_ERROR;
++
++        *ret_device = new_device;
++        *ret_root_dir = root_dir;
++        return EFI_SUCCESS;
++}
+diff --git a/src/boot/efi/xbootldr.h b/src/boot/efi/xbootldr.h
+new file mode 100644
+index 000000000..4cb370af2
+--- /dev/null
++++ b/src/boot/efi/xbootldr.h
+@@ -0,0 +1,8 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include <efi.h>
++
++#define XBOOTLDR_GUID \
++        &(const EFI_GUID) { 0xbc13c2ff, 0x59e6, 0x4262, { 0xa3, 0x52, 0xb2, 0x75, 0xfd, 0x6f, 0x71, 0x72 } }
++
++EFI_STATUS xbootldr_open(EFI_HANDLE *device, EFI_HANDLE *ret_device, EFI_FILE **ret_root_dir);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0063-sd-boot-Fix-xbootldr-detection.patch
+++ b/vendor/systemd-patches/0063-sd-boot-Fix-xbootldr-detection.patch
@@ -1,0 +1,49 @@
+From 657fa8dad4c6fd311ae595c38b80e0e029ac6ff0 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Mon, 27 Sep 2021 10:14:53 +0200
+Subject: [PATCH 63/73] sd-boot: Fix xbootldr detection
+
+The broken crc32 calculation was a copy pasta error introduced in
+87167331c902e89bea626c311f0d751ffbc95d73 and luckily has never been
+shipped yet.
+---
+ src/boot/efi/boot.c     | 2 --
+ src/boot/efi/xbootldr.c | 2 +-
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index e073217f3..a9ef1f351 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1321,7 +1321,6 @@ static VOID config_entry_add_from_file(
+         assert(path);
+         assert(file);
+         assert(content);
+-        assert(loaded_image_path);
+ 
+         entry = AllocatePool(sizeof(ConfigEntry));
+ 
+@@ -1509,7 +1508,6 @@ static VOID config_load_entries(
+         assert(config);
+         assert(device);
+         assert(root_dir);
+-        assert(loaded_image_path);
+ 
+         err = open_directory(root_dir, L"\\loader\\entries", &entries_dir);
+         if (EFI_ERROR(err))
+diff --git a/src/boot/efi/xbootldr.c b/src/boot/efi/xbootldr.c
+index 5ae205349..7ee4ed6f2 100644
+--- a/src/boot/efi/xbootldr.c
++++ b/src/boot/efi/xbootldr.c
+@@ -142,7 +142,7 @@ EFI_STATUS xbootldr_open(EFI_HANDLE *device, EFI_HANDLE *ret_device, EFI_FILE **
+                                 continue;
+ 
+                         /* Calculate CRC of entries array, too */
+-                        r = BS->CalculateCrc32(&entries, sz, &crc32);
++                        r = BS->CalculateCrc32(entries, sz, &crc32);
+                         if (EFI_ERROR(r) || crc32 != h->PartitionEntryArrayCRC32)
+                                 continue;
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0064-sd-boot-Split-up-xbootldr_open.patch
+++ b/vendor/systemd-patches/0064-sd-boot-Split-up-xbootldr_open.patch
@@ -1,0 +1,412 @@
+From 1e332ef465d7cc35d0cbd4646fb370fcb26fe706 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Mon, 27 Sep 2021 10:54:29 +0200
+Subject: [PATCH 64/73] sd-boot: Split up xbootldr_open()
+
+---
+ src/boot/efi/xbootldr.c | 329 +++++++++++++++++++++++++---------------
+ 1 file changed, 203 insertions(+), 126 deletions(-)
+
+diff --git a/src/boot/efi/xbootldr.c b/src/boot/efi/xbootldr.c
+index 7ee4ed6f2..4f66c1f85 100644
+--- a/src/boot/efi/xbootldr.c
++++ b/src/boot/efi/xbootldr.c
+@@ -7,6 +7,11 @@
+ #include "util.h"
+ #include "xbootldr.h"
+ 
++union GptHeaderBuffer {
++        EFI_PARTITION_TABLE_HEADER gpt_header;
++        uint8_t space[((sizeof(EFI_PARTITION_TABLE_HEADER) + 511) / 512) * 512];
++};
++
+ static EFI_DEVICE_PATH *path_parent(EFI_DEVICE_PATH *path, EFI_DEVICE_PATH *node) {
+         EFI_DEVICE_PATH *parent;
+         UINTN len;
+@@ -16,31 +21,165 @@ static EFI_DEVICE_PATH *path_parent(EFI_DEVICE_PATH *path, EFI_DEVICE_PATH *node
+ 
+         len = (UINT8*) NextDevicePathNode(node) - (UINT8*) path;
+         parent = (EFI_DEVICE_PATH*) AllocatePool(len + sizeof(EFI_DEVICE_PATH));
++        if (!parent)
++                return NULL;
++
+         CopyMem(parent, path, len);
+         CopyMem((UINT8*) parent + len, EndDevicePath, sizeof(EFI_DEVICE_PATH));
+ 
+         return parent;
+ }
+ 
+-EFI_STATUS xbootldr_open(EFI_HANDLE *device, EFI_HANDLE *ret_device, EFI_FILE **ret_root_dir) {
+-        EFI_DEVICE_PATH *partition_path, *disk_path, *copy;
+-        UINT32 found_partition_number = UINT32_MAX;
+-        UINT64 found_partition_start = UINT64_MAX;
+-        UINT64 found_partition_size = UINT64_MAX;
+-        UINT8 found_partition_signature[16] = {};
+-        EFI_HANDLE new_device;
+-        EFI_FILE *root_dir;
+-        EFI_STATUS r;
++static BOOLEAN verify_gpt(union GptHeaderBuffer *gpt_header_buffer, EFI_LBA lba_expected) {
++        EFI_PARTITION_TABLE_HEADER *h;
++        UINT32 crc32, crc32_saved;
++        EFI_STATUS err;
++
++        assert(gpt_header_buffer);
++
++        h = &gpt_header_buffer->gpt_header;
++
++        /* Some superficial validation of the GPT header */
++        if(CompareMem(&h->Header.Signature, "EFI PART", sizeof(h->Header.Signature) != 0))
++                return FALSE;
++
++        if (h->Header.HeaderSize < 92 || h->Header.HeaderSize > 512)
++                return FALSE;
++
++        if (h->Header.Revision != 0x00010000U)
++                return FALSE;
++
++        /* Calculate CRC check */
++        crc32_saved = h->Header.CRC32;
++        h->Header.CRC32 = 0;
++        err = BS->CalculateCrc32(gpt_header_buffer, h->Header.HeaderSize, &crc32);
++        h->Header.CRC32 = crc32_saved;
++        if (EFI_ERROR(err) || crc32 != crc32_saved)
++                return FALSE;
++
++        if (h->MyLBA != lba_expected)
++                return FALSE;
++
++        if (h->SizeOfPartitionEntry < sizeof(EFI_PARTITION_ENTRY))
++                return FALSE;
++
++        if (h->NumberOfPartitionEntries <= 0 || h->NumberOfPartitionEntries > 1024)
++                return FALSE;
++
++        /* overflow check */
++        if (h->SizeOfPartitionEntry > UINTN_MAX / h->NumberOfPartitionEntries)
++                return FALSE;
++
++        return TRUE;
++}
++
++static EFI_STATUS try_gpt(
++                EFI_BLOCK_IO *block_io,
++                EFI_LBA lba,
++                UINT32 *ret_part_number,
++                UINT64 *ret_part_start,
++                UINT64 *ret_part_size,
++                EFI_GUID *ret_part_uuid) {
++
++        _cleanup_freepool_ EFI_PARTITION_ENTRY *entries = NULL;
++        union GptHeaderBuffer gpt;
++        EFI_STATUS err;
++        UINT32 crc32;
++        UINTN size;
++
++        assert(block_io);
++        assert(ret_part_number);
++        assert(ret_part_start);
++        assert(ret_part_size);
++        assert(ret_part_uuid);
++
++        /* Read the GPT header */
++        err = uefi_call_wrapper(
++                        block_io->ReadBlocks, 5,
++                        block_io,
++                        block_io->Media->MediaId,
++                        lba,
++                        sizeof(gpt), &gpt);
++        if (EFI_ERROR(err))
++                return err;
++
++        if (!verify_gpt(&gpt, lba))
++                return EFI_NOT_FOUND;
++
++        /* Now load the GPT entry table */
++        size = ALIGN_TO((UINTN) gpt.gpt_header.SizeOfPartitionEntry * (UINTN) gpt.gpt_header.NumberOfPartitionEntries, 512);
++        entries = AllocatePool(size);
++        if (!entries)
++                return EFI_OUT_OF_RESOURCES;
++
++        err = uefi_call_wrapper(
++                        block_io->ReadBlocks, 5,
++                        block_io,
++                        block_io->Media->MediaId,
++                        gpt.gpt_header.PartitionEntryLBA,
++                        size, entries);
++        if (EFI_ERROR(err))
++                return err;
++
++        /* Calculate CRC of entries array, too */
++        err = BS->CalculateCrc32(entries, size, &crc32);
++        if (EFI_ERROR(err) || crc32 != gpt.gpt_header.PartitionEntryArrayCRC32)
++                return EFI_CRC_ERROR;
++
++        /* Now we can finally look for xbootloader partitions. */
++        for (UINTN i = 0; i < gpt.gpt_header.NumberOfPartitionEntries; i++) {
++                EFI_PARTITION_ENTRY *entry;
++                EFI_LBA start, end;
++
++                entry = (EFI_PARTITION_ENTRY*) ((UINT8*) entries + gpt.gpt_header.SizeOfPartitionEntry * i);
++
++                if (CompareMem(&entry->PartitionTypeGUID, XBOOTLDR_GUID, sizeof(entry->PartitionTypeGUID)) != 0)
++                        continue;
++
++                /* Let's use memcpy(), in case the structs are not aligned (they really should be though) */
++                CopyMem(&start, &entry->StartingLBA, sizeof(start));
++                CopyMem(&end, &entry->EndingLBA, sizeof(end));
++
++                if (end < start) /* Bogus? */
++                        continue;
++
++                *ret_part_number = i + 1;
++                *ret_part_start = start;
++                *ret_part_size = end - start + 1;
++                CopyMem(ret_part_uuid, &entry->UniquePartitionGUID, sizeof(*ret_part_uuid));
++
++                return EFI_SUCCESS;
++        }
++
++        /* This GPT was fully valid, but we didn't find what we are looking for. This
++         * means there's no reason to check the second copy of the GPT header */
++        return EFI_NOT_FOUND;
++}
++
++static EFI_STATUS find_device(
++                EFI_HANDLE *device,
++                EFI_DEVICE_PATH **ret_device_path,
++                UINT32 *ret_part_number,
++                UINT64 *ret_part_start,
++                UINT64 *ret_part_size,
++                EFI_GUID *ret_part_uuid) {
++
++        EFI_DEVICE_PATH *partition_path;
++        EFI_STATUS err;
+ 
+         assert(device);
+-        assert(ret_device);
+-        assert(ret_root_dir);
++        assert(ret_device_path);
++        assert(ret_part_number);
++        assert(ret_part_start);
++        assert(ret_part_size);
++        assert(ret_part_uuid);
+ 
+         partition_path = DevicePathFromHandle(device);
+         if (!partition_path)
+                 return EFI_NOT_FOUND;
+ 
+         for (EFI_DEVICE_PATH *node = partition_path; !IsDevicePathEnd(node); node = NextDevicePathNode(node)) {
++                _cleanup_freepool_ EFI_DEVICE_PATH *disk_path = NULL;
+                 EFI_HANDLE disk_handle;
+                 EFI_BLOCK_IO *block_io;
+                 EFI_DEVICE_PATH *p;
+@@ -51,14 +190,16 @@ EFI_STATUS xbootldr_open(EFI_HANDLE *device, EFI_HANDLE *ret_device, EFI_FILE **
+                         continue;
+ 
+                 /* Determine the device path one level up */
+-                disk_path = path_parent(partition_path, node);
+-                p = disk_path;
+-                r = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &p, &disk_handle);
+-                if (EFI_ERROR(r))
++                disk_path = p = path_parent(partition_path, node);
++                if (!disk_path)
++                        continue;
++
++                err = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &p, &disk_handle);
++                if (EFI_ERROR(err))
+                         continue;
+ 
+-                r = uefi_call_wrapper(BS->HandleProtocol, 3, disk_handle, &BlockIoProtocol, (VOID **)&block_io);
+-                if (EFI_ERROR(r))
++                err = uefi_call_wrapper(BS->HandleProtocol, 3, disk_handle, &BlockIoProtocol, (VOID **)&block_io);
++                if (EFI_ERROR(err))
+                         continue;
+ 
+                 /* Filter out some block devices early. (We only care about block devices that aren't
+@@ -71,116 +212,52 @@ EFI_STATUS xbootldr_open(EFI_HANDLE *device, EFI_HANDLE *ret_device, EFI_FILE **
+ 
+                 /* Try both copies of the GPT header, in case one is corrupted */
+                 for (UINTN nr = 0; nr < 2; nr++) {
+-                        _cleanup_freepool_ EFI_PARTITION_ENTRY* entries = NULL;
+-                        union {
+-                                EFI_PARTITION_TABLE_HEADER gpt_header;
+-                                uint8_t space[((sizeof(EFI_PARTITION_TABLE_HEADER) + 511) / 512) * 512];
+-                        } gpt_header_buffer;
+-                        EFI_PARTITION_TABLE_HEADER *h = &gpt_header_buffer.gpt_header;
+-                        UINT64 where;
+-                        UINTN sz;
+-                        UINT32 crc32, crc32_saved;
+-
+-                        if (nr == 0)
+-                                /* Read the first copy at LBA 1 */
+-                                where = 1;
+-                        else
+-                                /* Read the second copy at the very last LBA of this block device */
+-                                where = block_io->Media->LastBlock;
+-
+-                        /* Read the GPT header */
+-                        r = uefi_call_wrapper(block_io->ReadBlocks, 5,
+-                                              block_io,
+-                                              block_io->Media->MediaId,
+-                                              where,
+-                                              sizeof(gpt_header_buffer), &gpt_header_buffer);
+-                        if (EFI_ERROR(r))
+-                                continue;
+-
+-                        /* Some superficial validation of the GPT header */
+-                        if(CompareMem(&h->Header.Signature, "EFI PART", sizeof(h->Header.Signature) != 0))
+-                                continue;
+-
+-                        if (h->Header.HeaderSize < 92 ||
+-                            h->Header.HeaderSize > 512)
+-                                continue;
+-
+-                        if (h->Header.Revision != 0x00010000U)
+-                                continue;
+-
+-                        /* Calculate CRC check */
+-                        crc32_saved = h->Header.CRC32;
+-                        h->Header.CRC32 = 0;
+-                        r = BS->CalculateCrc32(&gpt_header_buffer, h->Header.HeaderSize, &crc32);
+-                        h->Header.CRC32 = crc32_saved;
+-                        if (EFI_ERROR(r) || crc32 != crc32_saved)
+-                                continue;
+-
+-                        if (h->MyLBA != where)
+-                                continue;
+-
+-                        if (h->SizeOfPartitionEntry < sizeof(EFI_PARTITION_ENTRY))
+-                                continue;
+-
+-                        if (h->NumberOfPartitionEntries <= 0 ||
+-                            h->NumberOfPartitionEntries > 1024)
+-                                continue;
+-
+-                        if (h->SizeOfPartitionEntry > UINTN_MAX / h->NumberOfPartitionEntries) /* overflow check */
+-                                continue;
+-
+-                        /* Now load the GPT entry table */
+-                        sz = ALIGN_TO((UINTN) h->SizeOfPartitionEntry * (UINTN) h->NumberOfPartitionEntries, 512);
+-                        entries = AllocatePool(sz);
+-
+-                        r = uefi_call_wrapper(block_io->ReadBlocks, 5,
+-                                              block_io,
+-                                              block_io->Media->MediaId,
+-                                              h->PartitionEntryLBA,
+-                                              sz, entries);
+-                        if (EFI_ERROR(r))
+-                                continue;
+-
+-                        /* Calculate CRC of entries array, too */
+-                        r = BS->CalculateCrc32(entries, sz, &crc32);
+-                        if (EFI_ERROR(r) || crc32 != h->PartitionEntryArrayCRC32)
+-                                continue;
+-
+-                        for (UINTN i = 0; i < h->NumberOfPartitionEntries; i++) {
+-                                EFI_PARTITION_ENTRY *entry;
+-
+-                                entry = (EFI_PARTITION_ENTRY*) ((UINT8*) entries + h->SizeOfPartitionEntry * i);
+-
+-                                if (CompareMem(&entry->PartitionTypeGUID, XBOOTLDR_GUID, 16) == 0) {
+-                                        UINT64 end;
+-
+-                                        /* Let's use memcpy(), in case the structs are not aligned (they really should be though) */
+-                                        CopyMem(&found_partition_start, &entry->StartingLBA, sizeof(found_partition_start));
+-                                        CopyMem(&end, &entry->EndingLBA, sizeof(end));
+-
+-                                        if (end < found_partition_start) /* Bogus? */
+-                                                continue;
+-
+-                                        found_partition_size = end - found_partition_start + 1;
+-                                        CopyMem(found_partition_signature, &entry->UniquePartitionGUID, sizeof(found_partition_signature));
+-
+-                                        found_partition_number = i + 1;
+-                                        goto found;
+-                                }
++                        /* Read the first copy at LBA 1 and then try backup GPT header at the very last
++                         * LBA of this block device if it was corrupted. */
++                        EFI_LBA lba = nr == 0 ? 1 : block_io->Media->LastBlock;
++
++                        err = try_gpt(
++                                block_io, lba,
++                                ret_part_number,
++                                ret_part_start,
++                                ret_part_size,
++                                ret_part_uuid);
++                        if (!EFI_ERROR(err)) {
++                                *ret_device_path = DuplicateDevicePath(partition_path);
++                                if (!*ret_device_path)
++                                        return EFI_OUT_OF_RESOURCES;
++                                return EFI_SUCCESS;
+                         }
+ 
+-                        break; /* This GPT was fully valid, but we didn't find what we are looking for. This
+-                                * means there's no reason to check the second copy of the GPT header */
++                        /* GPT was valid but no XBOOT loader partition found. */
++                        if (err == EFI_NOT_FOUND)
++                                break;
+                 }
+         }
+ 
++        /* No xbootloader partition found */
+         return EFI_NOT_FOUND;
++}
+ 
+-found:
+-        copy = DuplicateDevicePath(partition_path);
++EFI_STATUS xbootldr_open(EFI_HANDLE *device, EFI_HANDLE *ret_device, EFI_FILE **ret_root_dir) {
++        _cleanup_freepool_ EFI_DEVICE_PATH *partition_path = NULL;
++        UINT32 part_number = UINT32_MAX;
++        UINT64 part_start = UINT64_MAX, part_size = UINT64_MAX;
++        EFI_HANDLE new_device;
++        EFI_FILE *root_dir;
++        EFI_GUID part_uuid;
++        EFI_STATUS err;
++
++        assert(device);
++        assert(ret_device);
++        assert(ret_root_dir);
++
++        err = find_device(device, &partition_path, &part_number, &part_start, &part_size, &part_uuid);
++        if (EFI_ERROR(err))
++                return err;
+ 
+         /* Patch in the data we found */
+-        for (EFI_DEVICE_PATH *node = copy; !IsDevicePathEnd(node); node = NextDevicePathNode(node)) {
++        for (EFI_DEVICE_PATH *node = partition_path; !IsDevicePathEnd(node); node = NextDevicePathNode(node)) {
+                 HARDDRIVE_DEVICE_PATH *hd;
+ 
+                 if (DevicePathType(node) != MEDIA_DEVICE_PATH)
+@@ -190,21 +267,21 @@ found:
+                         continue;
+ 
+                 hd = (HARDDRIVE_DEVICE_PATH*) node;
+-                hd->PartitionNumber = found_partition_number;
+-                hd->PartitionStart = found_partition_start;
+-                hd->PartitionSize = found_partition_size;
+-                CopyMem(hd->Signature, found_partition_signature, sizeof(hd->Signature));
++                hd->PartitionNumber = part_number;
++                hd->PartitionStart = part_start;
++                hd->PartitionSize = part_size;
++                CopyMem(hd->Signature, &part_uuid, sizeof(hd->Signature));
+                 hd->MBRType = MBR_TYPE_EFI_PARTITION_TABLE_HEADER;
+                 hd->SignatureType = SIGNATURE_TYPE_GUID;
+         }
+ 
+-        r = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &copy, &new_device);
+-        if (EFI_ERROR(r))
+-                return r;
++        err = uefi_call_wrapper(BS->LocateDevicePath, 3, &BlockIoProtocol, &partition_path, &new_device);
++        if (EFI_ERROR(err))
++                return err;
+ 
+         root_dir = LibOpenRoot(new_device);
+         if (!root_dir)
+-                return EFI_DEVICE_ERROR;
++                return EFI_NOT_FOUND;
+ 
+         *ret_device = new_device;
+         *ret_root_dir = root_dir;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0065-sd-boot-Use-backup-LBA-location-from-first-GPT-heade.patch
+++ b/vendor/systemd-patches/0065-sd-boot-Use-backup-LBA-location-from-first-GPT-heade.patch
@@ -1,0 +1,69 @@
+From 3acd451ca45f1b2b1cad6dfdaef263dccdea0e02 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Mon, 27 Sep 2021 12:20:15 +0200
+Subject: [PATCH 65/73] sd-boot: Use backup LBA location from first GPT header
+
+If a disk were dd'd to a lager block device, the last block on it
+is not necessarily the backup header.
+---
+ src/boot/efi/xbootldr.c | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/src/boot/efi/xbootldr.c b/src/boot/efi/xbootldr.c
+index 4f66c1f85..ef7ca6cf4 100644
+--- a/src/boot/efi/xbootldr.c
++++ b/src/boot/efi/xbootldr.c
+@@ -76,6 +76,7 @@ static BOOLEAN verify_gpt(union GptHeaderBuffer *gpt_header_buffer, EFI_LBA lba_
+ static EFI_STATUS try_gpt(
+                 EFI_BLOCK_IO *block_io,
+                 EFI_LBA lba,
++                EFI_LBA *ret_backup_lba, /* May be changed even on error! */
+                 UINT32 *ret_part_number,
+                 UINT64 *ret_part_start,
+                 UINT64 *ret_part_size,
+@@ -103,6 +104,10 @@ static EFI_STATUS try_gpt(
+         if (EFI_ERROR(err))
+                 return err;
+ 
++        /* Indicate the location of backup LBA even if the rest of the header is corrupt. */
++        if (ret_backup_lba)
++                *ret_backup_lba = gpt.gpt_header.AlternateLBA;
++
+         if (!verify_gpt(&gpt, lba))
+                 return EFI_NOT_FOUND;
+ 
+@@ -210,14 +215,26 @@ static EFI_STATUS find_device(
+                     block_io->Media->LastBlock <= 1)
+                         continue;
+ 
+-                /* Try both copies of the GPT header, in case one is corrupted */
+-                for (UINTN nr = 0; nr < 2; nr++) {
+-                        /* Read the first copy at LBA 1 and then try backup GPT header at the very last
+-                         * LBA of this block device if it was corrupted. */
+-                        EFI_LBA lba = nr == 0 ? 1 : block_io->Media->LastBlock;
++                /* Try several copies of the GPT header, in case one is corrupted */
++                EFI_LBA backup_lba = 0;
++                for (UINTN nr = 0; nr < 3; nr++) {
++                        EFI_LBA lba;
++
++                        /* Read the first copy at LBA 1 and then try the backup GPT header pointed
++                         * to by the first header if that one was corrupted. As a last resort,
++                         * try the very last LBA of this block device. */
++                        if (nr == 0)
++                                lba = 1;
++                        else if (nr == 1 && backup_lba != 0)
++                                lba = backup_lba;
++                        else if (nr == 2 && backup_lba != block_io->Media->LastBlock)
++                                lba = block_io->Media->LastBlock;
++                        else
++                                continue;
+ 
+                         err = try_gpt(
+                                 block_io, lba,
++                                nr == 0 ? &backup_lba : NULL, /* Only get backup LBA location from first GPT header. */
+                                 ret_part_number,
+                                 ret_part_start,
+                                 ret_part_size,
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0066-sd-boot-Remove-unnecessary-TPM-conditionalization.patch
+++ b/vendor/systemd-patches/0066-sd-boot-Remove-unnecessary-TPM-conditionalization.patch
@@ -1,0 +1,33 @@
+From 95f8e9a79faf29c5b6452b42bae700bf161d208e Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Mon, 27 Sep 2021 12:29:00 +0200
+Subject: [PATCH 66/73] sd-boot: Remove unnecessary TPM conditionalization
+
+This is already done in measure.h.
+---
+ src/boot/efi/cpio.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/boot/efi/cpio.c b/src/boot/efi/cpio.c
+index 10a044cc9..e20615633 100644
+--- a/src/boot/efi/cpio.c
++++ b/src/boot/efi/cpio.c
+@@ -449,7 +449,6 @@ EFI_STATUS pack_cpio(
+         if (EFI_ERROR(err))
+                 return log_error_status_stall(err, L"Failed to pack cpio trailer: %r");
+ 
+-#if ENABLE_TPM
+         err = tpm_log_event(
+                         tpm_pcr,
+                         POINTER_TO_PHYSICAL_ADDRESS(buffer),
+@@ -457,7 +456,6 @@ EFI_STATUS pack_cpio(
+                         tpm_description);
+         if (EFI_ERROR(err))
+                 log_error_stall(L"Unable to add initrd TPM measurement for PCR %u (%s), ignoring: %r", tpm_pcr, tpm_description, err);
+-#endif
+ 
+         *ret_buffer = TAKE_PTR(buffer);
+         *ret_buffer_size = buffer_size;
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0067-sd-boot-Use-_cleanup_-in-more-places.patch
+++ b/vendor/systemd-patches/0067-sd-boot-Use-_cleanup_-in-more-places.patch
@@ -1,0 +1,130 @@
+From 88d1a2d867cb574b4a90487b7718ae2c4ad85d4e Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Mon, 27 Sep 2021 13:07:16 +0200
+Subject: [PATCH 67/73] sd-boot: Use _cleanup_ in more places
+
+---
+ src/boot/efi/boot.c | 35 ++++++++++++++---------------------
+ 1 file changed, 14 insertions(+), 21 deletions(-)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index a9ef1f351..5fdf26240 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -563,7 +563,7 @@ static BOOLEAN menu_run(
+         BOOLEAN refresh = TRUE, highlight = FALSE;
+         UINTN x_start = 0, y_start = 0, y_status = 0;
+         UINTN x_max, y_max;
+-        CHAR16 **lines = NULL;
++        _cleanup_(strv_freep) CHAR16 **lines = NULL;
+         _cleanup_freepool_ CHAR16 *clearline = NULL, *status = NULL;
+         UINT32 timeout_efivar_saved = config->timeout_sec_efivar;
+         UINT32 timeout_remain = config->timeout_sec == TIMEOUT_MENU_FORCE ? 0 : config->timeout_sec;
+@@ -623,15 +623,11 @@ static BOOLEAN menu_run(
+                         /* Put status line after the entry list, but give it some breathing room. */
+                         y_status = MIN(y_start + MIN(visible_max, config->entry_count) + 4, y_max - 1);
+ 
+-                        if (lines) {
+-                                for (UINTN i = 0; i < config->entry_count; i++)
+-                                        FreePool(lines[i]);
+-                                FreePool(lines);
+-                                FreePool(clearline);
+-                        }
++                        strv_free(lines);
++                        FreePool(clearline);
+ 
+                         /* menu entries title lines */
+-                        lines = AllocatePool(sizeof(CHAR16 *) * config->entry_count);
++                        lines = AllocatePool((config->entry_count + 1) * sizeof(CHAR16 *));
+                         for (UINTN i = 0; i < config->entry_count; i++) {
+                                 UINTN j, padding;
+ 
+@@ -648,6 +644,7 @@ static BOOLEAN menu_run(
+                                         lines[i][j] = ' ';
+                                 lines[i][line_width] = '\0';
+                         }
++                        lines[config->entry_count] = NULL;
+ 
+                         clearline = AllocatePool((x_max+1) * sizeof(CHAR16));
+                         for (UINTN i = 0; i < x_max; i++)
+@@ -921,10 +918,6 @@ static BOOLEAN menu_run(
+                                                config->timeout_sec_efivar, EFI_VARIABLE_NON_VOLATILE);
+         }
+ 
+-        for (UINTN i = 0; i < config->entry_count; i++)
+-                FreePool(lines[i]);
+-        FreePool(lines);
+-
+         clear_screen(COLOR_NORMAL);
+         return run;
+ }
+@@ -961,6 +954,10 @@ static VOID config_entry_free(ConfigEntry *entry) {
+         FreePool(entry);
+ }
+ 
++static inline VOID config_entry_freep(ConfigEntry **entry) {
++        config_entry_free(*entry);
++}
++
+ static CHAR8 *line_get_key_value(
+                 CHAR8 *content,
+                 const CHAR8 *sep,
+@@ -1307,7 +1304,7 @@ static VOID config_entry_add_from_file(
+                 CHAR8 *content,
+                 const CHAR16 *loaded_image_path) {
+ 
+-        ConfigEntry *entry;
++        _cleanup_(config_entry_freep) ConfigEntry *entry = NULL;
+         CHAR8 *line;
+         UINTN pos = 0;
+         CHAR8 *key, *value;
+@@ -1417,17 +1414,13 @@ static VOID config_entry_add_from_file(
+                 }
+         }
+ 
+-        if (entry->type == LOADER_UNDEFINED) {
+-                config_entry_free(entry);
++        if (entry->type == LOADER_UNDEFINED)
+                 return;
+-        }
+ 
+         /* check existence */
+         err = uefi_call_wrapper(root_dir->Open, 5, root_dir, &handle, entry->loader, EFI_FILE_MODE_READ, 0ULL);
+-        if (EFI_ERROR(err)) {
+-                config_entry_free(entry);
++        if (EFI_ERROR(err))
+                 return;
+-        }
+         uefi_call_wrapper(handle->Close, 1, handle);
+ 
+         /* add initrd= to options */
+@@ -1449,6 +1442,7 @@ static VOID config_entry_add_from_file(
+         config_add_entry(config, entry);
+ 
+         config_entry_parse_tries(entry, path, file, L".conf");
++        TAKE_PTR(entry);
+ }
+ 
+ static VOID config_load_defaults(Config *config, EFI_FILE *root_dir) {
+@@ -2313,9 +2307,9 @@ static VOID config_load_all_entries(
+ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         _cleanup_freepool_ EFI_LOADED_IMAGE *loaded_image = NULL;
+         _cleanup_(FileHandleClosep) EFI_FILE *root_dir = NULL;
++        _cleanup_(config_free) Config config = {};
+         CHAR16 *loaded_image_path;
+         EFI_STATUS err;
+-        Config config;
+         UINT64 init_usec;
+         BOOLEAN menu = FALSE;
+ 
+@@ -2430,7 +2424,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         }
+         err = EFI_SUCCESS;
+ out:
+-        config_free(&config);
+         uefi_call_wrapper(BS->CloseProtocol, 4, image, &LoadedImageProtocol, image, NULL);
+         return err;
+ }
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0068-sd-boot-Move-security-and-console-control-protocol-t.patch
+++ b/vendor/systemd-patches/0068-sd-boot-Move-security-and-console-control-protocol-t.patch
@@ -1,0 +1,237 @@
+From 7d1e97afc3850033ce4735db4e0fa677f3d3ec04 Mon Sep 17 00:00:00 2001
+From: Jan Janssen <medhefgo@web.de>
+Date: Thu, 30 Sep 2021 11:12:21 +0200
+Subject: [PATCH 68/73] sd-boot: Move security and console control protocol to
+ missing_efi.h
+
+This also fixes a broken #ifdefs in the header itself.
+---
+ src/boot/efi/graphics.c    | 36 +---------------
+ src/boot/efi/missing_efi.h | 86 ++++++++++++++++++++++++++++++++++++++
+ src/boot/efi/shim.c        | 38 +----------------
+ 3 files changed, 88 insertions(+), 72 deletions(-)
+
+diff --git a/src/boot/efi/graphics.c b/src/boot/efi/graphics.c
+index 3f6f3f75c..a7a99b344 100644
+--- a/src/boot/efi/graphics.c
++++ b/src/boot/efi/graphics.c
+@@ -8,44 +8,10 @@
+ #include <efilib.h>
+ 
+ #include "graphics.h"
++#include "missing_efi.h"
+ #include "util.h"
+ 
+-#define EFI_CONSOLE_CONTROL_GUID \
+-        &(const EFI_GUID) { 0xf42f7782, 0x12e, 0x4c12, { 0x99, 0x56, 0x49, 0xf9, 0x43, 0x4, 0xf7, 0x21 } }
+-
+ EFI_STATUS graphics_mode(BOOLEAN on) {
+-
+-        struct _EFI_CONSOLE_CONTROL_PROTOCOL;
+-
+-        typedef enum {
+-                EfiConsoleControlScreenText,
+-                EfiConsoleControlScreenGraphics,
+-                EfiConsoleControlScreenMaxValue,
+-        } EFI_CONSOLE_CONTROL_SCREEN_MODE;
+-
+-        typedef EFI_STATUS (EFIAPI *EFI_CONSOLE_CONTROL_PROTOCOL_GET_MODE)(
+-                struct _EFI_CONSOLE_CONTROL_PROTOCOL *This,
+-                EFI_CONSOLE_CONTROL_SCREEN_MODE *Mode,
+-                BOOLEAN *UgaExists,
+-                BOOLEAN *StdInLocked
+-        );
+-
+-        typedef EFI_STATUS (EFIAPI *EFI_CONSOLE_CONTROL_PROTOCOL_SET_MODE)(
+-                struct _EFI_CONSOLE_CONTROL_PROTOCOL *This,
+-                EFI_CONSOLE_CONTROL_SCREEN_MODE Mode
+-        );
+-
+-        typedef EFI_STATUS (EFIAPI *EFI_CONSOLE_CONTROL_PROTOCOL_LOCK_STD_IN)(
+-                struct _EFI_CONSOLE_CONTROL_PROTOCOL *This,
+-                CHAR16 *Password
+-        );
+-
+-        typedef struct _EFI_CONSOLE_CONTROL_PROTOCOL {
+-                EFI_CONSOLE_CONTROL_PROTOCOL_GET_MODE GetMode;
+-                EFI_CONSOLE_CONTROL_PROTOCOL_SET_MODE SetMode;
+-                EFI_CONSOLE_CONTROL_PROTOCOL_LOCK_STD_IN LockStdIn;
+-        } EFI_CONSOLE_CONTROL_PROTOCOL;
+-
+         EFI_CONSOLE_CONTROL_PROTOCOL *ConsoleControl = NULL;
+         EFI_CONSOLE_CONTROL_SCREEN_MODE new;
+         EFI_CONSOLE_CONTROL_SCREEN_MODE current;
+diff --git a/src/boot/efi/missing_efi.h b/src/boot/efi/missing_efi.h
+index fad75d82b..e3e0b978e 100644
+--- a/src/boot/efi/missing_efi.h
++++ b/src/boot/efi/missing_efi.h
+@@ -161,6 +161,10 @@ struct _EFI_DT_FIXUP_PROTOCOL {
+         EFI_DT_FIXUP   Fixup;
+ };
+ 
++#endif
++
++#ifndef EFI_TCG_GUID
++
+ #define EFI_TCG_GUID \
+         &(const EFI_GUID) { 0xf541796d, 0xa62e, 0x4954, { 0xa7, 0x75, 0x95, 0x84, 0xf6, 0x1b, 0x9c, 0xdd } }
+ 
+@@ -256,6 +260,10 @@ typedef struct _EFI_TCG {
+         EFI_TCG_HASH_LOG_EXTEND_EVENT HashLogExtendEvent;
+ } EFI_TCG;
+ 
++#endif
++
++#ifndef EFI_TCG2_GUID
++
+ #define EFI_TCG2_GUID \
+         &(const EFI_GUID) { 0x607f766c, 0x7455, 0x42be, { 0x93, 0x0b, 0xe4, 0xd7, 0x6d, 0xb2, 0x72, 0x0f } }
+ 
+@@ -340,3 +348,81 @@ typedef struct tdEFI_TCG2_PROTOCOL {
+ 
+ #define LINUX_INITRD_MEDIA_GUID \
+         {0x5568e427, 0x68fc, 0x4f3d, {0xac, 0x74, 0xca, 0x55, 0x52, 0x31, 0xcc, 0x68} }
++
++/* UEFI Platform Initialization (Vol2: DXE) */
++#ifndef SECURITY_PROTOCOL_GUID
++
++#define SECURITY_PROTOCOL_GUID \
++        &(const EFI_GUID) { 0xa46423e3, 0x4617, 0x49f1, { 0xb9, 0xff, 0xd1, 0xbf, 0xa9, 0x11, 0x58, 0x39 } }
++#define SECURITY_PROTOCOL2_GUID \
++        &(const EFI_GUID) { 0x94ab2f58, 0x1438, 0x4ef1, { 0x91, 0x52, 0x18, 0x94, 0x1a, 0x3a, 0x0e, 0x68 } }
++
++struct _EFI_SECURITY2_PROTOCOL;
++struct _EFI_SECURITY_PROTOCOL;
++struct _EFI_DEVICE_PATH_PROTOCOL;
++
++typedef struct _EFI_SECURITY2_PROTOCOL EFI_SECURITY2_PROTOCOL;
++typedef struct _EFI_SECURITY_PROTOCOL EFI_SECURITY_PROTOCOL;
++typedef struct _EFI_DEVICE_PATH_PROTOCOL EFI_DEVICE_PATH_PROTOCOL;
++
++typedef EFI_STATUS (EFIAPI *EFI_SECURITY_FILE_AUTHENTICATION_STATE) (
++        const EFI_SECURITY_PROTOCOL *This,
++        UINT32 AuthenticationStatus,
++        const EFI_DEVICE_PATH_PROTOCOL *File
++);
++
++typedef EFI_STATUS (EFIAPI *EFI_SECURITY2_FILE_AUTHENTICATION) (
++        const EFI_SECURITY2_PROTOCOL *This,
++        const EFI_DEVICE_PATH_PROTOCOL *DevicePath,
++        VOID *FileBuffer,
++        UINTN FileSize,
++        BOOLEAN  BootPolicy
++);
++
++struct _EFI_SECURITY2_PROTOCOL {
++        EFI_SECURITY2_FILE_AUTHENTICATION FileAuthentication;
++};
++
++struct _EFI_SECURITY_PROTOCOL {
++        EFI_SECURITY_FILE_AUTHENTICATION_STATE  FileAuthenticationState;
++};
++
++#endif
++
++#ifndef EFI_CONSOLE_CONTROL_GUID
++
++#define EFI_CONSOLE_CONTROL_GUID \
++        &(const EFI_GUID) { 0xf42f7782, 0x12e, 0x4c12, { 0x99, 0x56, 0x49, 0xf9, 0x43, 0x4, 0xf7, 0x21 } }
++
++struct _EFI_CONSOLE_CONTROL_PROTOCOL;
++
++typedef enum {
++        EfiConsoleControlScreenText,
++        EfiConsoleControlScreenGraphics,
++        EfiConsoleControlScreenMaxValue,
++} EFI_CONSOLE_CONTROL_SCREEN_MODE;
++
++typedef EFI_STATUS (EFIAPI *EFI_CONSOLE_CONTROL_PROTOCOL_GET_MODE)(
++        struct _EFI_CONSOLE_CONTROL_PROTOCOL *This,
++        EFI_CONSOLE_CONTROL_SCREEN_MODE *Mode,
++        BOOLEAN *UgaExists,
++        BOOLEAN *StdInLocked
++);
++
++typedef EFI_STATUS (EFIAPI *EFI_CONSOLE_CONTROL_PROTOCOL_SET_MODE)(
++        struct _EFI_CONSOLE_CONTROL_PROTOCOL *This,
++        EFI_CONSOLE_CONTROL_SCREEN_MODE Mode
++);
++
++typedef EFI_STATUS (EFIAPI *EFI_CONSOLE_CONTROL_PROTOCOL_LOCK_STD_IN)(
++        struct _EFI_CONSOLE_CONTROL_PROTOCOL *This,
++        CHAR16 *Password
++);
++
++typedef struct _EFI_CONSOLE_CONTROL_PROTOCOL {
++        EFI_CONSOLE_CONTROL_PROTOCOL_GET_MODE GetMode;
++        EFI_CONSOLE_CONTROL_PROTOCOL_SET_MODE SetMode;
++        EFI_CONSOLE_CONTROL_PROTOCOL_LOCK_STD_IN LockStdIn;
++} EFI_CONSOLE_CONTROL_PROTOCOL;
++
++#endif
+diff --git a/src/boot/efi/shim.c b/src/boot/efi/shim.c
+index e3fb073fd..9fcc45403 100644
+--- a/src/boot/efi/shim.c
++++ b/src/boot/efi/shim.c
+@@ -11,6 +11,7 @@
+ #include <efi.h>
+ #include <efilib.h>
+ 
++#include "missing_efi.h"
+ #include "util.h"
+ #include "shim.h"
+ 
+@@ -31,10 +32,6 @@ struct ShimLock {
+ };
+ 
+ #define SIMPLE_FS_GUID &(const EFI_GUID) SIMPLE_FILE_SYSTEM_PROTOCOL
+-#define SECURITY_PROTOCOL_GUID \
+-        &(const EFI_GUID) { 0xa46423e3, 0x4617, 0x49f1, { 0xb9, 0xff, 0xd1, 0xbf, 0xa9, 0x11, 0x58, 0x39 } }
+-#define SECURITY_PROTOCOL2_GUID \
+-        &(const EFI_GUID) { 0x94ab2f58, 0x1438, 0x4ef1, { 0x91, 0x52, 0x18, 0x94, 0x1a, 0x3a, 0x0e, 0x68 } }
+ #define SHIM_LOCK_GUID \
+         &(const EFI_GUID) { 0x605dab50, 0xe046, 0x4300, { 0xab, 0xb6, 0x3d, 0xd8, 0x10, 0xdd, 0x8b, 0x23 } }
+ 
+@@ -59,39 +56,6 @@ static BOOLEAN shim_validate(VOID *data, UINT32 size) {
+         return shim_lock->shim_verify(data, size) == EFI_SUCCESS;
+ }
+ 
+-/*
+- * See the UEFI Platform Initialization manual (Vol2: DXE) for this
+- */
+-struct _EFI_SECURITY2_PROTOCOL;
+-struct _EFI_SECURITY_PROTOCOL;
+-struct _EFI_DEVICE_PATH_PROTOCOL;
+-
+-typedef struct _EFI_SECURITY2_PROTOCOL EFI_SECURITY2_PROTOCOL;
+-typedef struct _EFI_SECURITY_PROTOCOL EFI_SECURITY_PROTOCOL;
+-typedef struct _EFI_DEVICE_PATH_PROTOCOL EFI_DEVICE_PATH_PROTOCOL;
+-
+-typedef EFI_STATUS (EFIAPI *EFI_SECURITY_FILE_AUTHENTICATION_STATE) (
+-        const EFI_SECURITY_PROTOCOL *This,
+-        UINT32 AuthenticationStatus,
+-        const EFI_DEVICE_PATH_PROTOCOL *File
+-);
+-
+-typedef EFI_STATUS (EFIAPI *EFI_SECURITY2_FILE_AUTHENTICATION) (
+-        const EFI_SECURITY2_PROTOCOL *This,
+-        const EFI_DEVICE_PATH_PROTOCOL *DevicePath,
+-        VOID *FileBuffer,
+-        UINTN FileSize,
+-        BOOLEAN  BootPolicy
+-);
+-
+-struct _EFI_SECURITY2_PROTOCOL {
+-        EFI_SECURITY2_FILE_AUTHENTICATION FileAuthentication;
+-};
+-
+-struct _EFI_SECURITY_PROTOCOL {
+-        EFI_SECURITY_FILE_AUTHENTICATION_STATE  FileAuthenticationState;
+-};
+-
+ /* Handle to the original authenticator for security1 protocol */
+ static EFI_SECURITY_FILE_AUTHENTICATION_STATE esfas = NULL;
+ 
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0069-fundamental-define-size_t-and-memcpy-for-sd-boot.patch
+++ b/vendor/systemd-patches/0069-fundamental-define-size_t-and-memcpy-for-sd-boot.patch
@@ -1,0 +1,104 @@
+From e4e3dec7772171cafae1a128275f8e0997f67d83 Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@microsoft.com>
+Date: Fri, 8 Oct 2021 13:06:51 +0100
+Subject: [PATCH 69/73] fundamental: define size_t and memcpy for sd-boot
+
+---
+ src/fundamental/macro-fundamental.h       | 2 ++
+ src/fundamental/string-util-fundamental.c | 8 ++++----
+ src/fundamental/string-util-fundamental.h | 4 ++--
+ src/fundamental/type.h                    | 3 +--
+ 4 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/src/fundamental/macro-fundamental.h b/src/fundamental/macro-fundamental.h
+index bef1b55cb..e76df3424 100644
+--- a/src/fundamental/macro-fundamental.h
++++ b/src/fundamental/macro-fundamental.h
+@@ -59,6 +59,8 @@
+                 #define assert(expr) ({ _likely_(expr) ? VOID_0 : efi_assert(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__); })
+                 #define assert_not_reached() efi_assert("Code should not be reached", __FILE__, __LINE__, __PRETTY_FUNCTION__)
+         #endif
++
++        #define memcpy(a, b, c) CopyMem((a), (b), (c))
+ #endif
+ 
+ #if defined(static_assert)
+diff --git a/src/fundamental/string-util-fundamental.c b/src/fundamental/string-util-fundamental.c
+index 383e39057..101d3f719 100644
+--- a/src/fundamental/string-util-fundamental.c
++++ b/src/fundamental/string-util-fundamental.c
+@@ -8,7 +8,7 @@
+ #include "string-util-fundamental.h"
+ 
+ sd_char *startswith(const sd_char *s, const sd_char *prefix) {
+-        sd_size_t l;
++        size_t l;
+ 
+         assert(s);
+         assert(prefix);
+@@ -22,7 +22,7 @@ sd_char *startswith(const sd_char *s, const sd_char *prefix) {
+ 
+ #ifndef SD_BOOT
+ sd_char *startswith_no_case(const sd_char *s, const sd_char *prefix) {
+-        sd_size_t l;
++        size_t l;
+ 
+         assert(s);
+         assert(prefix);
+@@ -36,7 +36,7 @@ sd_char *startswith_no_case(const sd_char *s, const sd_char *prefix) {
+ #endif
+ 
+ sd_char* endswith(const sd_char *s, const sd_char *postfix) {
+-        sd_size_t sl, pl;
++        size_t sl, pl;
+ 
+         assert(s);
+         assert(postfix);
+@@ -57,7 +57,7 @@ sd_char* endswith(const sd_char *s, const sd_char *postfix) {
+ }
+ 
+ sd_char* endswith_no_case(const sd_char *s, const sd_char *postfix) {
+-        sd_size_t sl, pl;
++        size_t sl, pl;
+ 
+         assert(s);
+         assert(postfix);
+diff --git a/src/fundamental/string-util-fundamental.h b/src/fundamental/string-util-fundamental.h
+index 7455c0549..dc0c1202b 100644
+--- a/src/fundamental/string-util-fundamental.h
++++ b/src/fundamental/string-util-fundamental.h
+@@ -68,10 +68,10 @@ static inline const sd_char *yes_no(sd_bool b) {
+ sd_int strverscmp_improved(const sd_char *a, const sd_char *b);
+ 
+ /* Like startswith(), but operates on arbitrary memory blocks */
+-static inline void *memory_startswith(const void *p, sd_size_t sz, const sd_char *token) {
++static inline void *memory_startswith(const void *p, size_t sz, const sd_char *token) {
+         assert(token);
+ 
+-        sd_size_t n = strlen(token) * sizeof(sd_char);
++        size_t n = strlen(token) * sizeof(sd_char);
+         if (sz < n)
+                 return NULL;
+ 
+diff --git a/src/fundamental/type.h b/src/fundamental/type.h
+index f645d2de7..2a9a114bb 100644
+--- a/src/fundamental/type.h
++++ b/src/fundamental/type.h
+@@ -7,7 +7,7 @@
+ typedef BOOLEAN sd_bool;
+ typedef CHAR16  sd_char;
+ typedef INTN    sd_int;
+-typedef UINTN   sd_size_t;
++typedef UINTN   size_t;
+ 
+ #define true    TRUE
+ #define false   FALSE
+@@ -18,5 +18,4 @@ typedef UINTN   sd_size_t;
+ typedef bool    sd_bool;
+ typedef char    sd_char;
+ typedef int     sd_int;
+-typedef size_t  sd_size_t;
+ #endif
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0070-Add-support-for-aarch64-booting-via-pe-entry-point.patch
+++ b/vendor/systemd-patches/0070-Add-support-for-aarch64-booting-via-pe-entry-point.patch
@@ -1,0 +1,758 @@
+From 83f4a3cf91ed2ce56cc617247f83e35d3f20b252 Mon Sep 17 00:00:00 2001
+From: Max Resch <resch.max@gmail.com>
+Date: Mon, 11 Oct 2021 15:15:30 +0200
+Subject: [PATCH 70/73] Add support for aarch64 booting via pe-entry point
+
+---
+ src/boot/efi/linux.c     | 227 ++++++++++++++++++++++++++-------------
+ src/boot/efi/linux.h     |  83 +-------------
+ src/boot/efi/linux_x86.c | 200 ++++++++++++++++++++++++++++++++++
+ src/boot/efi/meson.build |   6 +-
+ src/boot/efi/pe.c        |  75 ++++++++++++-
+ src/boot/efi/pe.h        |   6 ++
+ src/boot/efi/stub.c      |   5 +-
+ 7 files changed, 440 insertions(+), 162 deletions(-)
+ create mode 100644 src/boot/efi/linux_x86.c
+
+diff --git a/src/boot/efi/linux.c b/src/boot/efi/linux.c
+index 2c27ed503..98f1db24e 100644
+--- a/src/boot/efi/linux.c
++++ b/src/boot/efi/linux.c
+@@ -1,109 +1,186 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
++/*
++ * Generic Linux boot protocol using the EFI/PE entry point of the kernel. Passes
++ * initrd with the LINUX_INITRD_MEDIA_GUID DevicePath and cmdline with
++ * EFI LoadedImageProtocol.
++ *
++ * This method works for Linux 5.8 and newer on ARM/Aarch64, x86/x68_64 and RISC-V.
++ */
++
+ #include <efi.h>
+ #include <efilib.h>
+ 
+-#include "linux.h"
+ #include "initrd.h"
++#include "linux.h"
++#include "pe.h"
+ #include "util.h"
+ 
+-#ifdef __i386__
+-#define __regparm0__ __attribute__((regparm(0)))
+-#else
+-#define __regparm0__
+-#endif
++static EFI_LOADED_IMAGE * loaded_image_free(EFI_LOADED_IMAGE *img) {
++        if (!img)
++                return NULL;
++        mfree(img->LoadOptions);
++        return mfree(img);
++}
++
++static EFI_STATUS loaded_image_register(
++                const CHAR8 *cmdline, UINTN cmdline_len,
++                const VOID *linux_buffer, UINTN linux_length,
++                EFI_HANDLE *ret_image) {
++
++        EFI_LOADED_IMAGE *loaded_image = NULL;
++        EFI_STATUS err;
++
++        assert(cmdline || cmdline_len > 0);
++        assert(linux_buffer && linux_length > 0);
++        assert(ret_image);
+ 
+-typedef VOID(*handover_f)(VOID *image, EFI_SYSTEM_TABLE *table, struct boot_params *params) __regparm0__;
++        /* create and install new LoadedImage Protocol */
++        loaded_image = AllocatePool(sizeof(EFI_LOADED_IMAGE));
++        if (!loaded_image)
++                return EFI_OUT_OF_RESOURCES;
+ 
+-static VOID linux_efi_handover(EFI_HANDLE image, struct boot_params *params) {
+-        handover_f handover;
+-        UINTN start = (UINTN)params->hdr.code32_start;
++        /* provide the image base address and size */
++        *loaded_image = (EFI_LOADED_IMAGE) {
++                .ImageBase = (VOID *) linux_buffer,
++                .ImageSize = linux_length
++        };
+ 
+-        assert(params);
++        /* if a cmdline is set convert it to UTF16 */
++        if (cmdline) {
++                loaded_image->LoadOptions = stra_to_str(cmdline);
++                if (!loaded_image->LoadOptions) {
++                        loaded_image = loaded_image_free(loaded_image);
++                        return EFI_OUT_OF_RESOURCES;
++                }
++                loaded_image->LoadOptionsSize = StrSize(loaded_image->LoadOptions);
++        }
+ 
+-#ifdef __x86_64__
+-        asm volatile ("cli");
+-        start += 512;
+-#endif
+-        handover = (handover_f)(start + params->hdr.handover_offset);
+-        handover(image, ST, params);
++        /* install a new LoadedImage protocol. ret_handle is a new image handle */
++        err = uefi_call_wrapper(BS->InstallMultipleProtocolInterfaces, 4,
++                        ret_image,
++                        &LoadedImageProtocol, loaded_image,
++                        NULL);
++        if (EFI_ERROR(err))
++                loaded_image = loaded_image_free(loaded_image);
++
++        return err;
++}
++
++static EFI_STATUS loaded_image_unregister(EFI_HANDLE loaded_image_handle) {
++        EFI_LOADED_IMAGE_PROTOCOL *loaded_image;
++        EFI_STATUS err;
++
++        if (!loaded_image_handle)
++                return EFI_SUCCESS;
++
++        /* get the LoadedImage protocol that we allocated earlier */
++        err = uefi_call_wrapper(
++                        BS->OpenProtocol, 6,
++                        loaded_image_handle, &LoadedImageProtocol, (VOID **) &loaded_image,
++                        NULL, NULL, EFI_OPEN_PROTOCOL_GET_PROTOCOL);
++        if (EFI_ERROR(err))
++                return err;
++
++        /* close the handle */
++        (void) uefi_call_wrapper(
++                        BS->CloseProtocol, 4,
++                        loaded_image_handle, &LoadedImageProtocol, NULL, NULL);
++        err = uefi_call_wrapper(BS->UninstallMultipleProtocolInterfaces, 4,
++                        loaded_image_handle,
++                        &LoadedImageProtocol, loaded_image,
++                        NULL);
++        if (EFI_ERROR(err))
++                return err;
++        loaded_image_handle = NULL;
++        loaded_image = loaded_image_free(loaded_image);
++
++        return EFI_SUCCESS;
++}
++
++static inline void cleanup_initrd(EFI_HANDLE *initrd_handle) {
++        (void) initrd_unregister(*initrd_handle);
++        *initrd_handle = NULL;
++}
++
++static inline void cleanup_loaded_image(EFI_HANDLE *loaded_image_handle) {
++        (void) loaded_image_unregister(*loaded_image_handle);
++        *loaded_image_handle = NULL;
++}
++
++/* struct to call cleanup_pages */
++struct pages {
++        EFI_PHYSICAL_ADDRESS addr;
++        UINTN num;
++};
++
++static inline void cleanup_pages(struct pages *p) {
++        if (p->addr == 0)
++                return;
++        (void) uefi_call_wrapper(BS->FreePages, 2, p->addr, p->num);
+ }
+ 
+ EFI_STATUS linux_exec(
+                 EFI_HANDLE image,
+                 const CHAR8 *cmdline, UINTN cmdline_len,
+-                const VOID *linux_buffer,
++                const VOID *linux_buffer, UINTN linux_length,
+                 const VOID *initrd_buffer, UINTN initrd_length) {
+ 
+-        const struct boot_params *image_params;
+-        struct boot_params *boot_params;
+-        EFI_HANDLE initrd_handle = NULL;
+-        EFI_PHYSICAL_ADDRESS addr;
+-        UINT8 setup_sectors;
++        _cleanup_(cleanup_initrd) EFI_HANDLE initrd_handle = NULL;
++        _cleanup_(cleanup_loaded_image) EFI_HANDLE loaded_image_handle = NULL;
++        UINT32 kernel_alignment, kernel_size_of_image, kernel_entry_address;
++        EFI_IMAGE_ENTRY_POINT kernel_entry;
++        _cleanup_(cleanup_pages) struct pages kernel = {};
++        VOID *new_buffer;
+         EFI_STATUS err;
+ 
+         assert(image);
+         assert(cmdline || cmdline_len == 0);
+-        assert(linux_buffer);
++        assert(linux_buffer && linux_length > 0);
+         assert(initrd_buffer || initrd_length == 0);
+ 
+-        image_params = (const struct boot_params *) linux_buffer;
+-
+-        if (image_params->hdr.boot_flag != 0xAA55 ||
+-            image_params->hdr.header != SETUP_MAGIC ||
+-            image_params->hdr.version < 0x20b ||
+-            !image_params->hdr.relocatable_kernel)
+-                return EFI_LOAD_ERROR;
+-
+-        addr = UINT32_MAX; /* Below the 32bit boundary */
+-        err = uefi_call_wrapper(
+-                        BS->AllocatePages, 4,
+-                        AllocateMaxAddress,
+-                        EfiLoaderData,
+-                        EFI_SIZE_TO_PAGES(0x4000),
+-                        &addr);
++        /* get the necessary fields from the PE header */
++        err = pe_alignment_info(linux_buffer, &kernel_entry_address, &kernel_size_of_image, &kernel_alignment);
+         if (EFI_ERROR(err))
+                 return err;
++        /* sanity check */
++        assert(kernel_size_of_image >= linux_length);
++
++        /* Linux kernel complains if it's not loaded at a properly aligned memory address. The correct alignment
++           is provided by Linux as the SegmentAlignment in the PeOptionalHeader. Additionally the kernel needs to
++           be in a memory segment thats SizeOfImage (again from PeOptionalHeader) large, so that the Kernel has
++           space for its BSS section. SizeOfImage is always larger than linux_length, which is only the size of
++           Code, (static) Data and Headers.
++
++           Interrestingly only ARM/Aarch64 and RISC-V kernel stubs check these assertions and can even boot (with warnings)
++           if they are not met. x86 and x86_64 kernel stubs don't do checks and fail if the BSS section is too small.
++        */
++        /* allocate SizeOfImage + SectionAlignment because the new_buffer can move up to Alignment-1 bytes */
++        kernel.num = EFI_SIZE_TO_PAGES(ALIGN_TO(kernel_size_of_image, kernel_alignment) + kernel_alignment);
++        err = uefi_call_wrapper(
++                BS->AllocatePages, 4,
++                AllocateAnyPages, EfiLoaderData,
++                kernel.num, &kernel.addr);
++        if (EFI_ERROR(err))
++                return EFI_OUT_OF_RESOURCES;
++        new_buffer = PHYSICAL_ADDRESS_TO_POINTER(ALIGN_TO(kernel.addr, kernel_alignment));
++        CopyMem(new_buffer, linux_buffer, linux_length);
++        /* zero out rest of memory (probably not needed, but BSS section should be 0) */
++        SetMem((UINT8 *)new_buffer + linux_length, kernel_size_of_image - linux_length, 0);
+ 
+-        boot_params = (struct boot_params *) PHYSICAL_ADDRESS_TO_POINTER(addr);
+-        ZeroMem(boot_params, 0x4000);
+-        boot_params->hdr = image_params->hdr;
+-        boot_params->hdr.type_of_loader = 0xff;
+-        setup_sectors = image_params->hdr.setup_sects > 0 ? image_params->hdr.setup_sects : 4;
+-        boot_params->hdr.code32_start = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(linux_buffer) + (setup_sectors + 1) * 512;
++        /* get the entry point inside the relocated kernel */
++        kernel_entry = (EFI_IMAGE_ENTRY_POINT) ((const UINT8 *)new_buffer + kernel_entry_address);
+ 
+-        if (cmdline) {
+-                addr = 0xA0000;
+-
+-                err = uefi_call_wrapper(
+-                                BS->AllocatePages, 4,
+-                                AllocateMaxAddress,
+-                                EfiLoaderData,
+-                                EFI_SIZE_TO_PAGES(cmdline_len + 1),
+-                                &addr);
+-                if (EFI_ERROR(err))
+-                        return err;
+-
+-                CopyMem(PHYSICAL_ADDRESS_TO_POINTER(addr), cmdline, cmdline_len);
+-                ((CHAR8 *) PHYSICAL_ADDRESS_TO_POINTER(addr))[cmdline_len] = 0;
+-                boot_params->hdr.cmd_line_ptr = (UINT32) addr;
+-        }
+-
+-        /* Providing the initrd via LINUX_INITRD_MEDIA_GUID is only supported by Linux 5.8+ (5.7+ on ARM64).
+-           Until supported kernels become more established, we continue to set ramdisk in the handover struct.
+-           This value is overridden by kernels that support LINUX_INITRD_MEDIA_GUID.
+-           If you need to know which protocol was used by the kernel, pass "efi=debug" to the kernel,
+-           this will print a line when InitrdMediaGuid was successfully used to load the initrd.
+-         */
+-        boot_params->hdr.ramdisk_image = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(initrd_buffer);
+-        boot_params->hdr.ramdisk_size = (UINT32) initrd_length;
++        /* register a LoadedImage Protocol in order to pass on the commandline */
++        err = loaded_image_register(cmdline, cmdline_len, new_buffer, linux_length, &loaded_image_handle);
++        if (EFI_ERROR(err))
++                return err;
+ 
+-        /* register LINUX_INITRD_MEDIA_GUID */
++        /* register a LINUX_INITRD_MEDIA DevicePath to serve the initrd */
+         err = initrd_register(initrd_buffer, initrd_length, &initrd_handle);
+         if (EFI_ERROR(err))
+                 return err;
+-        linux_efi_handover(image, boot_params);
+-        (void) initrd_unregister(initrd_handle);
+-        initrd_handle = NULL;
+-        return EFI_LOAD_ERROR;
++
++        /* call the kernel */
++        return uefi_call_wrapper(kernel_entry, 2, loaded_image_handle, ST);
+ }
+diff --git a/src/boot/efi/linux.h b/src/boot/efi/linux.h
+index 01049d336..e030e4f31 100644
+--- a/src/boot/efi/linux.h
++++ b/src/boot/efi/linux.h
+@@ -2,90 +2,9 @@
+ #pragma once
+ 
+ #include <efi.h>
+-#include "macro-fundamental.h"
+-
+-#define SETUP_MAGIC             0x53726448      /* "HdrS" */
+-
+-struct setup_header {
+-        UINT8  setup_sects;
+-        UINT16 root_flags;
+-        UINT32 syssize;
+-        UINT16 ram_size;
+-        UINT16 vid_mode;
+-        UINT16 root_dev;
+-        UINT16 boot_flag;
+-        UINT16 jump;
+-        UINT32 header;
+-        UINT16 version;
+-        UINT32 realmode_swtch;
+-        UINT16 start_sys_seg;
+-        UINT16 kernel_version;
+-        UINT8  type_of_loader;
+-        UINT8  loadflags;
+-        UINT16 setup_move_size;
+-        UINT32 code32_start;
+-        UINT32 ramdisk_image;
+-        UINT32 ramdisk_size;
+-        UINT32 bootsect_kludge;
+-        UINT16 heap_end_ptr;
+-        UINT8  ext_loader_ver;
+-        UINT8  ext_loader_type;
+-        UINT32 cmd_line_ptr;
+-        UINT32 initrd_addr_max;
+-        UINT32 kernel_alignment;
+-        UINT8  relocatable_kernel;
+-        UINT8  min_alignment;
+-        UINT16 xloadflags;
+-        UINT32 cmdline_size;
+-        UINT32 hardware_subarch;
+-        UINT64 hardware_subarch_data;
+-        UINT32 payload_offset;
+-        UINT32 payload_length;
+-        UINT64 setup_data;
+-        UINT64 pref_address;
+-        UINT32 init_size;
+-        UINT32 handover_offset;
+-} _packed_;
+-
+-/* adapted from linux' bootparam.h */
+-struct boot_params {
+-        UINT8  screen_info[64];         // was: struct screen_info
+-        UINT8  apm_bios_info[20];       // was: struct apm_bios_info
+-        UINT8  _pad2[4];
+-        UINT64 tboot_addr;
+-        UINT8  ist_info[16];            // was: struct ist_info
+-        UINT8  _pad3[16];
+-        UINT8  hd0_info[16];
+-        UINT8  hd1_info[16];
+-        UINT8  sys_desc_table[16];      // was: struct sys_desc_table
+-        UINT8  olpc_ofw_header[16];     // was: struct olpc_ofw_header
+-        UINT32 ext_ramdisk_image;
+-        UINT32 ext_ramdisk_size;
+-        UINT32 ext_cmd_line_ptr;
+-        UINT8  _pad4[116];
+-        UINT8  edid_info[128];          // was: struct edid_info
+-        UINT8  efi_info[32];            // was: struct efi_info
+-        UINT32 alt_mem_k;
+-        UINT32 scratch;
+-        UINT8  e820_entries;
+-        UINT8  eddbuf_entries;
+-        UINT8  edd_mbr_sig_buf_entries;
+-        UINT8  kbd_status;
+-        UINT8  secure_boot;
+-        UINT8  _pad5[2];
+-        UINT8  sentinel;
+-        UINT8  _pad6[1];
+-        struct setup_header hdr;
+-        UINT8  _pad7[0x290-0x1f1-sizeof(struct setup_header)];
+-        UINT32 edd_mbr_sig_buffer[16];  // was: edd_mbr_sig_buffer[EDD_MBR_SIG_MAX]
+-        UINT8  e820_table[20*128];      // was: struct boot_e820_entry e820_table[E820_MAX_ENTRIES_ZEROPAGE]
+-        UINT8  _pad8[48];
+-        UINT8  eddbuf[6*82];            // was: struct edd_info eddbuf[EDDMAXNR]
+-        UINT8  _pad9[276];
+-} _packed_;
+ 
+ EFI_STATUS linux_exec(
+                 EFI_HANDLE image,
+                 const CHAR8 *cmdline, UINTN cmdline_len,
+-                const VOID *linux_buffer,
++                const VOID *linux_buffer, UINTN linux_length,
+                 const VOID *initrd_buffer, UINTN initrd_length);
+diff --git a/src/boot/efi/linux_x86.c b/src/boot/efi/linux_x86.c
+new file mode 100644
+index 000000000..539ad7236
+--- /dev/null
++++ b/src/boot/efi/linux_x86.c
+@@ -0,0 +1,200 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++/*
++ * x86 specific code to for EFI handover boot protocol
++ * Linux kernels version 5.8 and newer support providing the initrd by
++ * LINUX_INITRD_MEDIA_GUID DevicePath. In order to support older kernels too,
++ * this x86 specific linux_exec function passes the initrd by setting the
++ * corresponding fields in the setup_header struct.
++ *
++ * see https://www.kernel.org/doc/html/latest/x86/boot.html
++ */
++
++#include <efi.h>
++#include <efilib.h>
++
++#include "initrd.h"
++#include "linux.h"
++#include "macro-fundamental.h"
++#include "util.h"
++
++#define SETUP_MAGIC             0x53726448      /* "HdrS" */
++
++struct setup_header {
++        UINT8  setup_sects;
++        UINT16 root_flags;
++        UINT32 syssize;
++        UINT16 ram_size;
++        UINT16 vid_mode;
++        UINT16 root_dev;
++        UINT16 boot_flag;
++        UINT16 jump;
++        UINT32 header;
++        UINT16 version;
++        UINT32 realmode_swtch;
++        UINT16 start_sys_seg;
++        UINT16 kernel_version;
++        UINT8  type_of_loader;
++        UINT8  loadflags;
++        UINT16 setup_move_size;
++        UINT32 code32_start;
++        UINT32 ramdisk_image;
++        UINT32 ramdisk_size;
++        UINT32 bootsect_kludge;
++        UINT16 heap_end_ptr;
++        UINT8  ext_loader_ver;
++        UINT8  ext_loader_type;
++        UINT32 cmd_line_ptr;
++        UINT32 initrd_addr_max;
++        UINT32 kernel_alignment;
++        UINT8  relocatable_kernel;
++        UINT8  min_alignment;
++        UINT16 xloadflags;
++        UINT32 cmdline_size;
++        UINT32 hardware_subarch;
++        UINT64 hardware_subarch_data;
++        UINT32 payload_offset;
++        UINT32 payload_length;
++        UINT64 setup_data;
++        UINT64 pref_address;
++        UINT32 init_size;
++        UINT32 handover_offset;
++} _packed_;
++
++/* adapted from linux' bootparam.h */
++struct boot_params {
++        UINT8  screen_info[64];         // was: struct screen_info
++        UINT8  apm_bios_info[20];       // was: struct apm_bios_info
++        UINT8  _pad2[4];
++        UINT64 tboot_addr;
++        UINT8  ist_info[16];            // was: struct ist_info
++        UINT8  _pad3[16];
++        UINT8  hd0_info[16];
++        UINT8  hd1_info[16];
++        UINT8  sys_desc_table[16];      // was: struct sys_desc_table
++        UINT8  olpc_ofw_header[16];     // was: struct olpc_ofw_header
++        UINT32 ext_ramdisk_image;
++        UINT32 ext_ramdisk_size;
++        UINT32 ext_cmd_line_ptr;
++        UINT8  _pad4[116];
++        UINT8  edid_info[128];          // was: struct edid_info
++        UINT8  efi_info[32];            // was: struct efi_info
++        UINT32 alt_mem_k;
++        UINT32 scratch;
++        UINT8  e820_entries;
++        UINT8  eddbuf_entries;
++        UINT8  edd_mbr_sig_buf_entries;
++        UINT8  kbd_status;
++        UINT8  secure_boot;
++        UINT8  _pad5[2];
++        UINT8  sentinel;
++        UINT8  _pad6[1];
++        struct setup_header hdr;
++        UINT8  _pad7[0x290-0x1f1-sizeof(struct setup_header)];
++        UINT32 edd_mbr_sig_buffer[16];  // was: edd_mbr_sig_buffer[EDD_MBR_SIG_MAX]
++        UINT8  e820_table[20*128];      // was: struct boot_e820_entry e820_table[E820_MAX_ENTRIES_ZEROPAGE]
++        UINT8  _pad8[48];
++        UINT8  eddbuf[6*82];            // was: struct edd_info eddbuf[EDDMAXNR]
++        UINT8  _pad9[276];
++} _packed_;
++
++#ifdef __i386__
++#define __regparm0__ __attribute__((regparm(0)))
++#else
++#define __regparm0__
++#endif
++
++typedef VOID(*handover_f)(VOID *image, EFI_SYSTEM_TABLE *table, struct boot_params *params) __regparm0__;
++
++static VOID linux_efi_handover(EFI_HANDLE image, struct boot_params *params) {
++        handover_f handover;
++        UINTN start = (UINTN)params->hdr.code32_start;
++
++        assert(params);
++
++#ifdef __x86_64__
++        asm volatile ("cli");
++        start += 512;
++#endif
++        handover = (handover_f)(start + params->hdr.handover_offset);
++        handover(image, ST, params);
++}
++
++EFI_STATUS linux_exec(
++                EFI_HANDLE image,
++                const CHAR8 *cmdline, UINTN cmdline_len,
++                const VOID *linux_buffer, UINTN linux_length,
++                const VOID *initrd_buffer, UINTN initrd_length) {
++
++        const struct boot_params *image_params;
++        struct boot_params *boot_params;
++        EFI_HANDLE initrd_handle = NULL;
++        EFI_PHYSICAL_ADDRESS addr;
++        UINT8 setup_sectors;
++        EFI_STATUS err;
++
++        assert(image);
++        assert(cmdline || cmdline_len == 0);
++        assert(linux_buffer);
++        assert(initrd_buffer || initrd_length == 0);
++
++        image_params = (const struct boot_params *) linux_buffer;
++
++        if (image_params->hdr.boot_flag != 0xAA55 ||
++            image_params->hdr.header != SETUP_MAGIC ||
++            image_params->hdr.version < 0x20b ||
++            !image_params->hdr.relocatable_kernel)
++                return EFI_LOAD_ERROR;
++
++        addr = UINT32_MAX; /* Below the 32bit boundary */
++        err = uefi_call_wrapper(
++                        BS->AllocatePages, 4,
++                        AllocateMaxAddress,
++                        EfiLoaderData,
++                        EFI_SIZE_TO_PAGES(0x4000),
++                        &addr);
++        if (EFI_ERROR(err))
++                return err;
++
++        boot_params = (struct boot_params *) PHYSICAL_ADDRESS_TO_POINTER(addr);
++        ZeroMem(boot_params, 0x4000);
++        boot_params->hdr = image_params->hdr;
++        boot_params->hdr.type_of_loader = 0xff;
++        setup_sectors = image_params->hdr.setup_sects > 0 ? image_params->hdr.setup_sects : 4;
++        boot_params->hdr.code32_start = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(linux_buffer) + (setup_sectors + 1) * 512;
++
++        if (cmdline) {
++                addr = 0xA0000;
++
++                err = uefi_call_wrapper(
++                                BS->AllocatePages, 4,
++                                AllocateMaxAddress,
++                                EfiLoaderData,
++                                EFI_SIZE_TO_PAGES(cmdline_len + 1),
++                                &addr);
++                if (EFI_ERROR(err))
++                        return err;
++
++                CopyMem(PHYSICAL_ADDRESS_TO_POINTER(addr), cmdline, cmdline_len);
++                ((CHAR8 *) PHYSICAL_ADDRESS_TO_POINTER(addr))[cmdline_len] = 0;
++                boot_params->hdr.cmd_line_ptr = (UINT32) addr;
++        }
++
++        /* Providing the initrd via LINUX_INITRD_MEDIA_GUID is only supported by Linux 5.8+ (5.7+ on ARM64).
++           Until supported kernels become more established, we continue to set ramdisk in the handover struct.
++           This value is overridden by kernels that support LINUX_INITRD_MEDIA_GUID.
++           If you need to know which protocol was used by the kernel, pass "efi=debug" to the kernel,
++           this will print a line when InitrdMediaGuid was successfully used to load the initrd.
++         */
++        boot_params->hdr.ramdisk_image = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(initrd_buffer);
++        boot_params->hdr.ramdisk_size = (UINT32) initrd_length;
++
++        /* register LINUX_INITRD_MEDIA_GUID */
++        err = initrd_register(initrd_buffer, initrd_length, &initrd_handle);
++        if (EFI_ERROR(err))
++                return err;
++        linux_efi_handover(image, boot_params);
++        (void) initrd_unregister(initrd_handle);
++        initrd_handle = NULL;
++        return EFI_LOAD_ERROR;
++}
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index 605221c7e..c99150536 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -39,7 +39,6 @@ systemd_boot_sources = '''
+ '''.split()
+ 
+ stub_sources = '''
+-        linux.c
+         initrd.c
+         splash.c
+         stub.c
+@@ -210,6 +209,11 @@ if have_gnu_efi
+                 '-include', efi_config_h,
+                 '-include', version_h,
+         ]
++        if ['ia32', 'x86_64'].contains(efi_arch)
++                stub_sources += 'linux_x86.c'
++        else
++                stub_sources += 'linux.c'
++        endif
+         if efi_arch == 'x86_64'
+                 compile_args += ['-mno-red-zone',
+                                  '-mno-sse',
+diff --git a/src/boot/efi/pe.c b/src/boot/efi/pe.c
+index 04b4504c2..1309eb13a 100644
+--- a/src/boot/efi/pe.c
++++ b/src/boot/efi/pe.c
+@@ -56,10 +56,46 @@ struct CoffFileHeader {
+         UINT16  Characteristics;
+ } _packed_;
+ 
++#define OPTHDR32_MAGIC 0x10B /* PE32  OptionalHeader */
++#define OPTHDR64_MAGIC 0x20B /* PE32+ OptionalHeader */
++
++struct PeOptionalHeader {
++        UINT16  Magic;
++        UINT8   LinkerMajor;
++        UINT8   LinkerMinor;
++        UINT32  SizeOfCode;
++        UINT32  SizeOfInitializedData;
++        UINT32  SizeOfUninitializeData;
++        UINT32  AddressOfEntryPoint;
++        UINT32  BaseOfCode;
++        union {
++                struct { /* PE32 */
++                        UINT32 BaseOfData;
++                        UINT32 ImageBase32;
++                };
++                UINT64 ImageBase64; /* PE32+ */
++        };
++        UINT32 SectionAlignment;
++        UINT32 FileAlignment;
++        UINT16 MajorOperatingSystemVersion;
++        UINT16 MinorOperatingSystemVersion;
++        UINT16 MajorImageVersion;
++        UINT16 MinorImageVersion;
++        UINT16 MajorSubsystemVersion;
++        UINT16 MinorSubsystemVersion;
++        UINT32 Win32VersionValue;
++        UINT32 SizeOfImage;
++        UINT32 SizeOfHeaders;
++        UINT32 CheckSum;
++        UINT16 Subsystem;
++        UINT16 DllCharacteristics;
++        /* fields with different sizes for 32/64 omitted */
++} _packed_;
++
+ struct PeFileHeader {
+         UINT8   Magic[4];
+         struct CoffFileHeader FileHeader;
+-        /* OptionalHeader omitted */
++        struct PeOptionalHeader OptionalHeader;
+ } _packed_;
+ 
+ struct PeSectionHeader {
+@@ -91,7 +127,7 @@ static inline BOOLEAN verify_pe(const struct PeFileHeader *pe) {
+ static inline UINTN section_table_offset(const struct DosFileHeader *dos, const struct PeFileHeader *pe) {
+         assert(dos);
+         assert(pe);
+-        return dos->ExeHeader + sizeof(struct PeFileHeader) + pe->FileHeader.SizeOfOptionalHeader;
++        return dos->ExeHeader + OFFSETOF(struct PeFileHeader, OptionalHeader) + pe->FileHeader.SizeOfOptionalHeader;
+ }
+ 
+ static VOID locate_sections(
+@@ -122,6 +158,41 @@ static VOID locate_sections(
+         }
+ }
+ 
++EFI_STATUS pe_alignment_info(
++                const VOID *base,
++                UINT32 *ret_entry_point_address,
++                UINT32 *ret_size_of_image,
++                UINT32 *ret_section_alignment) {
++
++        const struct DosFileHeader *dos;
++        const struct PeFileHeader *pe;
++
++        assert(base);
++        assert(ret_entry_point_address);
++        assert(ret_size_of_image);
++        assert(ret_section_alignment);
++
++        dos = (const struct DosFileHeader *) base;
++        if (!verify_dos(dos))
++                return EFI_LOAD_ERROR;
++
++        pe = (const struct PeFileHeader*) ((const UINT8 *)base + dos->ExeHeader);
++        if (!verify_pe(pe))
++                return EFI_LOAD_ERROR;
++
++        *ret_entry_point_address = pe->OptionalHeader.AddressOfEntryPoint;
++
++        if (pe->OptionalHeader.Magic == OPTHDR32_MAGIC) {
++                *ret_size_of_image = pe->OptionalHeader.SizeOfImage;
++                *ret_section_alignment = pe->OptionalHeader.SectionAlignment;
++        } else if (pe->OptionalHeader.Magic == OPTHDR64_MAGIC) {
++                *ret_size_of_image = pe->OptionalHeader.SizeOfImage;
++                *ret_section_alignment = pe->OptionalHeader.SectionAlignment;
++        } else
++                return EFI_UNSUPPORTED;
++        return EFI_SUCCESS;
++}
++
+ EFI_STATUS pe_memory_locate_sections(
+                 const CHAR8 *base,
+                 const CHAR8 **sections,
+diff --git a/src/boot/efi/pe.h b/src/boot/efi/pe.h
+index e35521122..438cfe1b6 100644
+--- a/src/boot/efi/pe.h
++++ b/src/boot/efi/pe.h
+@@ -15,3 +15,9 @@ EFI_STATUS pe_file_locate_sections(
+                 const CHAR8 **sections,
+                 UINTN *offsets,
+                 UINTN *sizes);
++
++EFI_STATUS pe_alignment_info(
++                const VOID *base,
++                UINT32 *ret_entry_point_address,
++                UINT32 *ret_size_of_image,
++                UINT32 *ret_section_alignment);
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index 09171558c..f8735e556 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -152,7 +152,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 NULL,
+         };
+ 
+-        UINTN cmdline_len = 0, initrd_size, credential_initrd_size = 0, sysext_initrd_size = 0;
++        UINTN cmdline_len = 0, linux_size, initrd_size, credential_initrd_size = 0, sysext_initrd_size = 0;
+         _cleanup_freepool_ VOID *credential_initrd = NULL, *sysext_initrd = NULL;
+         EFI_PHYSICAL_ADDRESS linux_base, initrd_base;
+         EFI_LOADED_IMAGE *loaded_image;
+@@ -222,6 +222,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                          &sysext_initrd,
+                          &sysext_initrd_size);
+ 
++        linux_size = szs[SECTION_LINUX];
+         linux_base = POINTER_TO_PHYSICAL_ADDRESS(loaded_image->ImageBase) + addrs[SECTION_LINUX];
+ 
+         initrd_size = szs[SECTION_INITRD];
+@@ -250,7 +251,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         }
+ 
+         err = linux_exec(image, cmdline, cmdline_len,
+-                         PHYSICAL_ADDRESS_TO_POINTER(linux_base),
++                         PHYSICAL_ADDRESS_TO_POINTER(linux_base), linux_size,
+                          PHYSICAL_ADDRESS_TO_POINTER(initrd_base), initrd_size);
+         graphics_mode(FALSE);
+         return log_error_status_stall(err, L"Execution of embedded linux image failed: %r", err);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0071-move-mfree-to-macro-fundamentals.h.patch
+++ b/vendor/systemd-patches/0071-move-mfree-to-macro-fundamentals.h.patch
@@ -1,0 +1,52 @@
+From 9634e49b0e21b0e6ee75b79759b0282045bb3432 Mon Sep 17 00:00:00 2001
+From: Max Resch <resch.max@gmail.com>
+Date: Tue, 12 Oct 2021 01:26:00 +0200
+Subject: [PATCH 71/73] move mfree to macro-fundamentals.h
+
+---
+ src/basic/alloc-util.h              | 6 ------
+ src/fundamental/macro-fundamental.h | 7 +++++++
+ 2 files changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/src/basic/alloc-util.h b/src/basic/alloc-util.h
+index fc3531344..f245fe8c6 100644
+--- a/src/basic/alloc-util.h
++++ b/src/basic/alloc-util.h
+@@ -44,12 +44,6 @@ typedef void (*free_func_t)(void *p);
+ 
+ #define malloc0(n) (calloc(1, (n) ?: 1))
+ 
+-#define mfree(memory)                           \
+-        ({                                      \
+-                free(memory);                   \
+-                (typeof(memory)) NULL;          \
+-        })
+-
+ #define free_and_replace(a, b)                  \
+         ({                                      \
+                 free(a);                        \
+diff --git a/src/fundamental/macro-fundamental.h b/src/fundamental/macro-fundamental.h
+index e76df3424..c965f2dd7 100644
+--- a/src/fundamental/macro-fundamental.h
++++ b/src/fundamental/macro-fundamental.h
+@@ -61,6 +61,7 @@
+         #endif
+ 
+         #define memcpy(a, b, c) CopyMem((a), (b), (c))
++        #define free(a) FreePool(a)
+ #endif
+ 
+ #if defined(static_assert)
+@@ -249,3 +250,9 @@
+  * @x: a string literal.
+  */
+ #define STRLEN(x) (sizeof(""x"") - sizeof(typeof(x[0])))
++
++#define mfree(memory)                           \
++        ({                                      \
++                free(memory);                   \
++                (typeof(memory)) NULL;          \
++        })
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0072-add-support-for-embedding-devicetree.patch
+++ b/vendor/systemd-patches/0072-add-support-for-embedding-devicetree.patch
@@ -1,0 +1,144 @@
+From 387f3a0a9e22a60894736c096ed0d7f2fa234506 Mon Sep 17 00:00:00 2001
+From: Max Resch <resch.max@gmail.com>
+Date: Fri, 15 Oct 2021 14:18:57 +0200
+Subject: [PATCH 72/73] add support for embedding devicetree
+
+---
+ src/boot/efi/devicetree.c | 25 +++++++++++++++++++++++++
+ src/boot/efi/devicetree.h |  2 ++
+ src/boot/efi/meson.build  |  2 +-
+ src/boot/efi/stub.c       | 19 +++++++++++++++++--
+ 4 files changed, 45 insertions(+), 3 deletions(-)
+
+diff --git a/src/boot/efi/devicetree.c b/src/boot/efi/devicetree.c
+index fd4b9c406..d8a279e82 100644
+--- a/src/boot/efi/devicetree.c
++++ b/src/boot/efi/devicetree.c
+@@ -109,6 +109,31 @@ EFI_STATUS devicetree_install(struct devicetree_state *state,
+         return uefi_call_wrapper(BS->InstallConfigurationTable, 2, &EfiDtbTableGuid, PHYSICAL_ADDRESS_TO_POINTER(state->addr));
+ }
+ 
++EFI_STATUS devicetree_install_from_memory(struct devicetree_state *state,
++                const VOID *dtb_buffer, UINTN dtb_length) {
++
++        EFI_STATUS err;
++
++        assert(state);
++        assert(dtb_buffer && dtb_length > 0);
++
++        err = LibGetSystemConfigurationTable(&EfiDtbTableGuid, &state->orig);
++        if (EFI_ERROR(err))
++                return EFI_UNSUPPORTED;
++
++        err = devicetree_allocate(state, dtb_length);
++        if (EFI_ERROR(err))
++                return err;
++
++        CopyMem(PHYSICAL_ADDRESS_TO_POINTER(state->addr), dtb_buffer, dtb_length);
++
++        err = devicetree_fixup(state, dtb_length);
++        if (EFI_ERROR(err))
++                return err;
++
++        return uefi_call_wrapper(BS->InstallConfigurationTable, 2, &EfiDtbTableGuid, PHYSICAL_ADDRESS_TO_POINTER(state->addr));
++}
++
+ void devicetree_cleanup(struct devicetree_state *state) {
+         EFI_STATUS err;
+ 
+diff --git a/src/boot/efi/devicetree.h b/src/boot/efi/devicetree.h
+index 2839cb681..25f93f97f 100644
+--- a/src/boot/efi/devicetree.h
++++ b/src/boot/efi/devicetree.h
+@@ -8,4 +8,6 @@ struct devicetree_state {
+ };
+ 
+ EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE_HANDLE root_dir, CHAR16 *name);
++EFI_STATUS devicetree_install_from_memory(
++                struct devicetree_state *state, const VOID *dtb_buffer, UINTN dtb_length);
+ void devicetree_cleanup(struct devicetree_state *state);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index c99150536..c45b86f17 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -20,6 +20,7 @@ efi_headers = files('''
+ 
+ common_sources = '''
+         assert.c
++        devicetree.c
+         disk.c
+         graphics.c
+         measure.c
+@@ -31,7 +32,6 @@ common_sources = '''
+ systemd_boot_sources = '''
+         boot.c
+         console.c
+-        devicetree.c
+         drivers.c
+         random-seed.c
+         shim.c
+diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
+index f8735e556..1bda47b94 100644
+--- a/src/boot/efi/stub.c
++++ b/src/boot/efi/stub.c
+@@ -4,6 +4,7 @@
+ #include <efilib.h>
+ 
+ #include "cpio.h"
++#include "devicetree.h"
+ #include "disk.h"
+ #include "graphics.h"
+ #include "linux.h"
+@@ -141,6 +142,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 SECTION_LINUX,
+                 SECTION_INITRD,
+                 SECTION_SPLASH,
++                SECTION_DTB,
+                 _SECTION_MAX,
+         };
+ 
+@@ -149,12 +151,15 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 [SECTION_LINUX]   = (const CHAR8*) ".linux",
+                 [SECTION_INITRD]  = (const CHAR8*) ".initrd",
+                 [SECTION_SPLASH]  = (const CHAR8*) ".splash",
++                [SECTION_DTB]     = (const CHAR8*) ".dtb",
+                 NULL,
+         };
+ 
+-        UINTN cmdline_len = 0, linux_size, initrd_size, credential_initrd_size = 0, sysext_initrd_size = 0;
++        UINTN cmdline_len = 0, linux_size, initrd_size, dt_size;
++        UINTN credential_initrd_size = 0, sysext_initrd_size = 0;
+         _cleanup_freepool_ VOID *credential_initrd = NULL, *sysext_initrd = NULL;
+-        EFI_PHYSICAL_ADDRESS linux_base, initrd_base;
++        EFI_PHYSICAL_ADDRESS linux_base, initrd_base, dt_base;
++        _cleanup_(devicetree_cleanup) struct devicetree_state dt_state = {};
+         EFI_LOADED_IMAGE *loaded_image;
+         UINTN addrs[_SECTION_MAX] = {};
+         UINTN szs[_SECTION_MAX] = {};
+@@ -228,6 +233,9 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         initrd_size = szs[SECTION_INITRD];
+         initrd_base = initrd_size != 0 ? POINTER_TO_PHYSICAL_ADDRESS(loaded_image->ImageBase) + addrs[SECTION_INITRD] : 0;
+ 
++        dt_size = szs[SECTION_DTB];
++        dt_base = dt_size != 0 ? POINTER_TO_PHYSICAL_ADDRESS(loaded_image->ImageBase) + addrs[SECTION_DTB] : 0;
++
+         if (credential_initrd || sysext_initrd) {
+                 /* If we have generated initrds dynamically, let's combine them with the built-in initrd. */
+                 err = combine_initrd(
+@@ -250,6 +258,13 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 }
+         }
+ 
++        if (dt_size > 0) {
++                err = devicetree_install_from_memory(
++                                &dt_state, PHYSICAL_ADDRESS_TO_POINTER(dt_base), dt_size);
++                if (EFI_ERROR(err))
++                        log_error_stall(L"Error loading embedded devicetree: %r", err);
++        }
++
+         err = linux_exec(image, cmdline, cmdline_len,
+                          PHYSICAL_ADDRESS_TO_POINTER(linux_base), linux_size,
+                          PHYSICAL_ADDRESS_TO_POINTER(initrd_base), initrd_size);
+-- 
+2.25.1
+

--- a/vendor/systemd-patches/0073-sd-stub-do-not-print-warning-if-filesystem-is-not-su.patch
+++ b/vendor/systemd-patches/0073-sd-stub-do-not-print-warning-if-filesystem-is-not-su.patch
@@ -1,0 +1,52 @@
+From 178d598b5fae36fa9d54c30668771f9c626724f6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alfonso=20S=C3=A1nchez-Beato?=
+ <alfonso.sanchez-beato@canonical.com>
+Date: Thu, 3 Mar 2022 11:42:41 +0100
+Subject: [PATCH] sd-stub: do not print warning if filesystem is not supported
+
+Do not print a warning in case we try to load the file system protocol for an
+unsupported file system, just return EFI_SUCCESS instead.
+---
+ src/boot/efi/cpio.c | 22 +++++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/src/boot/efi/cpio.c b/src/boot/efi/cpio.c
+index 258755366ed7..2855c4119be7 100644
+--- a/src/boot/efi/cpio.c
++++ b/src/boot/efi/cpio.c
+@@ -324,6 +324,7 @@ EFI_STATUS pack_cpio(
+         _cleanup_freepool_ void *buffer = NULL;
+         UINT32 inode = 1; /* inode counter, so that each item gets a new inode */
+         EFI_STATUS err;
++        EFI_FILE_IO_INTERFACE *volume;
+ 
+         assert(loaded_image);
+         assert(target_dir_prefix);
+@@ -336,9 +337,24 @@ EFI_STATUS pack_cpio(
+                 return EFI_SUCCESS;
+         }
+ 
+-        root = LibOpenRoot(loaded_image->DeviceHandle);
+-        if (!root)
+-                return log_error_status_stall(EFI_LOAD_ERROR, L"Unable to open root directory.");
++        err = BS->HandleProtocol(loaded_image->DeviceHandle,
++                                 &FileSystemProtocol, (void*)&volume);
++        /* Error will be unsupported if the bootloader doesn't implement the
++         * file system protocol on its file handles.
++         */
++        if (err == EFI_UNSUPPORTED) {
++                *ret_buffer = NULL;
++                *ret_buffer_size = 0;
++                return EFI_SUCCESS;
++        }
++        if (EFI_ERROR(err))
++                return log_error_status_stall(
++                                err, L"Unable to load file system protocol: %r", err);
++
++        err = volume->OpenVolume(volume, &root);
++        if (EFI_ERROR(err))
++                return log_error_status_stall(
++                                err, L"Unable to open root directory: %r", err);
+ 
+         if (!dropin_dir)
+                 dropin_dir = rel_dropin_dir = xpool_print(L"%D.extra.d", loaded_image->FilePath);


### PR DESCRIPTION
Backport patches for systemd stub from systemd v250. These patches add
support to arm64 kernels by using a new kernel feature [1] for passing
the address of the initramfs to the kernel stub by a special device
path using the LoadFile2 EFI protocol. This feature is now used also
for x86. Support is in kernel 5.7 for arm64 and in 5.8 for x86.

The patches included are those affecting the src/boot/efi/ folder up
to commit [2]. Note that we are patching the Ubuntu package, which
uses as base
https://github.com/systemd/systemd-stable/releases/tag/v249.10 , so
some patches from v250 are already backported there. Additionally,
[3] from post-v250 has been included as well.

When backporting the patches, [4] has not been included because we
need to set a PCR different to the one in grub for measuring kernel
command line. An issue for this problem [5] has been opened in systemd
upstream. Also, [6] was not included either because it touched many
paths outside src/boot/efi/ and it is a cosmetic change.

Finally, some commits that do not touch src/boot/efi/ were also
included as they were needed because they do some refactoring of
macros that affect the sd-stub code. These are:

0003-alloc-util-make-mfree-typesafe.patch 5afcf89ca29b518eb2fa244b015afc2708f77e1d
0004-macro-Move-some-macros-to-macro-fundamental.h.patch f862e847246b5588d9d6ed7d91da11b6adbf39e7
0069-fundamental-define-size_t-and-memcpy-for-sd-boot.patch 5d8a725b0800ce572bb3308c03e98561251a9284
0071-move-mfree-to-macro-fundamentals.h.patch 200b1d997d96179aba9489ce9d373e869557460e

[1] https://github.com/torvalds/linux/commit/ec93fc371f014a6fb483e3556061ecad4b40735c
[2] https://github.com/systemd/systemd/commit/33bc9b756ea9a53c31340a7dcc6bc6b45c0fb2f5
[3] https://github.com/systemd/systemd/commit/178d598b5fae36fa9d54c30668771f9c626724f6
[4] https://github.com/systemd/systemd/commit/faacf1807e8fcbee4bf60495e0145e4522d76393
[5] https://github.com/systemd/systemd/issues/22635
[6] https://github.com/systemd/systemd/commit/fce9abb22793505fbb09eccd0b1e24b5d578dbcc