### PR TITLE
factory: do not mount /lib/{modules,firmware} if there is a drivers tree

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,7 +99,7 @@ jobs:
           echo "************* DOWNLOADING SNAPS *************"
           download_core_initrd_snaps 'edge'
 
-          echo "************* PREPAREING CORE24 IMAGE *************"
+          echo "************* PREPARING CORE24 IMAGE *************"
           rm -f "upstream-pc-kernel.snap" "upstream-pc-gadget.snap"
           mv "pc-kernel.artifact" "upstream-pc-kernel.snap"
           mv "pc-gadget.artifact" "upstream-pc-gadget.snap"

--- a/factory/usr/lib/core/extra-paths
+++ b/factory/usr/lib/core/extra-paths
@@ -2,8 +2,21 @@
 
 set -eu
 
-cat <<EOF >>/sysroot/etc/fstab
+cat <<'EOF' >>/sysroot/etc/fstab
 /run/mnt/data /writable none bind,x-initrd.mount 0 0
+EOF
+
+# Find out kernel name / revision
+kernelPath=$(cat /sys/dev/block/"$(mountpoint --fs-devno /run/mnt/kernel)"/loop/backing_file)
+kernelFile=$(basename "$kernelPath")
+kernelName=${kernelFile%%_*}
+rev=${kernelFile#*_}
+rev=${rev%%.*}
+
+# Mount /lib/{firmware,modules} only if there is no drivers tree created by snapd
+if [ ! -d /run/mnt/data/system-data/var/lib/snapd/kernel/"$kernelName"/"$rev" ]; then
+    cat <<'EOF' >>/sysroot/etc/fstab
 /run/mnt/kernel/firmware /usr/lib/firmware none bind,x-initrd.mount 0 0
 /run/mnt/kernel/modules /usr/lib/modules none bind,x-initrd.mount 0 0
 EOF
+fi

--- a/factory/usr/lib/systemd/system-generators/kernel-snap-generator
+++ b/factory/usr/lib/systemd/system-generators/kernel-snap-generator
@@ -35,6 +35,18 @@ if ! grep -q "^ID=ubuntu$" "${OS_RELEASE}"; then
     exit 0
 fi
 
+# Find out kernel name / revision
+kernelPath=$(cat /sys/dev/block/"$(mountpoint --fs-devno "$KERNEL_MNT_POINT")"/loop/backing_file)
+kernelFile=$(basename "$kernelPath")
+kernelName=${kernelFile%%_*}
+rev=${kernelFile#*_}
+rev=${rev%%.*}
+
+# Mount /lib/{firmware,modules} only if there is no drivers tree created by snapd
+if [ -d /run/mnt/data/var/lib/snapd/kernel/"$kernelName"/"$rev" ]; then
+    exit 0
+fi
+
 for entry in firmware modules; do
     what="${KERNEL_MNT_POINT}/${entry}"
     where="${sysroot}/usr/lib/${entry}"

--- a/tests/lib/prepare-utils.sh
+++ b/tests/lib/prepare-utils.sh
@@ -236,6 +236,11 @@ repack_and_sign_gadget() {
         create_cloud_init_cdimage_config "${gadget_dir}/cloud.conf"
     fi
 
+    # Show output in serial
+    cat > "${gadget_dir}/cmdline.extra" << 'EOF'
+console=ttyS0 systemd.journald.forward_to_console=1 rd.systemd.journald.forward_to_console=1
+EOF
+
     sbattach --remove "$gadget_dir/shim.efi.signed"
     sbsign --key "$snakeoil_dir/PkKek-1-snakeoil.key" --cert "$snakeoil_dir/PkKek-1-snakeoil.pem" --output "$gadget_dir/shim.efi.signed" "$gadget_dir/shim.efi.signed"
 

--- a/tests/spread/build/build-initrd/task.yaml
+++ b/tests/spread/build/build-initrd/task.yaml
@@ -13,7 +13,7 @@ prepare: |
 
   # download pc-kernel and pc gadget
   # FIXME: switch to 24 channel when available
-  snap download pc-kernel --channel=22/${SNAP_BRANCH} --basename=upstream-pc-kernel
+  snap download pc-kernel --channel=24/${SNAP_BRANCH} --basename=upstream-pc-kernel
   snap download pc --channel=24/${SNAP_BRANCH} --basename=upstream-pc-gadget
 
 execute: |


### PR DESCRIPTION
Do not mount /lib/{modules,firmware} in case snapd created a drivers
tree for our kernel snap, as in that case these mounts will be created
by snapd-generator from the base or from the snapd deb package for
hybrid systems. This situation is expected to happen only for UC24+.