### PR TITLE
Add fdisk build-depends for /sbin/sfdisk vendor

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Dimitri John Ledkov <xnox@ubuntu.com>
 Build-Depends: debhelper-compat (= 13), dh-python, python3:any, dracut-core, quilt, busybox-initramfs,
                util-linux,
                e2fsprogs,
+               fdisk,
                dbus,
                dosfstools,
                dmsetup,


### PR DESCRIPTION
Otherwise ubuntu-core-initramfs FTBFS in mantic.

Fixes: https://github.com/snapcore/core-initrd/pull/180