### PR TITLE
classic-mounts.service: wait for reload to finish

### DIFF
--- a/factory/usr/lib/systemd/system/classic-mounts.service
+++ b/factory/usr/lib/systemd/system/classic-mounts.service
@@ -10,7 +10,8 @@ After=initrd-root-fs.target
 Before=initrd-fs.target
 
 [Service]
-Type=oneshot
+Type=simple
+RemainAfterExit=yes
 # We force re-running kernel-snap-generator
 ExecStart=systemctl daemon-reload
 StandardError=journal+console


### PR DESCRIPTION
If we do not wait, then udev might cleanup its db and the reload will think devices are unplugged and then kill units bound to them.