### PR TITLE
ubuntu-core-initramfs: fix path to /sbin/modprobe

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -464,6 +464,8 @@ def install_misc(dest_dir):
     # /sbin/modprobe is a static path in the kernel
     os.makedirs(os.path.join(dest_dir, "sbin"))
     os.symlink("../usr/sbin/modprobe", os.path.join(dest_dir, "sbin", "modprobe"))
+    # FIXME: systemd is configured with the wrong path to dmsetup
+    os.symlink("../usr/sbin/dmsetup", os.path.join(dest_dir, "sbin", "dmsetup"))
 
 def create_initrd(parser, args):
     # TODO generate microcode instead of shipping in debian package

--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -461,6 +461,9 @@ def install_misc(dest_dir):
     # Build ld cache
     check_call(["ldconfig", "-r", dest_dir])
 
+    # /sbin/modprobe is a static path in the kernel
+    os.makedirs(os.path.join(dest_dir, "sbin"))
+    os.symlink("../usr/sbin/modprobe", os.path.join(dest_dir, "sbin", "modprobe"))
 
 def create_initrd(parser, args):
     # TODO generate microcode instead of shipping in debian package

--- a/factory/usr/lib/systemd/system/sysroot-usr-lib-firmware.mount.d/what.conf
+++ b/factory/usr/lib/systemd/system/sysroot-usr-lib-firmware.mount.d/what.conf
@@ -1,0 +1,4 @@
+[Mount]
+# systemd-fstab-generator tries to be smart and uses
+# /sysroot/run/mnt/kernel/firmware, so we need to set the path
+What=/run/mnt/kernel/firmware

--- a/factory/usr/lib/systemd/system/sysroot-usr-lib-modules.mount.d/what.conf
+++ b/factory/usr/lib/systemd/system/sysroot-usr-lib-modules.mount.d/what.conf
@@ -1,0 +1,4 @@
+[Mount]
+# systemd-fstab-generator tries to be smart and uses
+# /sysroot/run/mnt/kernel/modules, so we need to set the path
+What=/run/mnt/kernel/modules


### PR DESCRIPTION
The kernel will call specifically path `/sbin/modprobe`. So we need to make sure this path exists and points to modprobe.