### PR TITLE
Accept ubuntu_core.bootchart as alias for core.bootchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ where we use the default pocket although again it might vary.
 
 # Bootchart
 
-It is possible to enable bootcharts by adding `core.bootchart` to the
-kernel command line. The sample collector will run until the systemd
-switches root, and the chart will be saved in `/run/log`. If
+It is possible to enable bootcharts by adding `ubuntu_core.bootchart`
+to the kernel command line. The sample collector will run until the
+systemd switches root, and the chart will be saved in `/run/log`. If
 bootcharts are also enabled for the core snap, that file will be
 eventually moved to the `ubuntu-save` partition (see Core snap
 documentation).

--- a/factory/usr/lib/systemd/system/systemd-bootchart-quit.service
+++ b/factory/usr/lib/systemd/system/systemd-bootchart-quit.service
@@ -2,7 +2,8 @@
 Description=Stop Boot Process Profiler
 DefaultDependencies=no
 Before=initrd-switch-root.service
-ConditionKernelCommandLine=core.bootchart
+ConditionKernelCommandLine=|core.bootchart
+ConditionKernelCommandLine=|ubuntu_core.bootchart
 
 [Service]
 Type=oneshot

--- a/factory/usr/lib/systemd/system/systemd-bootchart.service
+++ b/factory/usr/lib/systemd/system/systemd-bootchart.service
@@ -2,7 +2,8 @@
 Description=Boot Process Profiler
 Documentation=man:systemd-bootchart.service(1) man:bootchart.conf(5)
 DefaultDependencies=no
-ConditionKernelCommandLine=core.bootchart
+ConditionKernelCommandLine=|core.bootchart
+ConditionKernelCommandLine=|ubuntu_core.bootchart
 
 [Service]
 ExecStartPre=/usr/sbin/mkdir -p /run/log


### PR DESCRIPTION
To keep consistency with other kernel command line settings.