### PR TITLE
modules: include intel drm in initramfs

### DIFF
--- a/modules/main/extra-modules.conf
+++ b/modules/main/extra-modules.conf
@@ -44,3 +44,5 @@ vmd
 xhci-pci-renesas
 # qemu drm (older kernels: bochs_drm)
 bochs
+# intel drm
+i915


### PR DESCRIPTION
So we can have splash with intel GPUs.