### PR TITLE
Xnox/core20 no arm64 efi again

### DIFF
--- a/postinst.d/ubuntu-core-initramfs
+++ b/postinst.d/ubuntu-core-initramfs
@@ -19,8 +19,10 @@ fi
 
 ubuntu-core-initramfs create-initrd --kernelver $version
 
+# Note focal's systemd & objcopy fail on arm64
+# Do not enable arm64, regressed twice now
 case `dpkg --print-architecture` in
-    amd64|arm64)
+    amd64)
         ubuntu-core-initramfs create-efi --unsigned --kernelver $version
         ;;
 esac


### PR DESCRIPTION
Most recent postinst.d change regressed on arm64 495af1406b580dcfffdbe6373c22ad16131a6b23

Like it did before in 0986f75dd1a2b9f809cda289271ec4db3b85e1cb and 0697a930371e52c972c0ac7342e3af7b48abcb97