### PR TITLE
releasing package ubuntu-core-initramfs version 57

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (57) jammy; urgency=medium
+
+  * Fix cloudimg-rootfs feature in jammy.
+
+ -- Dimitri John Ledkov <dimitri.ledkov@canonical.com>  Mon, 15 Aug 2022 16:09:50 +0100
+
 ubuntu-core-initramfs (56) jammy; urgency=medium
 
   [ Valentin David ]


### PR DESCRIPTION
Upload ubuntu-core-initramfs with cloudimg-rootfs feature fixedup