### PR TITLE
modules/main: enable USB HOST support for MediaTek mt8195-demo platform.

### DIFF
--- a/modules/main/extra-modules.conf
+++ b/modules/main/extra-modules.conf
@@ -37,6 +37,10 @@ sdhci-iproc
 ## in-theory boot on raspi with the right dtb, so just keep it in by
 ## default
 vc4
+# MediaTek SOC Peripherals
+nvmem_mtk-efuse
+mt6360_charger
+mtk-pmic-wrap
 # All HID drivers should be available. This is for
 # recovery-chooser-trigger to be able to read keyboards.
 =drivers/hid


### PR DESCRIPTION
These drivers are required for USB HOST for mt8195-demo board. 
mt6360_charger
mtk-pmic-wrap
nvmem_mtk-efuse

https://bugs.launchpad.net/ubuntu/+source/initramfs-tools/+bug/2038512