### PR TITLE
FIPS: also support HMAC checking on FIT images

### DIFF
--- a/fips/usr/lib/systemd/system/snap-initramfs-mounts.service.d/fips-efi.conf
+++ b/fips/usr/lib/systemd/system/snap-initramfs-mounts.service.d/fips-efi.conf
@@ -1,7 +1,11 @@
 [Unit]
 After=systemd-modules-load.service
 
+# This is for kernels that use an EFI UKI
+ConditionFirmware=uefi
+
 [Service]
+
 # Ensure tcrypt was loaded
 ExecStartPre=modprobe tcrypt
 # Then allow snap-bootstrap to mount things

--- a/fips/usr/lib/systemd/system/snap-initramfs-mounts.service.d/fips-img.conf
+++ b/fips/usr/lib/systemd/system/snap-initramfs-mounts.service.d/fips-img.conf
@@ -1,0 +1,15 @@
+[Unit]
+After=systemd-modules-load.service
+
+# This is for kernels that are not booted from an EFI environment. This probably
+# means a FIT image on arm64.
+ConditionFirmware=!uefi
+
+[Service]
+
+# Ensure tcrypt was loaded
+ExecStartPre=modprobe tcrypt
+# Then allow snap-bootstrap to mount things
+# Self-test verify FIPS computed hmac
+ExecStartPost=kcapi-hasher -n sha512hmac --check /run/mnt/kernel/.kernel.img.hmac
+# On failure, emergency.target is triggered with 10 second delay


### PR DESCRIPTION
@xnox initially wrote these units to check for a hmac that is named .kernel.efi.hmac. This is correct for all systems that boot EFI UKIs. However, potentially some arm64 systems might not use EFI UKIs, but rather FIT images which we standardly name kernel.img (hence HMAC would be .kernel.img.hmac)

This (potentially naively) assumes the kernel image on any non-EFI system is named kernel.img. I think this is effectively true at the moment, especially for the subset of things we actually validate kernels for. 

This probably also should be merged into the core22 branch. It cannot go to core20 though, as ConditionFirmware was introduced into systemd after 20.04