### PR TITLE
Enable riscv64 build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper-compat (= 13), dh-python, python3:any, dracut-core, qui
                gettext,
                gperf,
                git,
-               gnu-efi [amd64 i386 arm64 armhf],
+               gnu-efi [amd64 i386 arm64 armhf riscv64],
                libcap-dev (>= 1:2.24-9~),
                libpam0g-dev,
                libapparmor-dev (>= 2.13) <!stage1>,
@@ -71,7 +71,7 @@ Standards-Version: 4.4.1
 Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs
-Architecture: amd64 arm64 armhf
+Architecture: amd64 arm64 armhf riscv64
 Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, linux-firmware, llvm
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core


### PR DESCRIPTION
The better way to enable riscv64 builds than what was proposed in https://github.com/snapcore/core-initrd/pull/140

With full EFI support as well.

