### PR TITLE
ubuntu-core-initramfs: Fix discovery of compressed modules

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -80,9 +80,13 @@ class ModuleDb:
 
         for root, dirs, files in os.walk(module_path):
             for f in files:
-                name, ext = os.path.splitext(f)
-                if ext == '.ko':
-                    self._modules[name] = ModuleDb.ModuleInfo(False, [], [])
+                if f.endswith('.ko'):
+                    name, _ = os.path.splitext(f)
+                elif '.ko.' in f:
+                    name, _ = f.split('.ko.', maxsplit=1)
+                else:
+                    continue
+                self._modules[name] = ModuleDb.ModuleInfo(False, [], [])
 
         for alias, target in ModuleDb.__each_alias(os.path.join(module_path, "modules.alias")):
             try:


### PR DESCRIPTION
Now modules are compressed and have extension .ko.zstd. We need to ignore the compression extension. 

The module database was not properly generated, and was causing spurious error messages. (That database is only to find errors).