### PR TITLE
vendor/systemd: maintain stable default net-naming-scheme

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -72,6 +72,7 @@ override_dh_auto_configure:
       -Dwheel-group=false \
       -Ddev-kvm-mode=0660 \
       -Dgroup-render-mode=0660 \
+      -Ddefault-net-naming-scheme=v245 \
       -Ddefault-dnssec=no \
       -Dselinux=true \
       -Ddefault-kill-user-processes=false \


### PR DESCRIPTION
An upcoming systemd sru will introduce additional (future) naming schemes, to ensure backwards compatibility explicitly configure systemd networkd udevd net-naming-scheme to remain the same, at v245, as before.

See related LP & focal classic SRU.