### PR TITLE
factory: populate fstab for classic with modes

### DIFF
--- a/factory/usr/lib/classic/extra-paths
+++ b/factory/usr/lib/classic/extra-paths
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF >>/sysroot/etc/fstab
+/run/mnt/kernel/firmware /usr/lib/firmware none bind,x-initrd.mount 0 0
+/run/mnt/kernel/modules /usr/lib/modules none bind,x-initrd.mount 0 0
+EOF

--- a/factory/usr/lib/systemd/system/detect-classic-sysroot.service
+++ b/factory/usr/lib/systemd/system/detect-classic-sysroot.service
@@ -10,3 +10,4 @@ ConditionPathIsMountPoint=!/run/mnt/base
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/ln -s data /run/mnt/sysroot
+ExecStart=/usr/lib/classic/extra-paths


### PR DESCRIPTION
So we can load firmware/modules coming from the kernel snap. Fixes a regression from https://github.com/snapcore/core-initrd/pull/120.