### PR TITLE
debian: add support for building for riscv64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -71,7 +71,7 @@ Standards-Version: 4.4.1
 Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs
-Architecture: amd64 arm64 armhf
+Architecture: amd64 arm64 armhf riscv64
 Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, linux-firmware, llvm
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core

--- a/debian/install
+++ b/debian/install
@@ -2,6 +2,5 @@ bin/ubuntu-core-initramfs usr/bin
 postinst.d etc/kernel/
 snakeoil/* usr/lib/ubuntu-core-initramfs/snakeoil/
 debian/tmp/* usr/lib/ubuntu-core-initramfs/main
-debian/tmp/usr/lib/systemd/boot/efi/linux*.efi.stub usr/lib/ubuntu-core-initramfs/efi/
 debian/sbat.txt usr/lib/ubuntu-core-initramfs/efi/
 modules usr/lib/ubuntu-core-initramfs/

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,12 @@ export DH_VERBOSE=1
 
 include /usr/share/dpkg/default.mk
 
+ifeq ($(DEB_HOST_ARCH),riscv64)
+	USE_EFI:=false
+else
+	USE_EFI:=true
+endif
+
 %:
 	dh $@ --buildsystem=meson+ninja --sourcedirectory=vendor/systemd --with python3
 
@@ -117,7 +123,7 @@ override_dh_auto_configure:
       -Dhibernate=false \
       -Dldconfig=false \
       -Dresolve=false \
-      -Defi=true \
+      -Defi=$(USE_EFI) \
       -Dtpm=true \
       -Dtpm-pcrindex=12 \
       -Denvironment-d=false \
@@ -193,7 +199,7 @@ override_dh_auto_configure:
       -Dpcre2=true \
       -Dglib=false \
       -Ddbus=false \
-      -Dgnu-efi=true \
+      -Dgnu-efi=$(USE_EFI) \
       -Duserdb=false \
       -Dbashcompletiondir=no \
       -Dzshcompletiondir=no \

--- a/debian/rules
+++ b/debian/rules
@@ -334,6 +334,10 @@ ifeq ($(DEB_HOST_ARCH),amd64)
 	mkdir -p debian/ubuntu-core-initramfs/usr/lib/ubuntu-core-initramfs/early/
 	debian/generate-x86-microcode debian/ubuntu-core-initramfs/usr/lib/ubuntu-core-initramfs/early/microcode.cpio
 endif
+ifneq ($(DEB_HOST_ARCH),riscv64)
+	cp -a debian/tmp/usr/lib/systemd/boot/efi/linux*.efi.stub \
+		debian/ubuntu-core-initramfs/usr/lib/ubuntu-core-initramfs/efi/
+endif
 
 override_dh_clean:
 	# Include ubuntu-core plymouth theme in sources


### PR DESCRIPTION
This enables building the `ubuntu-core-initramfs` package for riscv64 platforms, which essentially just means disabling EFI  when building for riscv64. EFI is not currently supported, and there are no headers/packages available for building the functionality. 

