### PR TITLE
extra-paths: do not mark /writable as initrd in fstab

### DIFF
--- a/factory/usr/lib/core/extra-paths
+++ b/factory/usr/lib/core/extra-paths
@@ -3,7 +3,7 @@
 set -eu
 
 cat <<'EOF' >>/sysroot/etc/fstab
-/run/mnt/data /writable none bind,x-initrd.mount 0 0
+/run/mnt/data /writable none bind 0 0
 EOF
 
 # Find out kernel name / revision


### PR DESCRIPTION
Since populate-writable.service depends on /sysroot/writable to be mounted, but it will create /writable entry in fstab. The one created in fstab should not be tagged as x-initrd.mount. Otherwise it will hide the other one and confuse systemd in potentially restarting the mount.

This can be cleaned up once we get rid of writable-paths.