### PR TITLE
factory: create mount units specific to classic

### DIFF
--- a/factory/usr/lib/systemd/system/classic-mounts.service
+++ b/factory/usr/lib/systemd/system/classic-mounts.service
@@ -7,10 +7,10 @@ DefaultDependencies=no
 
 Requires=initrd-root-fs.target
 After=initrd-root-fs.target
+Before=initrd-fs.target
 
 [Service]
 Type=oneshot
 # We force re-running kernel-snap-generator
 ExecStart=systemctl daemon-reload
-StandardOutput=journal+console
 StandardError=journal+console

--- a/factory/usr/lib/systemd/system/classic-mounts.service
+++ b/factory/usr/lib/systemd/system/classic-mounts.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Create mount units specific to classic
+OnFailure=emergency.target
+OnFailureJobMode=replace-irreversibly
+
+DefaultDependencies=no
+
+Requires=initrd-root-fs.target
+After=initrd-root-fs.target
+
+[Service]
+Type=oneshot
+# We force re-running kernel-snap-generator
+ExecStart=systemctl daemon-reload
+StandardOutput=journal+console
+StandardError=journal+console

--- a/factory/usr/lib/systemd/system/detect-classic-sysroot.service
+++ b/factory/usr/lib/systemd/system/detect-classic-sysroot.service
@@ -3,6 +3,7 @@ Description=Detect Ubuntu classic sysroot
 DefaultDependencies=no
 Before=initrd-root-device.target
 After=snap-initramfs-mounts.service
+Wants=classic-mounts.service
 
 ConditionPathIsMountPoint=!/run/mnt/base
 

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -124,11 +124,11 @@ install_core_initrd_deps() {
     sudo add-apt-repository ppa:snappy-dev/image -y
     sudo DEBIAN_FRONTEND=noninteractive apt update -yqq
     sudo apt-mark hold grub-efi-amd64-signed
-    sudo DEBIAN_FRONTEND=noninteractive apt upgrade -yqq
+    sudo DEBIAN_FRONTEND=noninteractive apt upgrade -o Dpkg::Options::="--force-confnew" -yqq
 
     # these are already installed in the lxd image which speeds things up, but they
     # are missing in qemu and google images.
-    sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends psmisc fdisk snapd mtools ovmf qemu-system-x86 sshpass whois openssh-server -yqq
+    sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -o Dpkg::Options::="--force-confnew" psmisc fdisk snapd mtools ovmf qemu-system-x86 sshpass whois openssh-server -yqq
 
     # use the snapd snap explicitly
     # TODO: since ubuntu-image ships it's own version of `snap prepare-image`, 


### PR DESCRIPTION
On mantic, systemd has changed behavior and it does not run daemon-reload from the initrd-parse-etc service if there is nothing that specifically needs that in /etc/fstab, so we were not running kernel-snap-generator again at this point, which meant we did not mount /lib/{modules,firmware} on classic systems. To fix that, force re-running the generators from a service that runs after we have the needed mountpoints.

With this kernel modules can be loaded again and snapd.seeded can progress on classic systems.