### PR TITLE
Core20

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (51.16) focal; urgency=medium
+
+  * Set linux-firmware as recommended package
+
+ -- Ondrej Kubik <ondrej.kubik@canonical.com>  Fri, 02 Aug 2024 13:53:21 +0100
+
 ubuntu-core-initramfs (51.15) focal; urgency=medium
 
   * Pick up snapd 2.62 from ppa

--- a/debian/control
+++ b/debian/control
@@ -70,7 +70,8 @@ Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf
-Depends: ${python3:Depends}, ${misc:Depends}, binutils, dracut-core (>= 051-1), lz4, sbsigntool, linux-firmware
+Depends: ${python3:Depends}, ${misc:Depends}, binutils, dracut-core (>= 051-1), lz4, sbsigntool
+Recommends: linux-firmware
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core
  systems. Currently targetting creating BLS Type2 like binaries.


### PR DESCRIPTION
There are use-cases when the firmware is customised or pulled from
the custom packages, so installing linux-firmware is unnecessary.
Considering the size of the package, it is better set as "Recommends"
The prime use case is when building kernel snap package locally, firmware staged to the snap should be used  as a primarily source of truth.