### PR TITLE
Do not forward journal to console when quiet

### DIFF
--- a/factory/usr/lib/systemd/system-generators/journald-console
+++ b/factory/usr/lib/systemd/system-generators/journald-console
@@ -6,6 +6,10 @@ if [ "$(/usr/libexec/core/get-arg snapd_recovery_mode || true)" != install ]; th
     exit 0
 fi
 
+if /usr/libexec/core/get-arg quiet; then
+    exit 0
+fi
+
 mkdir -p /run/systemd/journald.conf.d
 cat <<EOF >/run/systemd/journald.conf.d/core-override.conf
 [Journal]

--- a/factory/usr/lib/systemd/system-generators/journald-console
+++ b/factory/usr/lib/systemd/system-generators/journald-console
@@ -1,9 +1,13 @@
 #!/bin/sh
-if ! grep -q 'snapd_recovery_mode=install' /proc/cmdline
-then
+
+set -eu
+
+if [ "$(/usr/libexec/core/get-arg snapd_recovery_mode || true)" != install ]; then
     exit 0
 fi
 
 mkdir -p /run/systemd/journald.conf.d
-echo [Journal] >> /run/systemd/journald.conf.d/core-override.conf
-echo ForwardToConsole=true >> /run/systemd/journald.conf.d/core-override.conf
+cat <<EOF >/run/systemd/journald.conf.d/core-override.conf
+[Journal]
+ForwardToConsole=true
+EOF

--- a/factory/usr/lib/the-modeenv
+++ b/factory/usr/lib/the-modeenv
@@ -8,7 +8,7 @@ cp /sysroot/run/image.fstab /run/
 # Always bind-mount all the host filesystems
 mkdir -p /run/mnt/host
 echo '/run/mnt/host /host none rbind 0 0' >> /run/image.fstab
-if grep -q snapd_recovery_mode=run /proc/cmdline; then
+if [ "$(/usr/libexec/core/get-arg snapd_recovery_mode || true)" = run ]; then
     # TODO:UC20: support other bootloaders too
     if [ -f /run/mnt/ubuntu-boot/EFI/ubuntu/grub.cfg ]; then
         echo '/run/mnt/ubuntu-boot/EFI/ubuntu /boot/grub none bind 0 0' >> /run/image.fstab

--- a/factory/usr/libexec/core/get-arg
+++ b/factory/usr/libexec/core/get-arg
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+# Usage:
+#   get-arg param-name
+#
+# get-arg will look for kernel parameter "param-name" or "param_name"
+# and return 0 if found, 1 if not found. If the parameter as a value,
+# e.g. "param-name=the-value", then the value "the-value" will be
+# printed.
+
+# For more information on how to parse kernel parameters, see function
+# `next_arg` in
+# https://github.com/torvalds/linux/blob/master/lib/cmdline.c
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected kernel parameter name as argument" 1>&2
+    exit 1
+fi
+
+looking_for="$(echo "${1}" | sed 's/_/-/g')"
+
+if [ "${SYSTEMD_PROC_CMDLINE:+set}" = set ]; then
+    # Using same debug variable as systemd for testing
+   cmdline="${SYSTEMD_PROC_CMDLINE}"
+else
+   cmdline=$(cat /proc/cmdline)
+fi
+
+set --
+
+# We cannot use ANSI-C quoting (e.g. $'\n') in busybox-initramfs
+whitespaces="$(printf '\t\n\v\f\r \xA0')"
+in_quote=no
+param=
+current="${cmdline}"
+while [ -n "${current}" ]; do
+    # We cannot use subtring parameter expansion
+    # (e.g. ${cmdline:$i:1}) in busybox-initramfs
+    suffix="${current#?}"
+    char="${current%${suffix}}"
+    current="${suffix}"
+    case "${char}" in
+        ["${whitespaces}"])
+            if [ "${in_quote}" = no ]; then
+                if [ -n "${param}" ]; then
+                    set -- "$@" "${param}"
+                fi
+                param=
+            else
+                param="${param}${char}"
+            fi
+            ;;
+        '"')
+            if [ "${in_quote}" = yes ]; then
+                in_quote=no
+            else
+                in_quote=yes
+            fi
+            ;;
+        *)
+            param="${param}${char}"
+            ;;
+    esac
+done
+
+if [ -n "${param}" ]; then
+    set -- "$@" "${param}"
+fi
+
+for param in "$@"; do
+    name="$(echo "${param%%=*}" | sed 's/_/-/g')"
+    if [ "${name}" = "${looking_for}" ]; then
+        case "${param}" in
+            *=*)
+                echo "${param#*=}"
+                ;;
+        esac
+        exit 0
+    fi
+done
+
+exit 1


### PR DESCRIPTION
Also:

Parse /proc/cmdline correctly
    
There is potential quotes in kernel command line and we need to handle those correctly.
    
For more information on how to parse kernel parameters, see function `next_arg` in https://github.com/torvalds/linux/blob/master/lib/cmdline.c
