### PR TITLE
factory: handle properly snapd_recovery_mode based on modeenv value

### DIFF
--- a/factory/usr/lib/systemd/system-generators/journald-console
+++ b/factory/usr/lib/systemd/system-generators/journald-console
@@ -1,6 +1,10 @@
 #!/bin/sh
-if ! grep -q 'snapd_recovery_mode=install' /proc/cmdline
-then
+
+mode="$(/usr/libexec/core/get-mode mode)" || mode="$(/usr/libexec/core/get-arg snapd_recovery_mode)" || mode="run"
+
+if [ "${mode}" = "run" ]; then
+    # remove any previous overrides
+    rm -rf /run/systemd/journald.conf.d/core-override.conf
     exit 0
 fi
 

--- a/factory/usr/lib/the-modeenv
+++ b/factory/usr/lib/the-modeenv
@@ -19,6 +19,13 @@ if [ "${mode}" = "run" ]; then
     elif [ -f /run/mnt/ubuntu-boot/uboot/ubuntu/boot.sel ]; then
         echo '/run/mnt/ubuntu-boot/uboot/ubuntu /boot/uboot none bind 0 0' >> /run/image.fstab
     fi
+    # if there is override for journald.conf, remove it, it has ForwardToConsole=true
+    # also modify generator, as current mode is now new run mode
+    if [ -f /run/systemd/journald.conf.d/core-override.conf ]; then
+        rm /run/systemd/journald.conf.d/core-override.conf
+        cmdline_mode="$(/usr/libexec/core/get-arg snapd_recovery_mode)
+        sed -i 's/snapd_recovery_mode=run/snapd_recovery_mode='"${cmdline_mode}"'/g' /usr/lib/systemd/system-generators/journald-console
+    fi
 fi
 mount -o bind /run/image.fstab /sysroot/etc/fstab
 umount -lf /sysroot/run


### PR DESCRIPTION
The real source of true for the current mode is stored in `/var/lib/snapd/modeenv `this value might be altered after
`/usr/lib/systemd/system-generators/journald-console` was already run.
Or `/var/lib/snapd/modeenv` did not even exist at that time.
This happens in `install`/`factory-reset`/`recovery` modes which might be handled within the initrd.
If this is detected, update `journald-console` generator and remove already created `journald.conf.d/core-override.conf` config overlay.