### PR TITLE
[core20] Add dbus system bus

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Dimitri John Ledkov <xnox@ubuntu.com>
 Build-Depends: debhelper-compat (= 12), dh-python, python3:any, dracut-core, quilt, busybox-initramfs,
                util-linux,
                e2fsprogs,
+               dbus,
                dosfstools,
                dmsetup,
                mount,

--- a/debian/rules
+++ b/debian/rules
@@ -134,6 +134,8 @@ INSTALL_FILES_FROM_HOST=						\
 	/lib/$(DEB_HOST_MULTIARCH)/libgcc_s.so.1			\
 	/lib/$(DEB_HOST_MULTIARCH)/libnss_compat.so.*			\
 	/lib/$(DEB_HOST_MULTIARCH)/libnss_files.so.*			\
+	/lib/systemd/system/dbus.service				\
+	/lib/systemd/system/dbus.socket					\
 	/lib/systemd/system/snapd.recovery-chooser-trigger.service	\
 	/lib/systemd/systemd-bootchart					\
 	/sbin/cryptsetup						\
@@ -144,10 +146,12 @@ INSTALL_FILES_FROM_HOST=						\
 	/sbin/mkfs.ext4							\
 	/sbin/mkfs.vfat							\
 	/sbin/sfdisk							\
+	/usr/bin/dbus-daemon						\
 	/usr/bin/partx							\
 	/usr/bin/unsquashfs						\
 	/usr/lib/snapd/info						\
-	/usr/lib/snapd/snap-bootstrap
+	/usr/lib/snapd/snap-bootstrap					\
+	/usr/share/dbus-1/system.conf
 
 override_dh_auto_install: TEMPLIBDIR := $(shell mktemp -d)
 override_dh_auto_install:

--- a/factory/usr/lib/systemd/system/the-tool.service
+++ b/factory/usr/lib/systemd/system/the-tool.service
@@ -8,6 +8,9 @@ Wants=systemd-modules-load.service
 After=systemd-udev-settle.service
 Wants=systemd-udev-settle.service
 
+Wants=dbus.socket
+After=dbus.socket
+
 [Service]
 Type=oneshot
 RemainAfterExit=true


### PR DESCRIPTION
D-Bus system bus is needed by `systemd-run --wait`.

Backport of #153 