### PR TITLE
Add mkfs.vfat for u-boot gadgets

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -142,6 +142,7 @@ INSTALL_FILES_FROM_HOST=						\
 	/sbin/fsck							\
 	/sbin/fsck.vfat							\
 	/sbin/mkfs.ext4							\
+	/sbin/mkfs.vfat							\
 	/sbin/sfdisk							\
 	/usr/bin/partx							\
 	/usr/bin/unsquashfs						\


### PR DESCRIPTION
U-boot needs to save `boot.sel` back to the boot partition. Because ext4 is not safe to write on some U-Boot builds due to journal corruption, we need to allow the gadget to create the boot partition as a vfat. Which means `mkfs.vfat` is required during installation.