### PR TITLE
Add build-conflicts on snapd 2.59.3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -62,6 +62,7 @@ Build-Depends: debhelper-compat (= 12), dh-python, python3:any, dracut-core, qui
                systemd-bootchart,
                golang-go, indent, libapparmor-dev, libcap-dev, libfuse-dev, libglib2.0-dev, liblzma-dev, liblzo2-dev, libseccomp-dev, libudev-dev, openssh-client, pkg-config, python3, python3-docutils, python3-markdown, squashfs-tools, tzdata, udev, xfslibs-dev
 Standards-Version: 4.4.1
+Build-Conflicts: snapd (= 2.59.3+20.04)
 Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs


### PR DESCRIPTION
add build-conflicts on the snap-bootstrap version that has caused a recent regression. This is a safety precaution to prevent a future missbuilt.