### PR TITLE
factory: handle properly snapd_recovery_mode based on modeenv value

### DIFF
--- a/factory/usr/lib/systemd/system-generators/journald-console
+++ b/factory/usr/lib/systemd/system-generators/journald-console
@@ -2,7 +2,11 @@
 
 set -eu
 
-if [ "$(/usr/libexec/core/get-arg snapd_recovery_mode || true)" != install ]; then
+mode="$(/usr/libexec/core/get-mode mode)" || mode="$(/usr/libexec/core/get-arg snapd_recovery_mode)" || mode="run"
+
+if [ "${mode}" = "run" ]; then
+    # remove any previous overrides
+    rm -rf /run/systemd/journald.conf.d/core-override.conf
     exit 0
 fi
 


### PR DESCRIPTION
The real source of true for the current mode is stored in `/var/lib/snapd/modeenv `this value might be altered after
`/usr/lib/systemd/system-generators/journald-console` was already run.
Or `/var/lib/snapd/modeenv` did not even exist at that time.
This happens in `install`/`factory-reset`/`recovery` modes which might be handled within the initrd.
If this is detected, update `journald-console` generator and remove already created `journald.conf.d/core-override.conf` config overlay.