### PR TITLE
bin,debian: include snapd bits from the run system

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -273,6 +273,7 @@ def add_modules_from_file(dest_d, kernel_root, modules_d, fw_d, conf_file, db,
 
 
 def create_initrd(parser, args):
+    rootfs = "/"
     if not args.kerneldir:
         args.kerneldir = "/lib/modules/%s" % args.kernelver
     if args.root:
@@ -280,6 +281,7 @@ def create_initrd(parser, args):
         args.kerneldir = path_join_make_rel_paths(args.root, args.kerneldir)
         args.firmwaredir = path_join_make_rel_paths(args.root, args.firmwaredir)
         args.output = path_join_make_rel_paths(args.root, args.output)
+        rootfs = args.root
     if args.kernelver:
         args.output = "-".join([args.output, args.kernelver])
     with tempfile.TemporaryDirectory(suffix=".ubuntu-core-initramfs") as d:
@@ -296,7 +298,7 @@ def create_initrd(parser, args):
         main = os.path.join(d, "main")
         os.makedirs(main, exist_ok=True)
         # Copy snapd bits
-        snapd_lib = "/usr/lib/snapd"
+        snapd_lib = path_join_make_rel_paths(rootfs, "/usr/lib/snapd")
         snapd_files = [os.path.join(snapd_lib, "snap-bootstrap"),
                        os.path.join(snapd_lib, "info"),
                        "/lib/systemd/system/snapd.recovery-chooser-trigger.service"]

--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -293,9 +293,22 @@ def create_initrd(parser, args):
         subprocess.check_call(["cp", "-ar", args.firmwaredir, firmware])
 
         db = ModuleDb(modules)
-        installed_module = set()
         main = os.path.join(d, "main")
         os.makedirs(main, exist_ok=True)
+        # Copy snapd bits
+        snapd_lib = "/usr/lib/snapd"
+        snapd_files = [os.path.join(snapd_lib, "snap-bootstrap"),
+                       os.path.join(snapd_lib, "info"),
+                       "/lib/systemd/system/snapd.recovery-chooser-trigger.service"]
+        for snapd_f in snapd_files:
+            subprocess.check_call(
+                [
+                    "/usr/lib/dracut/dracut-install",
+                    "-D", main,
+                    "--ldd", snapd_f,
+                ]
+            )
+        # Copy features
         for feature in args.features:
             # Add feature files
             feature_path = os.path.join(args.skeleton, feature)

--- a/debian/control
+++ b/debian/control
@@ -66,7 +66,6 @@ Build-Depends: debhelper-compat (= 13), dh-python, python3:any, dracut-core, qui
                kmod,
                libgcc-s1,
                squashfs-tools,
-               snapd (>= 2.50+20.04),
                systemd-bootchart,
                cryptsetup-bin,
                tar,
@@ -77,7 +76,7 @@ Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf riscv64
-Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, linux-firmware, llvm, kcapi-tools
+Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, snapd (>= 2.50+20.04), linux-firmware, llvm, kcapi-tools
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core
  systems. Currently targetting creating BLS Type2 like binaries.

--- a/debian/rules
+++ b/debian/rules
@@ -230,7 +230,6 @@ INSTALL_FILES_FROM_HOST=						\
 	/lib/systemd/system/dbus.socket					\
 	/lib/systemd/system/plymouth-start.service			\
 	/lib/systemd/system/plymouth-switch-root.service		\
-	/lib/systemd/system/snapd.recovery-chooser-trigger.service	\
 	/lib/systemd/systemd-bootchart					\
 	/sbin/cryptsetup						\
 	/sbin/dmsetup							\
@@ -248,8 +247,6 @@ INSTALL_FILES_FROM_HOST=						\
 	/usr/lib/$(DEB_HOST_MULTIARCH)/plymouth/renderers/*.so		\
 	/usr/lib/$(DEB_HOST_MULTIARCH)/plymouth/script.so		\
 	/usr/lib/$(DEB_HOST_MULTIARCH)/plymouth/two-step.so		\
-	/usr/lib/snapd/info						\
-	/usr/lib/snapd/snap-bootstrap					\
 	/usr/sbin/depmod						\
 	/usr/sbin/insmod						\
 	/usr/sbin/lsmod							\
@@ -304,11 +301,6 @@ override_dh_auto_install:
 	cp -a $(CURDIR)/debian/tmp/usr/lib/systemd/libsystemd-shared* $(TEMPLIBDIR)
 	LD_PRELOAD= LD_LIBRARY_PATH=$(TEMPLIBDIR) /usr/lib/dracut/dracut-install -D $(CURDIR)/debian/tmp --ldd $(INSTALL_FILES_FROM_HOST)
 	dpkg -L dmsetup | grep rules.d | xargs -L1 /usr/lib/dracut/dracut-install -D $(CURDIR)/debian/tmp --ldd
-ifeq ($(DEB_HOST_ARCH),amd64)
-	-cp $(CURDIR)/factory/usr/lib/snapd/snap-bootstrap $(CURDIR)/debian/tmp/usr/lib/snapd/snap-bootstrap
-else
-	-rm $(CURDIR)/factory/usr/lib/snapd/snap-bootstrap
-endif
 	ln -v -s e2fsck debian/tmp/usr/sbin/fsck.ext4
 
 	set -e; \
@@ -347,5 +339,3 @@ override_dh_makeshlibs:
 	dh_makeshlibs -Xusr/lib/ubuntu-core-initramfs/main
 override_dh_shlibdeps:
 	dh_shlibdeps -Xusr/lib/ubuntu-core-initramfs/main
-override_dh_strip:
-	dh_strip -Xsnap-bootstrap


### PR DESCRIPTION
Include snap-bootstrap and other files from snapd package when the ubuntu-core-initramfs script is run, instead of when the ubuntu-core-initramfs package is created. So now snapd is a run dependency instead of a build dependency.

Backport of https://github.com/snapcore/core-initrd/pull/167