### PR TITLE
tests: avoid interactions when using apt

### DIFF
--- a/tests/lib/prepare-uc.sh
+++ b/tests/lib/prepare-uc.sh
@@ -30,7 +30,7 @@ if [ ! -f "pc-kernel.artifact" || ! -f "pc-gadget.artifact" ]; then
 
     # install ubuntu-core-initramfs here so the repack-kernel uses the version of
     # ubuntu-core-initramfs we built here
-    apt install -yqq ./ubuntu-core-initramfs*.deb
+    DEBIAN_FRONTEND=noninteractive apt install -yqq ./ubuntu-core-initramfs*.deb
 
     # next repack / modify the snaps we use in the image, we do this for a few 
     # reasons:

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -121,12 +121,12 @@ install_core_initrd_deps() {
     # and for the version of snapd here which we want to use to pull snap-bootstrap
     # from when we build the debian package
     sudo add-apt-repository ppa:snappy-dev/image -y
-    sudo apt update -qq
-    sudo apt upgrade -yqq
+    sudo DEBIAN_FRONTEND=noninteractive apt update -yqq
+    sudo DEBIAN_FRONTEND=noninteractive apt upgrade -yqq
 
     # these are already installed in the lxd image which speeds things up, but they
     # are missing in qemu and google images.
-    sudo apt install initramfs-tools-core psmisc fdisk snapd mtools ovmf qemu-system-x86 sshpass whois openssh-server -yqq
+    sudo DEBIAN_FRONTEND=noninteractive apt install initramfs-tools-core psmisc fdisk snapd mtools ovmf qemu-system-x86 sshpass whois openssh-server -yqq
 
     # use the snapd snap explicitly
     # TODO: since ubuntu-image ships it's own version of `snap prepare-image`, 

--- a/tests/spread/ci/task.yaml
+++ b/tests/spread/ci/task.yaml
@@ -25,8 +25,8 @@ execute: |
     retry -d 1 -t 20 lxc exec $INSTANCE_NAME -- bash -c 'systemctl is-system-running --wait' || true
 
     # we build libtpms and swptm from source and preinstall that in the image for TPM emulation support
-    lxc exec $INSTANCE_NAME -- bash -c "apt update -yqq"
-    lxc exec $INSTANCE_NAME -- bash -c "apt install initramfs-tools-core psmisc fdisk openssh-server whois git coreutils net-tools iproute2 automake software-properties-common autoconf libtool gcc build-essential libssl-dev dh-exec pkg-config dh-autoreconf libtasn1-6-dev libjson-glib-dev libgnutls28-dev expect gawk socat libseccomp-dev make -yqq"
+    lxc exec $INSTANCE_NAME -- bash -c "DEBIAN_FRONTEND=noninteractive apt update -yqq"
+    lxc exec $INSTANCE_NAME -- bash -c "DEBIAN_FRONTEND=noninteractive apt install initramfs-tools-core psmisc fdisk openssh-server whois git coreutils net-tools iproute2 automake software-properties-common autoconf libtool gcc build-essential libssl-dev dh-exec pkg-config dh-autoreconf libtasn1-6-dev libjson-glib-dev libgnutls28-dev expect gawk socat libseccomp-dev make -yqq"
     lxc exec $INSTANCE_NAME -- bash -c "git clone https://github.com/stefanberger/libtpms"
     lxc exec $INSTANCE_NAME -- bash -c "git clone https://github.com/stefanberger/swtpm"
     lxc exec $INSTANCE_NAME -- bash -c "cd libtpms && ./autogen.sh --with-openssl --prefix=/usr --with-tpm2 && make -j4 && make check && make install"

--- a/vendor/systemd/.github/workflows/build_test.sh
+++ b/vendor/systemd/.github/workflows/build_test.sh
@@ -75,7 +75,7 @@ if [[ "$COMPILER" == clang ]]; then
     # ATTOW llvm-11 got into focal-updates, which conflicts with llvm-11
     # provided by the apt.llvm.org repositories. Let's use the system
     # llvm package if available in such cases to avoid that.
-    if ! apt install --dry-run "llvm-$COMPILER_VERSION" >/dev/null; then
+    if ! DEBIAN_FRONTEND=noninteractive apt install --dry-run "llvm-$COMPILER_VERSION" >/dev/null; then
         # Latest LLVM stack deb packages provided by https://apt.llvm.org/
         # Following snippet was partly borrowed from https://apt.llvm.org/llvm.sh
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --yes --dearmor --output /usr/share/keyrings/apt-llvm-org.gpg


### PR DESCRIPTION
Lately CI was failing because of some problem with configuration of openssh-server.