### PR TITLE
core22: Nullboot doesn't seal cmdline yet, thus it must be baked in.

### DIFF
--- a/postinst.d/ubuntu-core-initramfs
+++ b/postinst.d/ubuntu-core-initramfs
@@ -21,6 +21,13 @@ ubuntu-core-initramfs create-initrd --kernelver $version
 
 case `dpkg --print-architecture` in
     amd64|arm64)
-        ubuntu-core-initramfs create-efi --unsigned --kernelver $version
-        ;;
+	case $version in
+	    *-azure)
+		# Currently nullboot doesn't seal cmdline, thus it must be baked in for azure
+		ubuntu-core-initramfs create-efi --unsigned --kernelver $version --cmdline "snapd_recovery_mode=cloudimg-rootfs console=tty1 console=ttyS0 earlyprintk=ttyS0"
+		;;
+	    *)
+		ubuntu-core-initramfs create-efi --unsigned --kernelver $version
+		;;
+	esac
 esac


### PR DESCRIPTION
Also see https://github.com/canonical/nullboot/issues/53

Previously kernel.efi for azure passed in cmdline argument, but I'm now trying to standardtize creation of all kernel.efi, thus it would be best to move this change here for now.

Pull request for main is at https://github.com/snapcore/core-initrd/pull/194