### PR TITLE
bin/ubuntu-core-initramfs: create /etc for ldconfig

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -478,7 +478,9 @@ def install_misc(dest_dir, sysroot):
     if sysroot != "/":
         cmd += ["-r", sysroot]
     check_call(cmd + to_resolve, env=proc_env)
-    # Build ld cache
+    # Build ld cache (make sure /etc is there before)
+    etc_d = os.path.join(dest_dir, "etc")
+    os.makedirs(etc_d, exist_ok=True)
     check_call(["ldconfig", "-r", dest_dir])
 
     # /sbin/modprobe is a static path in the kernel


### PR DESCRIPTION
ldconfig assumes /etc exists and fails otherwise. This issue started to happen on oracular because in the past previous steps already created /etc.