### PR TITLE
Fix unit dependencies

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -241,6 +241,8 @@ override_dh_auto_install:
 		rm -r debian/tmp/$$p ;		\
 	done
 	touch debian/tmp/etc/machine-id
+	# This hack should be removed with #113
+	sed -i '/^After=/{;s, *plymouth-start[.]service *, ,;/^After= *$$/d;}' debian/tmp/usr/lib/systemd/system/systemd-ask-password-*
 
 	LD_LIBRARY_PATH=`pwd`/debian/tmp/usr/lib/*/:`pwd`/debian/tmp/usr/lib/systemd `pwd`/debian/tmp/usr/bin/systemd-hwdb --root debian/tmp update --usr --strict
 	rm -rf debian/tmp/usr/lib/udev/hwdb.d

--- a/factory/usr/lib/systemd/system/basic.target.wants/populate-writable.service
+++ b/factory/usr/lib/systemd/system/basic.target.wants/populate-writable.service
@@ -1,1 +1,0 @@
-../populate-writable.service


### PR DESCRIPTION
Break cycle introduced in #102 with plymouth and systemd-password. It was discovered in https://github.com/snapcore/core-initrd/pull/102#issuecomment-1222297471 but was not properly fixed.

Also remove `populate-writable.service` from `basic.target`. It is not needed.