### PR TITLE
core20: fix hook permissions

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -161,7 +161,7 @@ def create_efi(parser, args):
                 args.output,
             ]
         )
-    os.chmod(args.output, 0o600)
+    os.chmod(args.output, 0o644)
 
 
 def main():

--- a/postinst.d/ubuntu-core-initramfs
+++ b/postinst.d/ubuntu-core-initramfs
@@ -20,7 +20,7 @@ fi
 ubuntu-core-initramfs create-initrd --kernelver $version
 
 case `dpkg --print-architecture` in
-    amd64)
-        ubuntu-core-initramfs create-efi --kernelver $version
+    amd64|arm64)
+        ubuntu-core-initramfs create-efi --unsigned --kernelver $version
         ;;
 esac


### PR DESCRIPTION
cherry-pick fix from main to ease building & signing kernel.efi snaps