### PR TITLE
WIP: Provide staged packages manifest & built-using

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -73,6 +73,7 @@ Homepage: https://launchpad.net/ubuntu-core-initramfs
 Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf riscv64
 Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, linux-firmware, llvm
+Built-Using: ${generated:Built-Using}
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core
  systems. Currently targetting creating BLS Type2 like binaries.

--- a/debian/generate-primed-stage-packages
+++ b/debian/generate-primed-stage-packages
@@ -1,0 +1,56 @@
+#!/bin/bash
+declare -A binaries
+binaries["busybox-initramfs"]=1
+binaries["snapd"]=1
+binaries["plymouth-label-ft"]=1
+binaries["plymouth-theme-spinner"]=1
+
+if [ -e /usr/sbin/iucode_tool ]; then
+	binaries["intel-microcode"]=1
+	binaries["amd64-microcode"]=1
+fi
+for pf in $(find debian/tmp/usr/lib -type f -name 'lib*.so*'); do
+	[ ! -f $pf ] && continue
+	loc_usrlib=$(echo $pf | sed 's|^debian/tmp/||')
+	loc_lib=$(echo $loc_usrlib | sed 's|^/usr||')
+	bin="$(dpkg-query -S $loc_usrlib $loc_lib 2>/dev/null | sed 's|: .*||')"
+	[ -z "$bin" ] && continue
+	binaries[$bin]=1
+done
+
+for pf in $(find debian/tmp/usr/bin -type f); do
+	[ ! -f $pf ] && continue
+	prog=$(basename $pf)
+	bin="$(dpkg-query -S /usr/bin/$prog /usr/sbin/$prog /bin/$prog /sbin/$prog 2>/dev/null | sed 's|: .*||')"
+	[ -z "$bin" ] && continue
+	binaries[$bin]=1
+done
+
+systemd_ver=$(dpkg-parsechangelog -l vendor/systemd/debian/changelog -SVersion)
+
+declare -A bin_ver
+declare -A src_ver
+for bin in "${!binaries[@]}"; do
+	case $bin in
+		libsystemd0|libudev1|systemd|udev)
+			bin_ver["$bin"]="$systemd_ver"
+			src_ver["systemd"]="$systemd_ver"
+			;;
+		*)
+			pkg="$(dpkg-query -W --showformat='${Package}' $bin)"
+			src="$(dpkg-query -W --showformat='${Source}' $bin)"
+			[ -z "$src" ] && src=$pkg
+			version="$(dpkg-query -W --showformat='${Version}' $bin)"
+			bin_ver["$pkg"]=$version
+			src_ver["$src"]=$version
+			;;
+	esac
+done
+for bin in "${!bin_ver[@]}"; do
+	echo "  $bin=${bin_ver[$bin]}: null"
+done | sort >debian/tmp/primed-stage-packages.txt
+printf "generated:Built-Using=" >>debian/ubuntu-core-initramfs.substvars
+for src in "${!src_ver[@]}"; do
+	printf "$src (= ${src_ver[$src]}), "
+done >>debian/ubuntu-core-initramfs.substvars
+echo >>debian/ubuntu-core-initramfs.substvars

--- a/debian/rules
+++ b/debian/rules
@@ -322,6 +322,7 @@ endif
 	rm -rf debian/tmp/tmp/
 
 override_dh_install:
+	./debian/generate-primed-stage-packages
 	dh_install
 	rm -rf debian/ubuntu-core-initramfs/usr/lib/ubuntu-core-initramfs/main/usr/lib/systemd/boot
 ifeq ($(DEB_HOST_ARCH),amd64)


### PR DESCRIPTION
first of all this is a draft.

second i hate how it is generated.

I do think we will need a build-time and run-time component to it, as there are things that are vendored at build-time, and things that are vendored at runtime.

I aslo think we will not get away from not generating some sort of source & binary manifest, because some things in .deb form need source versions, and others will want the binary components and versions.

This is more of a very WIP thing, rather than ready to merge. I want to prototype this thing a bit more, and experiment with a few snaps first.