### PR TITLE
Fix recovery chooser trigger on NUC

### DIFF
--- a/factory/usr/lib/modules-load.d/ubuntu-core-initramfs.conf
+++ b/factory/usr/lib/modules-load.d/ubuntu-core-initramfs.conf
@@ -2,7 +2,7 @@
 i2c-bcm2708
 nvme
 usbhid
-hid-generic
+xhci-pci
 squashfs
 ahci
 libahci

--- a/factory/usr/lib/recovery-chooser-trigger-switch-root
+++ b/factory/usr/lib/recovery-chooser-trigger-switch-root
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eux
+
+kill -USR1 $(systemctl show --property MainPID --value snapd.recovery-chooser-trigger.service)

--- a/factory/usr/lib/systemd/system/initrd-switch-root.target.wants/recovery-chooser-trigger-switchroot.service
+++ b/factory/usr/lib/systemd/system/initrd-switch-root.target.wants/recovery-chooser-trigger-switchroot.service
@@ -1,0 +1,1 @@
+../recovery-chooser-trigger-switchroot.service

--- a/factory/usr/lib/systemd/system/recovery-chooser-trigger-switchroot.service
+++ b/factory/usr/lib/systemd/system/recovery-chooser-trigger-switchroot.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Recovery chooser trigger switch root service
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+Before=initrd-switch-root.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/usr/lib/recovery-chooser-trigger-switch-root

--- a/modules/main/extra-modules.conf
+++ b/modules/main/extra-modules.conf
@@ -1,2 +1,5 @@
 # raspi USB OTG driver, needed for jammy
 dwc2
+# All HID drivers should be available. This is for
+# recovery-chooser-trigger to be able to read keyboards.
+=drivers/hid


### PR DESCRIPTION
We need to chroot when switching root, so we send SIGUSR1 to recovery
chooser trigger.

We need to load all hid drivers. We should not load them into the
kernel though.

This works with https://github.com/snapcore/snapd/pull/11742