### PR TITLE
factory: make classic-mounts.service active after finishing

### DIFF
--- a/factory/usr/lib/systemd/system/classic-mounts.service
+++ b/factory/usr/lib/systemd/system/classic-mounts.service
@@ -11,6 +11,7 @@ Before=initrd-fs.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 # We force re-running kernel-snap-generator
 ExecStart=systemctl daemon-reload
 StandardError=journal+console


### PR DESCRIPTION
Add RemainAfterExit=yes to classic-mounts.service unit to make sure it is considered active by systemd. Otherwise, it was started twice in the initramfs, and in the second run there was a race condition with initrd-udevadm-cleanup-db.service, where if daemon-reload happened after cleaning the udev database, systemd considered some device units unplugged, including disks, which in turn led to unmounts in /run/mnt. In turn this was causing that /lib/{modules,firmware} was not being mounted after switch root.