### PR TITLE
Adapt maintainer scripts for ease of snap automation

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -400,7 +400,7 @@ def create_efi(parser, args):
                 args.output,
             ]
         )
-    os.chmod(args.output, 0o600)
+    os.chmod(args.output, 0o644)
 
 
 def main():

--- a/postinst.d/ubuntu-core-initramfs
+++ b/postinst.d/ubuntu-core-initramfs
@@ -20,7 +20,7 @@ fi
 ubuntu-core-initramfs create-initrd --kernelver $version
 
 case `dpkg --print-architecture` in
-    amd64)
-        ubuntu-core-initramfs create-efi --kernelver $version
+    amd64|arm64)
+        ubuntu-core-initramfs create-efi --unsigned --kernelver $version
         ;;
 esac


### PR DESCRIPTION
As part of automating and producing more kernel snaps for more targets, it is desired to auto-generate kernel.efi as unsigned, and world-readable. Neither unsigned or snakeoil kernel.efi are ever installed on end user systems, and this .deb packaging hook is only used as part of kernel team's build processes.

Also add support for arm64, as we do produce many EFI arm64 snaps already, which use more complicated packaging, because of this missing create-efi call.