### PR TITLE
[backport] Persist device mapper devices in udev database

### DIFF
--- a/factory/usr/lib/udev/rules.d/56-persist-device-mapper.rules
+++ b/factory/usr/lib/udev/rules.d/56-persist-device-mapper.rules
@@ -1,0 +1,8 @@
+# 55-dm.rules will disable in the main boot, all device mapper block
+# devices that are cold plugged. This rule file states that to keep a
+# dm device that was initialized in initrd, we are required to keep
+# its database. To prevent initrd-udevadm-cleanup-db.service from
+# removing the device from the database, we have to make all device
+# mapper block device as "db_persist".
+
+SUBSYSTEM=="block", KERNEL=="dm-[0-9]*", ACTION=="add|change", OPTIONS+="db_persist"


### PR DESCRIPTION
Note that while we do not plan to bring systemd re-exec in UC20, this fix does fix the state of dev mapper devices. Without this fix, they are disabled with `SYSTEMD_READY=0` while being dependencies of inferred mount units, which can be problematic in some cases.

The following is the commit message:

55-dm.rules will disable cold plugged device mapper block devices.  In order for it not to disable them we need to keep the state from initrd to main boot. That is we need to mark the devices as `persist_db` so that initrd-udevadm-cleanup-db.service does not remove it.

When a device mapper device gets disabled, then all systemd mounts with BindsTo to the device will get unmounted, as well as all bind mounts that depend on it. Which causes a catastrophic failure of Ubuntu Core.

As a work-around for this issue we have used a stateless reexecution of systemd. This was making systemd forget about encrypted mount units and thus did not trigger unmount when devices were taken down.

Now that we mark the device mapper devices as `persist_db`, this work-around is not needed anymore.

Tested on:
 - qemu x86_64 without secure boot
 - qemu x86_64 with secure boot
 - intel nuc with secure boot
 - raspberry pi 4

The mounts in `/proc/mounts` are the same as before the fix, except than now `systemd-mount --list` properly lists device mapper mounts.

This commit does not contain the removal of the stateless reexecutil work around.