### PR TITLE
Fix overriding of ExecStart for recovery-chooser-trigger

### DIFF
--- a/factory/usr/lib/systemd/system/snapd.recovery-chooser-trigger.service.d/survive-switch-root.conf
+++ b/factory/usr/lib/systemd/system/snapd.recovery-chooser-trigger.service.d/survive-switch-root.conf
@@ -10,4 +10,5 @@ After=sysinit.target
 After=basic.target
 
 [Service]
+ExecStart=
 ExecStart=@/usr/lib/snapd/snap-bootstrap @snap-bootstrap recovery-chooser-trigger


### PR DESCRIPTION
Because ExecStart can be added multiple times, when overriding we need
to reset it. Otherwise it is started first without override, and since
it does not start with `@`, it gets killed during switch.