### PR TITLE
Add mkfs.vfat for u-boot gadgets

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,6 +26,7 @@ INSTALL_FILES_FROM_HOST=					\
 	/sbin/fsck.vfat						\
 	/sbin/fsck.vfat						\
 	/sbin/mkfs.ext4						\
+	/sbin/mkfs.vfat						\
 	/sbin/sfdisk						\
 	/usr/bin/dbus-daemon					\
 	/usr/bin/mountpoint					\


### PR DESCRIPTION
Same as #176, but for main branch.

U-boot needs to save `boot.sel` back to the boot partition. Because ext4 is not safe to write on some U-Boot builds due to journal corruption, we need to allow the gadget to create the boot partition as a vfat. Which means `mkfs.vfat` is required during installation.

