### PR TITLE
modules/main/extra-modules.conf: enable dm_verity and overlay modules

### DIFF
--- a/modules/main/extra-modules.conf
+++ b/modules/main/extra-modules.conf
@@ -18,8 +18,6 @@ algif_skcipher
 cryptomgr
 dm_crypt
 dm_mod
-dm_verity
-overlay
 aes
 cbc
 echainiv

--- a/modules/main/extra-modules.conf
+++ b/modules/main/extra-modules.conf
@@ -18,6 +18,8 @@ algif_skcipher
 cryptomgr
 dm_crypt
 dm_mod
+dm_verity
+overlay
 aes
 cbc
 echainiv

--- a/modules/server/extra-modules.conf
+++ b/modules/server/extra-modules.conf
@@ -9,3 +9,6 @@ hv_storvsc
 megaraid_sas
 # VMWare Fusion
 mptspi
+# CVM
+dm_verity
+overlay


### PR DESCRIPTION
This will allow mounting partitions with dm-verity in the initrd as well as overlayfs mounts.