### PR TITLE
bin/ubuntu-core-initramfs: Fix systemd package file paths

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -320,7 +320,7 @@ def install_systemd_files(dest_dir):
     # * udev rules
     # * Configuration for systemd-tmpfiles
     # TODO: some of this can be cleaned up
-    to_include = re.compile(r"^/lib/systemd/system|"
+    to_include = re.compile(r"^(/usr)?/lib/systemd/system|"
                             r".*/modprobe\.d/|"
                             r".*/sysctl\.d/|"
                             r".*/rules\.d/|"


### PR DESCRIPTION
In Noble, systemd package files moved from /lib to /usr/lib, account for that.