### PR TITLE
core22: Add build-conflicts on snapd 2.59.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-core-initramfs (66.1) UNRELEASED; urgency=medium
+
+  * Add build-conflicts on snapd 2.59.3
+  * Add new changelog entry with correct SRU version numbering for jammy
+
+ -- Dimitri John Ledkov <dimitri.ledkov@canonical.com>  Wed, 10 May 2023 11:13:37 +0100
+
 ubuntu-core-initramfs (67) jammy; urgency=medium
 
   * No change rebuild to pick up snapd 2.59.3

--- a/debian/control
+++ b/debian/control
@@ -68,6 +68,7 @@ Build-Depends: debhelper-compat (= 13), dh-python, python3:any, dracut-core, qui
                systemd-bootchart,
                golang-go, indent, libapparmor-dev, libcap-dev, libfuse-dev, libglib2.0-dev, liblzma-dev, liblzo2-dev, libseccomp-dev, libudev-dev, openssh-client, pkg-config, python3, python3-docutils, python3-markdown, squashfs-tools, tzdata, udev, xfslibs-dev
 Standards-Version: 4.4.1
+Build-Conflicts: snapd (= 2.59.3+22.04)
 Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs


### PR DESCRIPTION
add build-conflicts on the snap-bootstrap version that has caused a recent regression. This is a safety precaution to prevent a future missbuilt.

also set a correct, SRU style version number for jammy builds going forward.