### PR TITLE
[core22] Add dbus system bus

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Dimitri John Ledkov <xnox@ubuntu.com>
 Build-Depends: debhelper-compat (= 13), dh-python, python3:any, dracut-core, quilt, busybox-initramfs,
                util-linux,
                e2fsprogs,
+               dbus,
                dosfstools,
                dmsetup,
                mount,

--- a/debian/rules
+++ b/debian/rules
@@ -277,6 +277,10 @@ override_dh_auto_install:
 		/usr/sbin/modinfo						\
 		/usr/sbin/modprobe						\
 		/usr/sbin/rmmod							\
+		/usr/bin/dbus-daemon						\
+		/lib/systemd/system/dbus.service				\
+		/lib/systemd/system/dbus.socket					\
+		/usr/share/dbus-1/system.conf					\
 		/usr/sbin/plymouthd						\
 		/usr/bin/plymouth						\
 		/lib/systemd/system/plymouth-start.service			\

--- a/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
+++ b/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
@@ -7,6 +7,9 @@ DefaultDependencies=no
 After=sysinit.target
 Before=initrd-root-device.target
 
+Wants=dbus.socket
+After=dbus.socket
+
 [Service]
 Type=oneshot
 RemainAfterExit=true


### PR DESCRIPTION
D-Bus system bus is needed by `systemd-run --wait`.

Backport of #153