### PR TITLE
Fix python3-pyparsing build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -52,7 +52,7 @@ Build-Depends: debhelper-compat (= 13), dh-python, python3:any, dracut-core, qui
                python3:native,
                python3-jinja2:native,
                python3-lxml:native,
-               python3-pyparsing:native <!nocheck>,
+               python3-pyparsing:native <!nocheck> | python3-pyparsing <!nocheck>,
                python3-evdev:native <!nocheck>,
                tzdata <!nocheck>,
                libcap2-bin <!nocheck>,


### PR DESCRIPTION
See:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1023363 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1023442

python3-pyparsing switched from Multi-Arch: no to Multi-Arch: foreign in most recent releses. To continue cross-building, the build-dependency must change from python3-pyparsing:native to an arch-unqualified name. Use alternative specification to allow building existing core-initrd on either jammy or lunar, simultaniously. This should unbreak the recipe build.