### PR TITLE
Switch from lz4 to zstd compression

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -80,7 +80,7 @@ def create_initrd(parser, args):
                     shutil.copyfileobj(f, output)
             output.write(
                 subprocess.run(
-                    "find . | cpio --create --quiet --format='newc' --owner=0:0 | lz4 -9 -l",
+                    "find . | cpio --create --quiet --format='newc' --owner=0:0 | zstd -1 -T0",
                     cwd=main,
                     capture_output=True,
                     shell=True,

--- a/debian/control
+++ b/debian/control
@@ -69,7 +69,7 @@ Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf
-Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), lz4, sbsigntool, linux-firmware, llvm
+Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, linux-firmware, llvm
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core
  systems. Currently targetting creating BLS Type2 like binaries.


### PR DESCRIPTION
UC22 kernels support zstd compressed initramfs, and after extensive
analysis the default compression on classic was changed to zstd -1 -T0
(see ubuntu-devel threads and analysis from waveform). This
compression method improves compression ratio, compression speed, as
well as reduces decompression memory required.

Further improvements can be achieved later with firmware and module
compression.