### PR TITLE
move linux-firmware to Recommends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (69) noble; urgency=medium
+
+  * Set linux-firmware as recommended package
+
+ -- Ondrej Kubik <ondrej.kubik@canonical.com>  Fri, 02 Aug 2024 14:02:53 +0100
+
 ubuntu-core-initramfs (68) noble; urgency=medium
 
   [ Valentin David ]

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1),
          zstd,
          sbsigntool,
          snapd (>= 2.50+20.04),
-         linux-firmware,
          kcapi-tools (>= 1.4.0-1ubuntu3),
          dbus,
          dmsetup,
@@ -45,6 +44,7 @@ Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1),
          tar,
          udev,
          util-linux
+Recommends: linux-firmware
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core
  systems. Currently targetting creating BLS Type2 like binaries.


### PR DESCRIPTION
There are use-cases when the firmware is customised or pulled from
the custom packages, so installing linux-firmware is unnecessary.
Considering the size of the package, it is better set as "Recommends"
The prime use case is when building kernel snap package locally, firmware staged to the snap should be used  as a primarily source of truth.