### PR TITLE
core22: On arm64, attempt to decompress vmlinuz automatically.

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -367,6 +367,17 @@ def create_efi(parser, args):
         args.initrd = "-".join([args.initrd, args.kernelver])
         args.output = "-".join([args.output, args.kernelver])
 
+        if platform.machine() == "aarch64":
+            import gzip
+            raw_kernel=tempfile.NamedTemporaryFile(mode='wb')
+            try:
+                with gzip.open(args.kernel, 'rb') as comp_kernel:
+                    shutil.copyfileobj(comp_kernel, raw_kernel)
+                raw_kernel.flush()
+                args.kernel = raw_kernel.name
+            except gzip.BadGzipFile:
+                pass
+
     # kernel.efi sections will be aligned to the page size by llvm-objcopy
     # (which is the default value for SectionAlignment in the PE header).
     # --set-section-flags are such so added COFF sections have flags:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (66.5) jammy; urgency=medium
+
+  * On arm64, attempt to decompress vmlinuz automatically.
+
+ -- Dimitri John Ledkov <dimitri.ledkov@canonical.com>  Thu, 14 Sep 2023 17:54:41 +0100
+
 ubuntu-core-initramfs (66.4) jammy; urgency=medium
 
   [ Dimitri John Ledkov ]


### PR DESCRIPTION
This removes requirement to gzip decompress kernels before creating kernel.efi on arm.